### PR TITLE
fixed version read between screens to HomeFragment

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/communication/PacketHandler.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/PacketHandler.java
@@ -19,7 +19,7 @@ public class PacketHandler {
     private boolean loadBurst, connected;
     int inputQueueSize = 0, BAUD = 1000000;
     private CommunicationHandler mCommunicationHandler = null;
-    String version = "";
+    public static String version = "";
     private CommandsProto mCommandsProto;
     private int timeout = 500, VERSION_STRING_LENGTH = 15;
     ByteBuffer burstBuffer = ByteBuffer.allocate(2000);

--- a/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
@@ -3171,5 +3171,6 @@ public class ScienceLab {
 
     public void disconnect() throws IOException {
         mCommunicationHandler.close();
+        PacketHandler.version = "";
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/fragment/HomeFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/HomeFragment.java
@@ -11,9 +11,9 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import org.fossasia.pslab.R;
+import org.fossasia.pslab.communication.PacketHandler;
 import org.fossasia.pslab.communication.ScienceLab;
 import org.fossasia.pslab.others.InitializationVariable;
-import org.fossasia.pslab.others.PreferenceManager;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.io.IOException;
@@ -87,12 +87,10 @@ public class HomeFragment extends Fragment {
                 public void run() {
                     try {
 
-                        String version;
-                        PreferenceManager preferenceManager = new PreferenceManager(getActivity());
-                        if ("none".equals(preferenceManager.getVersion())) {
+                        String version = PacketHandler.version;
+                        if ("".equals(version)) {
                             version = scienceLab.getVersion();
-                        } else {
-                            version = preferenceManager.getVersion();
+                            PacketHandler.version = version;
                         }
                         tvVersion.setText(version);
                         tvInitializationStatus.setText(getString(R.string.initialising_wait));

--- a/app/src/main/java/org/fossasia/pslab/receivers/USBDetachReceiver.java
+++ b/app/src/main/java/org/fossasia/pslab/receivers/USBDetachReceiver.java
@@ -11,8 +11,8 @@ import android.widget.Toast;
 
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.activity.MainActivity;
+import org.fossasia.pslab.communication.PacketHandler;
 import org.fossasia.pslab.fragment.HomeFragment;
-import org.fossasia.pslab.others.PreferenceManager;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
 /**
@@ -37,7 +37,7 @@ public class USBDetachReceiver extends BroadcastReceiver {
                     ScienceLabCommon.scienceLab.close();
                     Toast.makeText(context, "USB Device Disconnected", Toast.LENGTH_SHORT).show();
 
-                    new PreferenceManager(context).setVersion("none"); // writing version as "none" so that its read againg when PSLab is connected
+                    PacketHandler.version = "";
 
                     if (activityContext != null) {
                         MainActivity mainActivity = (MainActivity) activityContext;


### PR DESCRIPTION
Fixes issue #258 

Changes: Stored Version in ```PacketHandler Version``` variable and read from it during the time app is opened. Version is read only once when device is connected.

