### PR TITLE
replaced default Android icon with the specific pslab icon

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,9 +7,9 @@
 
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="@drawable/logo"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
+        android:roundIcon="@drawable/logo"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".activity.SplashActivity">


### PR DESCRIPTION
Fixes #221 

Changes:
- replaced default Android icon with the specific pslab icon

Screenshots for the change: 

![screenshot_1498331490](https://user-images.githubusercontent.com/26146675/27511383-1573a5f4-5940-11e7-88bc-336f29d6de97.png)


