### PR TITLE
Autogenerate apk in apk branch

### DIFF
--- a/upload-apk.sh
+++ b/upload-apk.sh
@@ -10,7 +10,7 @@ cd $HOME
 git config --global user.email "noreply@travis.com"
 git config --global user.name "Travis CI" 
 #clone the repository in the buildApk folder
-git clone --quiet --branch=apk https://fossasia:$GITHUB_API_KEY@github.com/fossasia/pslab-android apk > /dev/null
+git clone --quiet --branch=apk https://viveksb007:$GITHUB_API_KEY@github.com/fossasia/pslab-android apk > /dev/null
 cp -Rf $HOME/buildApk/*
 cd apk
 


### PR DESCRIPTION
Its working, there is only token issue, its gets exposed as Travis logs when there is some error in script.
My API_KEY won't work as I don't have write permission on fossasia's pslab-android repo. So 
add @wavicles API_KEY once KEYS aren't exposed in Travis logs.
I opened an issue on open-event-android https://github.com/fossasia/open-event-android/issues/1399
I will do necessary changes when it gets solved on open-event-android.

Tested it with my own repo, its working.
![imageedit_2_8521474607](https://cloud.githubusercontent.com/assets/12713808/24835049/a32c1656-1d13-11e7-806f-1a39ec297768.png)

