### PR TITLE
Fixes #167 removes focus from edittext on opening Control UI

### DIFF
--- a/app/src/main/res/layout/fragment_control_main.xml
+++ b/app/src/main/res/layout/fragment_control_main.xml
@@ -5,6 +5,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
     <android.support.v7.widget.RecyclerView


### PR DESCRIPTION
Fixes issue #167 

Changes: 
* Earlier, the keyboard used to pop-up whenever Control UI was opened due to presence of edit-texts.
* Removed the focus on opening. Keyboard pops up only when an edit-text is clicked.

Screenshots for the change: 
Screenshots cannot show the difference of the actual working though.
<img src = "https://user-images.githubusercontent.com/19410364/27270025-f5a88b74-54d8-11e7-9a0d-95a223762e36.png" height="640" width="360">