### PR TITLE
Fixes re-initialisation on screen rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".activity.MainActivity">
+        <activity android:name=".activity.MainActivity"
+            android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>

--- a/app/src/main/java/org/fossasia/pslab/fragment/ApplicationsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/ApplicationsFragment.java
@@ -158,4 +158,9 @@ public class ApplicationsFragment extends Fragment {
         }
     }
 
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        getActivity().getSupportFragmentManager().beginTransaction().detach(this).attach(this).commit();
+    }
 }


### PR DESCRIPTION
Fixes issue #194 

Changes: State of Activity is retained on screen rotation so that scienceLab object doesn't re-initialises itself.
