### PR TITLE
Closes Oscilloscope Activity when device is disconnected

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -108,6 +108,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
     private CaptureTask captureTask;
     private CaptureTaskTwo captureTask2;
     private CaptureTaskThree captureTask3;
+    private static Context context;
 
 
     @Override
@@ -135,6 +136,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
         x1 = mChart.getXAxis();
         y1 = mChart.getAxisLeft();
         y2 = mChart.getAxisRight();
+        context = this;
         //scienceLab.setW1(1100, "sine");
 
         Display display = getWindowManager().getDefaultDisplay();
@@ -170,7 +172,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
             public void run() {
                 //Thread to check which checkbox is enabled
                 while (true) {
-                    if (isCH1Selected && !isCH2Selected && !isCH3Selected && !isMICSelected){
+                    if (isCH1Selected && !isCH2Selected && !isCH3Selected && !isMICSelected) {
                         captureTask = new CaptureTask();
                         captureTask.execute("CH1");
                         synchronized (lock){
@@ -183,7 +185,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
 
                     }
 
-                    if (isCH2Selected && !isCH1Selected && !isCH3Selected && !isMICSelected){
+                    if (isCH2Selected && !isCH1Selected && !isCH3Selected && !isMICSelected) {
                         captureTask = new CaptureTask();
                         captureTask.execute("CH2");
                         synchronized (lock){
@@ -196,7 +198,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
 
                     }
 
-                    if (isCH3Selected && !isCH1Selected && !isCH2Selected && !isMICSelected){
+                    if (isCH3Selected && !isCH1Selected && !isCH2Selected && !isMICSelected) {
                         {
                             captureTask = new CaptureTask();
                             captureTask.execute("CH3");
@@ -210,7 +212,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
                         }
                     }
 
-                    if (isMICSelected && !isCH1Selected && !isCH2Selected && !isCH3Selected){
+                    if (isMICSelected && !isCH1Selected && !isCH2Selected && !isCH3Selected) {
                         captureTask = new CaptureTask();
                         captureTask.execute("MIC");
                         synchronized (lock){
@@ -223,7 +225,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
 
                     }
 
-                    if (isCH1Selected && isCH2Selected && !isCH3Selected && !isMICSelected){
+                    if (isCH1Selected && isCH2Selected && !isCH3Selected && !isMICSelected) {
                         captureTask2 = new CaptureTaskTwo();
                         captureTask2.execute("CH1");
                         synchronized (lock){
@@ -235,7 +237,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
                         }
                     }
 
-                    if (isCH3Selected && isCH2Selected && !isCH1Selected && !isMICSelected){
+                    if (isCH3Selected && isCH2Selected && !isCH1Selected && !isMICSelected) {
                         captureTask2 = new CaptureTaskTwo();
                         captureTask2.execute("CH3");
                         synchronized (lock){
@@ -247,7 +249,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
                         }
                     }
 
-                    if (isMICSelected && isCH2Selected && !isCH3Selected && !isCH1Selected){
+                    if (isMICSelected && isCH2Selected && !isCH3Selected && !isCH1Selected) {
                         captureTask2 = new CaptureTaskTwo();
                         captureTask2.execute("MIC");
                         synchronized (lock){
@@ -259,7 +261,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
                         }
                     }
 
-                    if (isCH1Selected && isCH2Selected && isCH3Selected && isMICSelected){
+                    if (isCH1Selected && isCH2Selected && isCH3Selected && isMICSelected) {
                         captureTask3 = new CaptureTaskThree();
                         captureTask3.execute("CH1");
                         synchronized (lock){
@@ -360,6 +362,10 @@ public class OscilloscopeActivity extends AppCompatActivity implements
     @Override
     public void onFragmentInteraction(Uri uri) {
 
+    }
+
+    public static Context getContext() {
+        return context;
     }
 
     @Override
@@ -540,7 +546,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
         }
 
         @Override
-        protected void onPostExecute(Void aVoid){
+        protected void onPostExecute(Void aVoid) {
             super.onPostExecute(aVoid);
             LineDataSet dataset1 = new LineDataSet(entries1, analogInput);
             LineDataSet dataSet2 = new LineDataSet(entries2, "CH2");

--- a/app/src/main/java/org/fossasia/pslab/receivers/USBDetachReceiver.java
+++ b/app/src/main/java/org/fossasia/pslab/receivers/USBDetachReceiver.java
@@ -1,5 +1,6 @@
 package org.fossasia.pslab.receivers;
 
+import android.app.ActivityManager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -11,9 +12,14 @@ import android.widget.Toast;
 
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.activity.MainActivity;
+import org.fossasia.pslab.activity.OscilloscopeActivity;
 import org.fossasia.pslab.fragment.HomeFragment;
 import org.fossasia.pslab.others.PreferenceManager;
 import org.fossasia.pslab.others.ScienceLabCommon;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Created by viveksb007 on 21/6/17.
@@ -39,20 +45,27 @@ public class USBDetachReceiver extends BroadcastReceiver {
 
                     new PreferenceManager(context).setVersion("none"); // writing version as "none" so that its read againg when PSLab is connected
 
-                    if (activityContext != null) {
-                        MainActivity mainActivity = (MainActivity) activityContext;
-                        Fragment currentFragment = mainActivity.getSupportFragmentManager().findFragmentById(R.id.frame);
-                        if (currentFragment instanceof HomeFragment) {
-                            mainActivity.getSupportFragmentManager().beginTransaction().replace(R.id.frame, HomeFragment.newInstance(false, false)).commitAllowingStateLoss();
-                        }
+                    ArrayList<String> runningactivities = new ArrayList<String>();
+                    ActivityManager activityManager = (ActivityManager)context.getSystemService (Context.ACTIVITY_SERVICE);
+                    List<ActivityManager.RunningTaskInfo> services = activityManager.getRunningTasks(Integer.MAX_VALUE);
+
+                    for (int i = 0; i < services.size(); i++) {
+                        runningactivities.add(0,services.get(i).topActivity.toString());
+                        Log.v(TAG, runningactivities.get(i));
+                    }
+                    if(runningactivities.contains("ComponentInfo{org.fossasia.pslab/org.fossasia.pslab.activity.OscilloscopeActivity}")) {
+                        Context oscilloscopeContext = OscilloscopeActivity.getContext();
+                        ((OscilloscopeActivity) oscilloscopeContext).finish();
+                    }
+                    MainActivity mainActivity = (MainActivity) activityContext;
+                    mainActivity.getSupportFragmentManager().beginTransaction().replace(R.id.frame, HomeFragment.newInstance(false, false)).commitAllowingStateLoss();
                     }
                 } else {
                     Log.v(TAG, "USB Device is null");
                 }
-            }
-        } catch (IllegalStateException ignored){
+
+        } catch (IllegalStateException ignored) {
 
         }
-
     }
 }


### PR DESCRIPTION
Fixes #247 

Changes: 
- Oscilloscope Activity closes when the device is disconnected.
- Reformatted code

Screenshots for the change: 
Video link - https://goo.gl/photos/v29Eho4HWxor5WkV8