### PR TITLE
Logic Analyzer UI modified as per pslab-desktop-app and labels indicate channel

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/LAChannelModeFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LAChannelModeFragment.java
@@ -24,11 +24,15 @@ import org.fossasia.pslab.R;
 public class LAChannelModeFragment extends Fragment {
 
 
-    private String[] channels = {"ID1", "ID2", "ID3", "ID4"};
-    private String[] edges = {"EVERY EDGE", "EVERY FALLING EDGE", "EVERY RISING EDGE", "EVERY FOURTH RISING EDGE", "EVERY SIXTEENTH RISING EDGE"};
+    private String[] channels = {"ID1", "ID2", "ID3", "ID4", "SEN", "EXT", "CNTR"};
+    private String[] edges = {"EVERY EDGE", "EVERY FALLING EDGE", "EVERY RISING EDGE", "EVERY FOURTH RISING EDGE", "DISABLED"};
     private LinearLayout llChannel1, llChannel2, llChannel3, llChannel4;
     private int channelMode = 1;
     private Activity activity;
+    private Spinner channelSelectSpinner1;
+    private Spinner channelSelectSpinner2;
+    private Spinner channelSelectSpinner3;
+    private Spinner channelSelectSpinner4;
 
     public static LAChannelModeFragment newInstance(Activity activity) {
         LAChannelModeFragment laChannelModeFragment = new LAChannelModeFragment();
@@ -64,6 +68,12 @@ public class LAChannelModeFragment extends Fragment {
                         break;
                     case 2:
                         channelMode = 3;
+                        channelSelectSpinner1.setSelection(0);
+                        channelSelectSpinner2.setSelection(1);
+                        channelSelectSpinner3.setSelection(2);
+                        channelSelectSpinner1.setEnabled(false);
+                        channelSelectSpinner2.setEnabled(false);
+                        channelSelectSpinner3.setEnabled(false);
                         llChannel1.setVisibility(View.VISIBLE);
                         llChannel2.setVisibility(View.VISIBLE);
                         llChannel3.setVisibility(View.VISIBLE);
@@ -71,6 +81,14 @@ public class LAChannelModeFragment extends Fragment {
                         break;
                     case 3:
                         channelMode = 4;
+                        channelSelectSpinner1.setSelection(0);
+                        channelSelectSpinner2.setSelection(1);
+                        channelSelectSpinner3.setSelection(2);
+                        channelSelectSpinner4.setSelection(3);
+                        channelSelectSpinner1.setEnabled(false);
+                        channelSelectSpinner2.setEnabled(false);
+                        channelSelectSpinner3.setEnabled(false);
+                        channelSelectSpinner4.setEnabled(false);
                         llChannel1.setVisibility(View.VISIBLE);
                         llChannel2.setVisibility(View.VISIBLE);
                         llChannel3.setVisibility(View.VISIBLE);
@@ -104,22 +122,23 @@ public class LAChannelModeFragment extends Fragment {
     private View createSingleChannelMode(LayoutInflater inflater) {
 
         View selectView = inflater.inflate(R.layout.logic_analyzer_select_channel_mode, null);
-        final Spinner channelSelectSpinner1 = (Spinner) selectView.findViewById(R.id.single_channel_input_1);
+
+        channelSelectSpinner1 = (Spinner) selectView.findViewById(R.id.single_channel_input_1);
         channelSelectSpinner1.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, channels));
         final Spinner edgeSelectSpinner1 = (Spinner) selectView.findViewById(R.id.single_channel_edge_1);
         edgeSelectSpinner1.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, edges));
 
-        final Spinner channelSelectSpinner2 = (Spinner) selectView.findViewById(R.id.single_channel_input_2);
+        channelSelectSpinner2 = (Spinner) selectView.findViewById(R.id.single_channel_input_2);
         channelSelectSpinner2.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, channels));
         final Spinner edgeSelectSpinner2 = (Spinner) selectView.findViewById(R.id.single_channel_edge_2);
         edgeSelectSpinner2.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, edges));
 
-        final Spinner channelSelectSpinner3 = (Spinner) selectView.findViewById(R.id.single_channel_input_3);
+        channelSelectSpinner3 = (Spinner) selectView.findViewById(R.id.single_channel_input_3);
         channelSelectSpinner3.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, channels));
         final Spinner edgeSelectSpinner3 = (Spinner) selectView.findViewById(R.id.single_channel_edge_3);
         edgeSelectSpinner3.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, edges));
 
-        final Spinner channelSelectSpinner4 = (Spinner) selectView.findViewById(R.id.single_channel_input_4);
+        channelSelectSpinner4 = (Spinner) selectView.findViewById(R.id.single_channel_input_4);
         channelSelectSpinner4.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, channels));
         final Spinner edgeSelectSpinner4 = (Spinner) selectView.findViewById(R.id.single_channel_edge_4);
         edgeSelectSpinner4.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, edges));

--- a/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
@@ -19,7 +19,7 @@ import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 
 import org.fossasia.pslab.R;
-import org.fossasia.pslab.items.ChannelAxisFormatter;
+import org.fossasia.pslab.others.ChannelAxisFormatter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +36,7 @@ public class LALogicLinesFragment extends Fragment {
     private int channelMode;
     private Context context;
     private LineChart logicLinesChart;
+    private ArrayList<String> channelNames = new ArrayList<>();
 
     public static LALogicLinesFragment newInstance(Bundle params, Context context) {
         LALogicLinesFragment laLogicLinesFragment = new LALogicLinesFragment();
@@ -48,6 +49,27 @@ public class LALogicLinesFragment extends Fragment {
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         this.channelMode = params.getInt("channelMode");
+        switch (channelMode) {
+            case 1:
+                channelNames.add(params.getString("inputChannel1"));
+                break;
+            case 2:
+                channelNames.add(params.getString("inputChannel1"));
+                channelNames.add(params.getString("inputChannel2"));
+                break;
+            case 3:
+                channelNames.add(params.getString("inputChannel1"));
+                channelNames.add(params.getString("inputChannel2"));
+                channelNames.add(params.getString("inputChannel3"));
+                break;
+            case 4:
+                channelNames.add(params.getString("inputChannel1"));
+                channelNames.add(params.getString("inputChannel2"));
+                channelNames.add(params.getString("inputChannel3"));
+                channelNames.add(params.getString("inputChannel4"));
+                break;
+            default:
+        }
     }
 
     @Nullable
@@ -69,11 +91,17 @@ public class LALogicLinesFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         updateLogicLines();
         YAxis left = logicLinesChart.getAxisLeft();
-        left.setValueFormatter(new ChannelAxisFormatter());
+        left.setValueFormatter(new ChannelAxisFormatter(channelNames, channelMode));
         left.setGranularity(1f);
         left.setTextColor(Color.BLACK);
         left.setTextSize(12f);
         logicLinesChart.getAxisRight().setDrawLabels(false);
+
+        /*  For HIDING GRID LINES
+        logicLinesChart.getAxisLeft().setDrawGridLines(false);
+        logicLinesChart.getAxisRight().setDrawGridLines(false);
+        logicLinesChart.getXAxis().setDrawGridLines(false);
+        */
     }
 
     private void updateLogicLines() {
@@ -83,6 +111,7 @@ public class LALogicLinesFragment extends Fragment {
         for (int j = 0; j < channelMode; j++) {
             List<Entry> tempInput = new ArrayList<>();
             int[] temp = timeStamps.get(j);
+            tempInput.add(new Entry(0, 0 + (j * 2)));
             for (int i = 0; i < temp.length; i++) {
                 if (high) {
                     tempInput.add(new Entry(temp[i], 1 + (j * 2)));

--- a/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
@@ -12,12 +12,14 @@ import android.view.ViewGroup;
 import android.widget.LinearLayout;
 
 import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 
 import org.fossasia.pslab.R;
+import org.fossasia.pslab.items.ChannelAxisFormatter;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,6 +68,12 @@ public class LALogicLinesFragment extends Fragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         updateLogicLines();
+        YAxis left = logicLinesChart.getAxisLeft();
+        left.setValueFormatter(new ChannelAxisFormatter());
+        left.setGranularity(1f);
+        left.setTextColor(Color.BLACK);
+        left.setTextSize(12f);
+        logicLinesChart.getAxisRight().setDrawLabels(false);
     }
 
     private void updateLogicLines() {

--- a/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.YAxis;
@@ -37,6 +38,7 @@ public class LALogicLinesFragment extends Fragment {
     private Context context;
     private LineChart logicLinesChart;
     private ArrayList<String> channelNames = new ArrayList<>();
+    private TextView tvTimeUnit;
 
     public static LALogicLinesFragment newInstance(Bundle params, Context context) {
         LALogicLinesFragment laLogicLinesFragment = new LALogicLinesFragment();
@@ -69,6 +71,7 @@ public class LALogicLinesFragment extends Fragment {
                 channelNames.add(params.getString("inputChannel4"));
                 break;
             default:
+                channelNames.add(params.getString("inputChannel1"));
         }
     }
 
@@ -83,6 +86,8 @@ public class LALogicLinesFragment extends Fragment {
         logicLinesChart.setDrawBorders(true);
         logicLinesChart.setBorderWidth(2);
         llLogicLines.addView(logicLinesChart);
+        tvTimeUnit = (TextView) v.findViewById(R.id.la_tv_time_unit);
+        tvTimeUnit.setText("Time -> (ms)");
         return v;
     }
 
@@ -91,13 +96,13 @@ public class LALogicLinesFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
         updateLogicLines();
         YAxis left = logicLinesChart.getAxisLeft();
-        left.setValueFormatter(new ChannelAxisFormatter(channelNames, channelMode));
+        left.setValueFormatter(new ChannelAxisFormatter(channelNames));
         left.setGranularity(1f);
         left.setTextColor(Color.BLACK);
         left.setTextSize(12f);
         logicLinesChart.getAxisRight().setDrawLabels(false);
 
-        /*  For HIDING GRID LINES
+        /*  For HIGHI
         logicLinesChart.getAxisLeft().setDrawGridLines(false);
         logicLinesChart.getAxisRight().setDrawGridLines(false);
         logicLinesChart.getXAxis().setDrawGridLines(false);

--- a/app/src/main/java/org/fossasia/pslab/items/ChannelAxisFormatter.java
+++ b/app/src/main/java/org/fossasia/pslab/items/ChannelAxisFormatter.java
@@ -1,0 +1,33 @@
+package org.fossasia.pslab.items;
+
+import com.github.mikephil.charting.components.AxisBase;
+import com.github.mikephil.charting.formatter.IAxisValueFormatter;
+
+/**
+ * Created by viveksb007 on 14/6/17.
+ */
+
+public class ChannelAxisFormatter implements IAxisValueFormatter {
+
+    String[] laChannelNames = new String[]{"ID1", "ID2", "ID3", "ID4"};
+
+    public ChannelAxisFormatter() {
+
+    }
+
+    @Override
+    public String getFormattedValue(float value, AxisBase axis) {
+        switch ((int) value) {
+            case 1:
+                return "ID1";
+            case 3:
+                return "ID2";
+            case 5:
+                return "ID3";
+            case 7:
+                return "ID4";
+        }
+        return "";
+    }
+
+}

--- a/app/src/main/java/org/fossasia/pslab/others/ChannelAxisFormatter.java
+++ b/app/src/main/java/org/fossasia/pslab/others/ChannelAxisFormatter.java
@@ -1,7 +1,9 @@
-package org.fossasia.pslab.items;
+package org.fossasia.pslab.others;
 
 import com.github.mikephil.charting.components.AxisBase;
 import com.github.mikephil.charting.formatter.IAxisValueFormatter;
+
+import java.util.ArrayList;
 
 /**
  * Created by viveksb007 on 14/6/17.
@@ -9,23 +11,23 @@ import com.github.mikephil.charting.formatter.IAxisValueFormatter;
 
 public class ChannelAxisFormatter implements IAxisValueFormatter {
 
-    String[] laChannelNames = new String[]{"ID1", "ID2", "ID3", "ID4"};
+    private ArrayList<String> laChannelNames;
 
-    public ChannelAxisFormatter() {
-
+    public ChannelAxisFormatter(ArrayList<String> channelNames, int channelMode) {
+        this.laChannelNames = channelNames;
     }
 
     @Override
     public String getFormattedValue(float value, AxisBase axis) {
         switch ((int) value) {
             case 1:
-                return "ID1";
+                return laChannelNames.get(0);
             case 3:
-                return "ID2";
+                return laChannelNames.get(1);
             case 5:
-                return "ID3";
+                return laChannelNames.get(2);
             case 7:
-                return "ID4";
+                return laChannelNames.get(3);
         }
         return "";
     }

--- a/app/src/main/java/org/fossasia/pslab/others/ChannelAxisFormatter.java
+++ b/app/src/main/java/org/fossasia/pslab/others/ChannelAxisFormatter.java
@@ -13,7 +13,7 @@ public class ChannelAxisFormatter implements IAxisValueFormatter {
 
     private ArrayList<String> laChannelNames;
 
-    public ChannelAxisFormatter(ArrayList<String> channelNames, int channelMode) {
+    public ChannelAxisFormatter(ArrayList<String> channelNames) {
         this.laChannelNames = channelNames;
     }
 
@@ -28,8 +28,9 @@ public class ChannelAxisFormatter implements IAxisValueFormatter {
                 return laChannelNames.get(2);
             case 7:
                 return laChannelNames.get(3);
+            default:
+                return "";
         }
-        return "";
     }
 
 }

--- a/app/src/main/res/layout/logic_analyzer_logic_lines.xml
+++ b/app/src/main/res/layout/logic_analyzer_logic_lines.xml
@@ -6,4 +6,10 @@
     android:gravity="center"
     android:orientation="vertical">
 
+    <TextView
+        android:id="@+id/la_tv_time_unit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textStyle="bold" />
+
 </LinearLayout>


### PR DESCRIPTION
Fixes issue #169  #173 

Changes: 

- Modified Channel selection at different modes as per pslab-desktop-app
- Named logic lines according to which Channel was selected in Channel Mode select Fragment

Screenshots for the change: 
For Three channel mode, input channels are locked to ID1, ID2, ID3
![screenshot_2017-06-15-21-54-45-167_org fossasia pslab](https://user-images.githubusercontent.com/12713808/27191464-791da00a-5215-11e7-84f1-13e30b5cfa6f.png)

In two Channel Mode, **SEN** & **CNTR** are selected which are passed to next fragment.
![screenshot_2017-06-15-21-55-00-978_org fossasia pslab](https://user-images.githubusercontent.com/12713808/27191469-7bd10972-5215-11e7-9f2f-c989973ccd6a.png)
![screenshot_2017-06-15-21-55-05-710_org fossasia pslab](https://user-images.githubusercontent.com/12713808/27191472-7df3571e-5215-11e7-8dd8-54cfdfd4aef5.png)

Added time label also in latest commit.
![screenshot_2017-06-15-23-03-25-484_org fossasia pslab](https://user-images.githubusercontent.com/12713808/27194281-a19a067c-521f-11e7-9622-703f84b16dea.png)


