### PR TITLE
Fixes #323: prevent unncessary running thread

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -317,7 +317,10 @@ public class OscilloscopeActivity extends AppCompatActivity implements
                 }
             }
         };
-        new Thread(runnable).start();
+
+        if (scienceLab.isConnected())
+            new Thread(runnable).start();
+        
     }
 
     @Override


### PR DESCRIPTION
Fixes issue #323 

Changes:
- Thread to monitor checkboxes would start only if device is connected.
