### PR TITLE
Fix #120 : Applications grid rows change in landscape orientation

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/ApplicationsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/ApplicationsFragment.java
@@ -2,6 +2,7 @@ package org.fossasia.pslab.fragment;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -76,7 +77,9 @@ public class ApplicationsFragment extends Fragment {
                     }
                 });
         // Initiate Views
-        initiateViews(view);
+        int rows = context.getResources().getConfiguration().orientation
+                == Configuration.ORIENTATION_PORTRAIT ? 2 : 3;
+        initiateViews(view, rows);
         // Generate Applications
         new loadList().execute();
         // Return created view
@@ -86,10 +89,10 @@ public class ApplicationsFragment extends Fragment {
     /**
      * Initiate Recycler view
      */
-    private void initiateViews(View view) {
+    private void initiateViews(View view, int rows) {
         // Initiate Recycler View with a Grid
         RecyclerView listView = (RecyclerView) view.findViewById(R.id.applications_recycler_view);
-        RecyclerView.LayoutManager mLayoutManager = new GridLayoutManager(context, 2);
+        RecyclerView.LayoutManager mLayoutManager = new GridLayoutManager(context, rows);
         listView.setLayoutManager(mLayoutManager);
         listView.setItemAnimator(new DefaultItemAnimator());
         // Set adapter


### PR DESCRIPTION
When the screen orientation is changed, the grid rows will change accordingly avoiding huge icons

| Portrait | Landscape |
| ---- | ---- |
| ![Portrait](https://cloud.githubusercontent.com/assets/14261304/26285056/604e81b2-3e37-11e7-8233-399ac0f489ba.png) | ![Landscape](https://cloud.githubusercontent.com/assets/14261304/26285057/605b1bac-3e37-11e7-845e-69e40e6c761e.png) |


