### PR TITLE
modified write function to support device with API level < 18

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "org.fossasia.pslab"
-        minSdkVersion 18
+        minSdkVersion 15
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Partly Fixes #156 

Changes: modified write function to support device with API level < 18

Tested by jithin on device with API level 15, there was  a permission issue #179  which @akarshan96 is taking care of.
