### PR TITLE
added auto-start option in settings fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,31 @@ Our chat channel is on gitter here: https://gitter.im/fossasia/pslab
 
 ## Roadmap
  - First we need to get communication between Android App and PSLab working.
+
+## How to set up the Android app in your development environment
+
+### Development Setup
+
+Before you begin, you should already have the Android Studio SDK downloaded and set up correctly. You can find a guide on how to do this here: [Setting up Android Studio](http://developer.android.com/sdk/installing/index.html?pkg=studio)
+
+### Setting up the Android Project
+
+1. Download the _pslab-android_ project source. You can do this either by forking and cloning the repository (recommended if you plan on pushing changes) or by downloading it as a ZIP file and extracting it.
+
+2. Open Android Studio, you will see a **Welcome to Android** window. Under Quick Start, select _Import Project (Eclipse ADT, Gradle, etc.)_
+
+3. Navigate to the directory where you saved the pslab-android project, select the "pslab-android" folder, and hit OK. Android Studio should now begin building the project with Gradle.
+
+4. Once this process is complete and Android Studio opens, check the Console for any build errors.
+
+  - _Note:_ If you receive a Gradle sync error titled, "failed to find ...", you should click on the link below the error message (if available) that says _Install missing platform(s) and sync project_ and allow Android studio to fetch you what is missing.
+
+5. Once all build errors have been resolved, you should be all set to build the app and test it.
+
+6. To Build the app, go to _Build>Make Project_ (or alternatively press the Make Project icon in the toolbar).
+
+7. If the app was built successfully, you can test it by running it on either a real device or an emulated one by going to _Run>Run 'app'_ or presing the Run icon in the toolbar.
+ 
  
 ## Setup to use PSLab with Android App
 To use PSLab device with Android, you simply need an OTG cable, an Android Device with USB Host feature enabled ( most modern phones have OTG support ) and PSLab Android App. Connect PSLab device to Android Phone via OTG cable. Rest is handled by App itself.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile 'com.github.PhilJay:MPAndroidChart:v3.0.1'
     compile 'com.android.support:design:25.2.0'
     compile 'com.android.support:support-v4:25.2.0'
+    compile 'com.android.support:preference-v7:25.2.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'de.hdodenhof:circleimageview:2.1.0'
     testCompile 'junit:junit:4.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile 'com.github.PhilJay:MPAndroidChart:v3.0.1'
     compile 'com.android.support:design:25.2.0'
     compile 'com.android.support:support-v4:25.2.0'
-    compile 'com.android.support:preference-v7:25.2.0'
+    compile 'com.android.support:preference-v14:25.2.0'
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile 'de.hdodenhof:circleimageview:2.1.0'
     testCompile 'junit:junit:4.12'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,16 +12,16 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="org.fossasia.pslab.activity.SplashActivity">
+        <activity android:name=".activity.SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="org.fossasia.pslab.activity.MainActivity" />
-        <activity android:name="org.fossasia.pslab.activity.AboutUs"/>
-        <activity android:name="org.fossasia.pslab.activity.HelpAndFeedback"/>
-        <activity android:name="org.fossasia.pslab.activity.ReportUs"/>
+        <activity android:name=".activity.MainActivity" />
+        <activity android:name=".activity.AboutUs"/>
+        <activity android:name=".activity.HelpAndFeedback"/>
+        <activity android:name=".activity.ReportUs"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -116,7 +116,7 @@ public class MainActivity extends AppCompatActivity {
                 FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
                 fragmentTransaction.setCustomAnimations(android.R.anim.fade_in,
                         android.R.anim.fade_out);
-                fragmentTransaction.replace(org.fossasia.pslab.R.id.frame, fragment, CURRENT_TAG);
+                fragmentTransaction.replace(R.id.frame, fragment, CURRENT_TAG);
                 fragmentTransaction.commitAllowingStateLoss();
             }
         };

--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -157,35 +157,35 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public boolean onNavigationItemSelected(@NonNull MenuItem item) {
                 switch (item.getItemId()) {
-                    case org.fossasia.pslab.R.id.nav_home:
+                    case R.id.nav_home:
                         navItemIndex = 0;
                         CURRENT_TAG = TAG_HOME;
                         break;
-                    case org.fossasia.pslab.R.id.nav_applications:
+                    case R.id.nav_applications:
                         navItemIndex = 1;
                         CURRENT_TAG = TAG_APPLICATIONS;
                         break;
-                    case org.fossasia.pslab.R.id.nav_saved_experiments:
+                    case R.id.nav_saved_experiments:
                         navItemIndex = 2;
                         CURRENT_TAG = TAG_SAVED_EXPERIMENTS;
                         break;
-                    case org.fossasia.pslab.R.id.nav_design_experiments:
+                    case R.id.nav_design_experiments:
                         navItemIndex = 3;
                         CURRENT_TAG = TAG_DESIGN_EXPERIMENTS;
                         break;
-                    case org.fossasia.pslab.R.id.nav_settings:
+                    case R.id.nav_settings:
                         navItemIndex = 4;
                         CURRENT_TAG = TAG_SETTINGS;
                         break;
-                    case org.fossasia.pslab.R.id.nav_about_us:
+                    case R.id.nav_about_us:
                         startActivity(new Intent(MainActivity.this, AboutUs.class));
                         drawer.closeDrawers();
                         break;
-                    case org.fossasia.pslab.R.id.nav_help_feedback:
+                    case R.id.nav_help_feedback:
                         startActivity(new Intent(MainActivity.this, HelpAndFeedback.class));
                         drawer.closeDrawers();
                         break;
-                    case org.fossasia.pslab.R.id.nav_report_us:
+                    case R.id.nav_report_us:
                         startActivity(new Intent(MainActivity.this, ReportUs.class));
                         drawer.closeDrawers();
                         break;

--- a/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
@@ -1,11 +1,7 @@
 package org.fossasia.pslab.fragment;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.ViewGroup;
+import android.support.v7.preference.PreferenceFragmentCompat;
 
 import org.fossasia.pslab.R;
 
@@ -13,17 +9,21 @@ import org.fossasia.pslab.R;
  * Created by viveksb007 on 15/3/17.
  */
 
-public class SettingsFragment extends Fragment {
+public class SettingsFragment extends PreferenceFragmentCompat {
 
     public static SettingsFragment newInstance() {
         SettingsFragment settingsFragment = new SettingsFragment();
         return settingsFragment;
     }
 
-    @Nullable
-    @Override
-    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        View view = inflater.inflate(R.layout.settings_fragment, container, false);
-        return view;
+
+    public SettingsFragment() {
+
     }
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.settings_preference_fragment, rootKey);
+    }
+
 }

--- a/app/src/main/res/layout/settings_fragment.xml
+++ b/app/src/main/res/layout/settings_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -2,5 +2,5 @@
 <resources>
     <color name="colorPrimary">#d32f2f</color>
     <color name="colorPrimaryDark">#c72c2c</color>
-    <color name="colorAccent">#FFFFFF</color>
+    <color name="colorAccent">#ce525f</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,7 +8,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
-        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,6 +8,7 @@
         <item name="colorAccent">@color/colorAccent</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionBar">false</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>

--- a/app/src/main/res/xml/settings_preference_fragment.xml
+++ b/app/src/main/res/xml/settings_preference_fragment.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <PreferenceCategory android:title="App Settings">
     <CheckBoxPreference
         android:key="setting_auto_start"
-        android:summary="Auto Start App when PSLab device is connected"
+        android:summary="Auto start app when PSLab device is connected"
         android:title="Auto Start" />
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/settings_preference_fragment.xml
+++ b/app/src/main/res/xml/settings_preference_fragment.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <CheckBoxPreference
+        android:key="setting_auto_start"
+        android:summary="Auto Start App when PSLab device is connected"
+        android:title="Auto Start" />
+</PreferenceScreen>


### PR DESCRIPTION
Fixes #44 
Added auto-start option in settings activity with Material Theme.
Further settings needed by project would be added later.

![screenshot_2017-04-13-19-21-31-621_org fossasia pslab](https://cloud.githubusercontent.com/assets/12713808/25008154/7e330628-2080-11e7-8f70-bc511c3012f7.png)
