### PR TITLE
Fixes #296 : Same button layout in Osc and LA

### DIFF
--- a/app/src/main/res/layout-land/logic_analyzer_select_channel_mode.xml
+++ b/app/src/main/res/layout-land/logic_analyzer_select_channel_mode.xml
@@ -104,7 +104,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:text="Analyze" />
+            android:background="@drawable/selector_button"
+            android:text="@string/analyze"
+            android:textColor="@color/white"
+            android:textSize="@dimen/control_textsize_small" />
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/layout-sw600dp/fragment_xyplot.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_xyplot.xml
@@ -56,7 +56,10 @@
         android:layout_toEndOf="@+id/spinner_channel_select_xy2"
         android:layout_toRightOf="@+id/spinner_channel_select_xy2"
         android:layout_weight="1"
-        android:text="VIEW"
+        android:background="@drawable/selector_button"
+        android:text="@string/view"
+        android:textColor="@color/white"
+        android:textSize="@dimen/control_textsize_small"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
 

--- a/app/src/main/res/layout/fragment_xyplot.xml
+++ b/app/src/main/res/layout/fragment_xyplot.xml
@@ -59,7 +59,10 @@
         android:layout_toEndOf="@+id/spinner_channel_select_xy2"
         android:layout_toRightOf="@+id/spinner_channel_select_xy2"
         android:layout_weight="1"
-        android:text="VIEW"
+        android:background="@drawable/selector_button"
+        android:text="@string/view"
+        android:textColor="@color/white"
+        android:textSize="@dimen/control_textsize_small"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
 

--- a/app/src/main/res/layout/logic_analyzer_select_channel_mode.xml
+++ b/app/src/main/res/layout/logic_analyzer_select_channel_mode.xml
@@ -104,7 +104,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
-            android:text="Analyze" />
+            android:background="@drawable/selector_button"
+            android:text="@string/analyze"
+            android:textColor="@color/white"
+            android:textSize="@dimen/control_textsize_small" />
     </LinearLayout>
 
 </ScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,5 +95,7 @@
     <string name="device_not_found">Device Not Found</string>
 
     <string name="time_unit_la">Time -> (ms)</string>
+    <string name="analyze">Analyze</string>
+    <string name="view">VIEW</string>
 
 </resources>


### PR DESCRIPTION
Fixes issue #296 

Changes:
- Added button selector background to all the buttons in Oscilloscope and Logic Analyzer
- Added hard-coded strings to strings.xml in the respective button views

Screenshots for the change: 

| Logic Analyzer | Oscilloscope |
| -------- | ------- |
| ![after](https://user-images.githubusercontent.com/14261304/28072245-0c2f863c-6685-11e7-8226-4a170f0a52b8.png) | ![after2](https://user-images.githubusercontent.com/14261304/28072393-69519292-6685-11e7-98ed-412d7ad1c635.png) |

APK for testing:
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/1139163/app-debug.apk.zip)

