### PR TITLE
Fixed : abrupt disconnections of device and prevent version read during initialisation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".activity.MainActivity"
+        <activity
+            android:name=".activity.MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
@@ -39,6 +40,8 @@
         <activity
             android:name=".activity.LogicalAnalyzerActivity"
             android:configChanges="screenSize|orientation" />
+
+        <receiver android:name=".receivers.USBDetachReceiver" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.others.ScienceLabCommon;
+import org.fossasia.pslab.receivers.USBDetachReceiver;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -75,6 +76,7 @@ public class MainActivity extends AppCompatActivity {
     private UsbManager usbManager;
     private PendingIntent mPermissionIntent;
     private CommunicationHandler communicationHandler;
+    private USBDetachReceiver usbDetachReceiver;
     private static final String ACTION_USB_PERMISSION = "com.android.example.USB_PERMISSION";
 
     @Override
@@ -102,6 +104,11 @@ public class MainActivity extends AppCompatActivity {
         }
 
         mScienceLabCommon.openDevice(communicationHandler);
+
+        IntentFilter usbDetachFilter = new IntentFilter();
+        usbDetachFilter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+        usbDetachReceiver = new USBDetachReceiver(this);
+        registerReceiver(usbDetachReceiver, usbDetachFilter);
 
         setSupportActionBar(toolbar);
         mHandler = new Handler();
@@ -266,6 +273,7 @@ public class MainActivity extends AppCompatActivity {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        unregisterReceiver(usbDetachReceiver);
         if (receiverRegister)
             unregisterReceiver(mUsbReceiver);
     }

--- a/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
@@ -2,7 +2,9 @@ package org.fossasia.pslab.communication;
 
 import android.os.Handler;
 import android.os.Looper;
+
 import java.lang.Thread;
+
 import android.util.Log;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -41,18 +43,19 @@ import static org.apache.commons.lang3.math.NumberUtils.max;
 public class ScienceLab {
 
     private static final String TAG = "ScienceLab";
+    public static Thread initialisationThread;
 
-    public int CAP_AND_PCS = 0;
-    public int ADC_SHIFTS_LOCATION1 = 1;
-    public int ADC_SHIFTS_LOCATION2 = 2;
-    public int ADC_POLYNOMIALS_LOCATION = 3;
+    private int CAP_AND_PCS = 0;
+    private int ADC_SHIFTS_LOCATION1 = 1;
+    private int ADC_SHIFTS_LOCATION2 = 2;
+    private int ADC_POLYNOMIALS_LOCATION = 3;
 
-    public int DAC_SHIFTS_PV1A = 4;
-    public int DAC_SHIFTS_PV1B = 5;
-    public int DAC_SHIFTS_PV2A = 6;
-    public int DAC_SHIFTS_PV2B = 7;
-    public int DAC_SHIFTS_PV3A = 8;
-    public int DAC_SHIFTS_PV3B = 9;
+    private int DAC_SHIFTS_PV1A = 4;
+    private int DAC_SHIFTS_PV1B = 5;
+    private int DAC_SHIFTS_PV2A = 6;
+    private int DAC_SHIFTS_PV2B = 7;
+    private int DAC_SHIFTS_PV3A = 8;
+    private int DAC_SHIFTS_PV3B = 9;
 
     public int BAUD = 1000000;
     public int DDS_CLOCK, MAX_SAMPLES, samples, triggerLevel, triggerChannel, errorCount,
@@ -96,7 +99,7 @@ public class ScienceLab {
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    new Thread(new Runnable() {
+                    initialisationThread = new Thread(new Runnable() {
                         @Override
                         public void run() {
                             try {
@@ -112,7 +115,8 @@ public class ScienceLab {
                                 }
                             });
                         }
-                    }).start();
+                    });
+                    initialisationThread.start();
                 }
             }, 1000);
         }

--- a/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
@@ -1,7 +1,8 @@
 package org.fossasia.pslab.communication;
 
 import android.os.Handler;
-import android.os.SystemClock;
+import android.os.Looper;
+import java.lang.Thread;
 import android.util.Log;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -83,7 +84,7 @@ public class ScienceLab {
         if (isDeviceFound()) {
             try {
                 mCommunicationHandler.open();
-                //SystemClock.sleep(200);
+                //Thread.sleep(200);
                 mPacketHandler = new PacketHandler(500, mCommunicationHandler);
             } catch (IOException e) {
                 e.printStackTrace();
@@ -94,13 +95,23 @@ public class ScienceLab {
             new Handler().postDelayed(new Runnable() {
                 @Override
                 public void run() {
-                    try {
-                        runInitSequence(true);
-                        calibrated = true;
-                        HomeFragment.booleanVariable.setVariable(true);
-                    } catch (IOException e) {
-                        e.printStackTrace();
-                    }
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                runInitSequence(true);
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
+                            calibrated = true;
+                            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    HomeFragment.booleanVariable.setVariable(true);
+                                }
+                            });
+                        }
+                    }).start();
                 }
             }, 1000);
         }
@@ -506,7 +517,11 @@ public class ScienceLab {
     public Map<String, double[]> captureTwo(int samples, double timeGap, String traceOneRemap) {
         if (traceOneRemap == null) traceOneRemap = "CH1";
         this.captureTraces(2, samples, timeGap, traceOneRemap, null, null);
-        SystemClock.sleep((long) (1e-6 * this.samples * this.timebase + 0.1) * 1000);
+        try {
+            Thread.sleep((long) (1e-6 * this.samples * this.timebase + 0.1) * 1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         while (this.oscilloscopeProgress()[0] == 0) ;
         this.fetchChannel(1);
         this.fetchChannel(2);
@@ -520,7 +535,11 @@ public class ScienceLab {
     public Map<String, double[]> captureFour(int samples, double timeGap, String traceOneRemap) {
         if (traceOneRemap == null) traceOneRemap = "CH1";
         this.captureTraces(4, samples, timeGap, traceOneRemap, null, null);
-        SystemClock.sleep((long) (1e-6 * this.samples * this.timebase + 0.1) * 1000);
+        try {
+            Thread.sleep((long) (1e-6 * this.samples * this.timebase + 0.1) * 1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         while (this.oscilloscopeProgress()[0] == 0) ;
         Map<String, double[]> retData = new HashMap<>();
         Map<String, double[]> tempMap = this.fetchTrace(1);
@@ -559,7 +578,7 @@ public class ScienceLab {
             mPacketHandler.sendInt((int) this.timebase * 8);
             mPacketHandler.getAcknowledgement();
             Log.v(TAG, "Wait");
-            SystemClock.sleep((long) (1e-6 * totalSamples * timeGap + .01) * 1000);
+            Thread.sleep((long) (1e-6 * totalSamples * timeGap + .01) * 1000);
             Log.v(TAG, "Done");
             ArrayList<Byte> listData = new ArrayList<>();
             for (int i = 0; i < totalSamples / this.dataSplitting; i++) {
@@ -603,7 +622,7 @@ public class ScienceLab {
                 retData.put("CH" + String.valueOf(i + 1), yValues);
             }
             return retData;
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
         return null;
@@ -639,10 +658,10 @@ public class ScienceLab {
             mPacketHandler.sendInt((int) timeGap * 8);
             if (args.contains("FIRE_PULSES")) {
                 mPacketHandler.sendInt(interval);
-                SystemClock.sleep((long) (interval * 1e-6));
+                Thread.sleep((long) (interval * 1e-6));
             }
             mPacketHandler.getAcknowledgement();
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
     }
@@ -653,7 +672,11 @@ public class ScienceLab {
         */
 
         this.captureFullSpeedInitialize(channel, samples, timeGap, args, interval);
-        SystemClock.sleep((long) (1e-6 * this.samples * this.timebase + 0.1 + ((interval != null) ? interval : 0) * 1e-6));
+        try {
+            Thread.sleep((long) (1e-6 * this.samples * this.timebase + 0.1 + ((interval != null) ? interval : 0) * 1e-6));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         this.fetchChannel(1);
         Map<String, double[]> retData = new HashMap<>();
         retData.put("x", this.aChannels.get(0).getXAxis());
@@ -693,7 +716,11 @@ public class ScienceLab {
 
     public Map<String, double[]> captureFullSpeedHr(String channel, int samples, double timeGap, List<String> args) {
         this.captureFullSpeedHrInitialize(channel, samples, timeGap, args);
-        SystemClock.sleep((long) (1e-6 * this.samples * this.timebase + 0.1));
+        try {
+            Thread.sleep((long) (1e-6 * this.samples * this.timebase + 0.1));
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         Map<String, double[]> axisData = retrieveBufferData(channel, this.samples, this.timebase);
         if (axisData == null) {
             Log.v(TAG, "Retrieved Buffer Data as null");
@@ -1296,7 +1323,11 @@ public class ScienceLab {
                 this.dChannels.get(0).loadData(tempMap, doubleData);
                 return 1e-6 * (this.dChannels.get(0).timestamps[skipCycle + 1] - this.dChannels.get(0).timestamps[0]);
             }
-            SystemClock.sleep(100);
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
         }
         return null;
     }
@@ -1329,7 +1360,11 @@ public class ScienceLab {
                 this.dChannels.get(0).loadData(tempMap, doubleData);
                 return 1e-6 * (this.dChannels.get(0).timestamps[skipCycle + 1] - this.dChannels.get(0).timestamps[0]);
             }
-            SystemClock.sleep(100);
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
         }
         return null;
     }
@@ -1537,7 +1572,11 @@ public class ScienceLab {
         if (aquireMode == null) aquireMode = 3;
         if (triggerMode == null) triggerMode = 3;
         this.startOneChannelLA(aquireChannel, aquireMode, triggerChannel, triggerMode);
-        SystemClock.sleep(waitingTime * 1000);
+        try {
+            Thread.sleep(waitingTime * 1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         LinkedHashMap<String, Integer> data = this.getLAInitialStates();
         long[] temp = this.fetchLongDataFromLA(data.get("A"), 1);
         double[] retData = new double[temp.length];
@@ -2196,7 +2235,7 @@ public class ScienceLab {
             else
                 mPacketHandler.sendByte((int) trim / 2);
             mPacketHandler.sendInt(chargeTime);
-            SystemClock.sleep((long) (chargeTime * 1e-6 + .02));
+            Thread.sleep((long) (chargeTime * 1e-6 + .02));
             int VCode = mPacketHandler.getInt();
             double v = 3.3 * VCode / 4095;
             mPacketHandler.getAcknowledgement();
@@ -2206,7 +2245,7 @@ public class ScienceLab {
                 c = (chargeCurrent * chargeTime * 1e-6 / v - this.SOCKET_CAPACITANCE) / this.currentScalars[currentRange];
 
             return new double[]{v, c};
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
         return null;
@@ -2332,9 +2371,9 @@ public class ScienceLab {
             mPacketHandler.sendByte(page);
             mPacketHandler.sendByte(location);
             mCommunicationHandler.write(data.getBytes(), 500);
-            SystemClock.sleep(100);
+            Thread.sleep(100);
             mPacketHandler.getAcknowledgement();
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
     }
@@ -2957,8 +2996,8 @@ public class ScienceLab {
             mPacketHandler.sendByte(mCommandsProto.STEPPER_MOTOR);
             mPacketHandler.sendInt((steps << 1) | direction);
             mPacketHandler.sendInt(delay);
-            SystemClock.sleep((long) (steps * delay * 1e-3 * 1000));
-        } catch (IOException e) {
+            Thread.sleep((long) (steps * delay * 1e-3 * 1000));
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
     }

--- a/app/src/main/java/org/fossasia/pslab/fragment/HomeFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/HomeFragment.java
@@ -68,10 +68,10 @@ public class HomeFragment extends Fragment {
         unbinder = ButterKnife.bind(this, view);
         if (deviceFound & deviceConnected) {
             imgViewDeviceStatus.setImageResource(org.fossasia.pslab.R.drawable.usb_connected);
-            tvDeviceStatus.setText("Device Connected Successfully");
+            tvDeviceStatus.setText(getString(R.string.device_connected_successfully));
         } else {
             imgViewDeviceStatus.setImageResource(org.fossasia.pslab.R.drawable.usb_disconnected);
-            tvDeviceStatus.setText("PSLab Device not found");
+            tvDeviceStatus.setText(getString(R.string.device_not_found));
         }
         return view;
     }
@@ -86,9 +86,9 @@ public class HomeFragment extends Fragment {
                 public void run() {
                     try {
                         tvVersion.setText(scienceLab.getVersion());
-                        tvInitializationStatus.setText("Initialising Wait ...");
+                        tvInitializationStatus.setText(getString(R.string.initialising_wait));
                         if (booleanVariable.isInitialised())
-                            tvInitializationStatus.setText("Initialsation Completed");
+                            tvInitializationStatus.setText(getString(R.string.initialisation_completed));
 
                     } catch (IOException e) {
                         e.printStackTrace();
@@ -97,16 +97,17 @@ public class HomeFragment extends Fragment {
             }, 100);
 
         } else {
-            tvVersion.setText("Not Connected");
+            tvVersion.setText(getString(R.string.not_connected));
         }
 
         booleanVariable.setValueChangeListener(new InitializationVariable.onValueChangeListener() {
             @Override
             public void onChange() {
-                if (booleanVariable.isInitialised())
-                    tvInitializationStatus.setText("Initialsation Completed");
-                else
-                    tvInitializationStatus.setText("Initialising Wait ...");
+                if (tvInitializationStatus != null)
+                    if (booleanVariable.isInitialised())
+                        tvInitializationStatus.setText(getString(R.string.initialisation_completed));
+                    else
+                        tvInitializationStatus.setText(getString(R.string.initialising_wait));
             }
         });
 

--- a/app/src/main/java/org/fossasia/pslab/fragment/HomeFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/HomeFragment.java
@@ -13,6 +13,7 @@ import android.widget.TextView;
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.communication.ScienceLab;
 import org.fossasia.pslab.others.InitializationVariable;
+import org.fossasia.pslab.others.PreferenceManager;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.io.IOException;
@@ -85,7 +86,14 @@ public class HomeFragment extends Fragment {
                 @Override
                 public void run() {
                     try {
-                        tvVersion.setText(scienceLab.getVersion());
+                        String version;
+                        PreferenceManager preferenceManager = new PreferenceManager(getActivity());
+                        if ("none".equals(preferenceManager.getVersion())) {
+                            version = scienceLab.getVersion();
+                        } else {
+                            version = preferenceManager.getVersion();
+                        }
+                        tvVersion.setText(version);
                         tvInitializationStatus.setText(getString(R.string.initialising_wait));
                         if (booleanVariable.isInitialised())
                             tvInitializationStatus.setText(getString(R.string.initialisation_completed));

--- a/app/src/main/java/org/fossasia/pslab/others/PreferenceManager.java
+++ b/app/src/main/java/org/fossasia/pslab/others/PreferenceManager.java
@@ -1,0 +1,34 @@
+package org.fossasia.pslab.others;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * Created by viveksb007 on 21/6/17.
+ */
+
+public class PreferenceManager {
+
+    private SharedPreferences sharedPreferences;
+    private SharedPreferences.Editor editor;
+    private Context context;
+
+    private static final String preferenceName = "PSLAB";
+    private static final String version = "version";
+
+    public PreferenceManager(Context context) {
+        this.context = context;
+        sharedPreferences = context.getSharedPreferences(preferenceName, Context.MODE_PRIVATE);
+    }
+
+    public void setVersion(String version) {
+        editor = sharedPreferences.edit();
+        editor.putString(version, version);
+        editor.apply();
+    }
+
+    public String getVersion() {
+        return sharedPreferences.getString(version, "none");
+    }
+
+}

--- a/app/src/main/java/org/fossasia/pslab/receivers/USBDetachReceiver.java
+++ b/app/src/main/java/org/fossasia/pslab/receivers/USBDetachReceiver.java
@@ -1,0 +1,54 @@
+package org.fossasia.pslab.receivers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbManager;
+import android.support.v4.app.Fragment;
+import android.util.Log;
+import android.widget.Toast;
+
+import org.fossasia.pslab.R;
+import org.fossasia.pslab.activity.MainActivity;
+import org.fossasia.pslab.fragment.HomeFragment;
+import org.fossasia.pslab.others.PreferenceManager;
+import org.fossasia.pslab.others.ScienceLabCommon;
+
+/**
+ * Created by viveksb007 on 21/6/17.
+ */
+
+public class USBDetachReceiver extends BroadcastReceiver {
+
+    private final String TAG = this.getClass().getSimpleName();
+    private Context activityContext;
+
+    public USBDetachReceiver(Context context) {
+        this.activityContext = context;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(intent.getAction())) {
+            UsbDevice device = (UsbDevice) intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+            if (device != null) {
+                ScienceLabCommon.scienceLab.close();
+                Toast.makeText(context, "USB Device Disconnected", Toast.LENGTH_SHORT).show();
+
+                new PreferenceManager(context).setVersion("none"); // writing version as "none" so that its read againg when PSLab is connected
+
+                if (activityContext != null) {
+                    MainActivity mainActivity = (MainActivity) activityContext;
+                    Fragment currentFragment = mainActivity.getSupportFragmentManager().findFragmentById(R.id.frame);
+                    if (currentFragment instanceof HomeFragment) {
+                        mainActivity.getSupportFragmentManager().beginTransaction().replace(R.id.frame, HomeFragment.newInstance(false, false)).commit();
+                    }
+                }
+            } else {
+                Log.v(TAG, "USB Device is null");
+            }
+        }
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,5 +90,10 @@
     <string-array name="sensors">
 
     </string-array>
+    <string name="not_connected">Not Connected</string>
+    <string name="initialisation_completed">Initialisation Completed</string>
+    <string name="initialising_wait">Initialising Wait…</string>
+    <string name="device_connected_successfully">Device Connected Successfully</string>
+    <string name="device_not_found">Device Not Found</string>
 
 </resources>


### PR DESCRIPTION
Fixes issue #72 and #216 

Changes: 

- Abrupt disconnection is handled by receiving USB_DEVICE_DETACHED intent in BroadcastReceiver.
- prevents version read again and again by storing it as preference when device is connected and discarding it when its disconnected.   

[APK Link](https://drive.google.com/open?id=0B30IF3fyX4Q3M2xQM3hFVHBNVjg) for testing.

App crashes if device is removed during initialisation as initialisation is going on another thread ( bulkTransfer methods are called before broadcastReceiver can handle things ) and thread.stop() and thread.kill() methods are deprecated. Would look for something that prevents app crash and thread would be killed on its own after some time.

One commit from previous PR is reflected as I forgot to change branch.