### PR TITLE
Fixed App crash when coming back to application fragment after screen orientation

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/ApplicationsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/ApplicationsFragment.java
@@ -161,6 +161,6 @@ public class ApplicationsFragment extends Fragment {
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        getActivity().getSupportFragmentManager().beginTransaction().detach(this).attach(this).commit();
+        getActivity().getSupportFragmentManager().beginTransaction().detach(this).attach(this).commitAllowingStateLoss();
     }
 }


### PR DESCRIPTION
Fixes issue #207 

Now App doesn't crash when coming back to Application Fragment from specific Application say Logic Analyser after changing screen orientation.