### PR TITLE
Fixes #170 highlights bottomnavigation bar

### DIFF
--- a/app/src/main/res/drawable/navigationbar_text_color.xml
+++ b/app/src/main/res/drawable/navigationbar_text_color.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:state_selected="true"
-        android:color="@color/black" />
-    <item
-        android:state_selected="false"
-        android:color="@color/white" />
-</selector>

--- a/app/src/main/res/layout/activity_control.xml
+++ b/app/src/main/res/layout/activity_control.xml
@@ -23,7 +23,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         android:background="@color/colorPrimary"
-        app:itemIconTint="@color/white"
-        app:itemTextColor="@color/white"
+        app:theme="@style/AppTheme.Bottomnavigationbar"
         app:menu="@menu/activity_control_bottom_navigationbar"/>
 </RelativeLayout>

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,2 +1,17 @@
 <resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="windowActionBar">false</item>
+        <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
+    </style>
+
+    <style name="AppTheme.Bottomnavigationbar" parent="Theme.AppCompat.Light">
+        <item name="colorControlHighlight">@color/black</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes issue #170 

Changes: 
* Enables highlighting of bottom navigation bar.
* The active bar is displayed in white and inactive in black.
* Only meant for API level > 21.

Screenshots for the change: 
<img src="https://user-images.githubusercontent.com/19410364/27269731-d33c5e82-54d6-11e7-8cdf-087944cc8184.png" height="640" width="360">
