### PR TITLE
checked views inside fragments

### DIFF
--- a/app/src/androidTest/java/org/fossasia/pslab/MainActivityTest.java
+++ b/app/src/androidTest/java/org/fossasia/pslab/MainActivityTest.java
@@ -7,13 +7,20 @@ import android.support.test.filters.LargeTest;
 import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 
+import org.fossasia.pslab.activity.LogicalAnalyzerActivity;
 import org.fossasia.pslab.activity.MainActivity;
+import org.fossasia.pslab.activity.OscilloscopeActivity;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static android.support.test.espresso.Espresso.onData;
 import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
 
 /**
  * Created by viveksb007 on 18/7/17.
@@ -27,24 +34,47 @@ public class MainActivityTest {
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<MainActivity>(MainActivity.class);
 
     @Test
-    public void checkingAllFragments() throws InterruptedException {
+    public void checkingAllFragments() throws Throwable {
         Thread.sleep(2000);
 
+        // checking home fragment views
+        onView(withId(R.id.img_device_status)).check(matches(isDisplayed()));
+        onView(withId(R.id.tv_device_status)).check(matches(isDisplayed()));
+        onView(withId(R.id.tv_device_version)).check(matches(isDisplayed()));
+        onView(withId(R.id.tv_initialisation_status)).check(matches(isDisplayed()));
+
+        // Shifting to Applications Fragment
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
         onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_applications));
         Thread.sleep(1000);
 
+        // checking all is visible tiles inside Application Fragment
+        onView(withText("Oscilloscope")).check(matches(isDisplayed()));
+        onView(withText("Control")).check(matches(isDisplayed()));
+        onView(withText("Logical Analyzer")).check(matches(isDisplayed()));
+        onView(withText("Data Sensor Logger")).check(matches(isDisplayed()));
+        onView(withText("Wireless Sensor")).check(matches(isDisplayed()));
+        onView(withText("Sensor QuickView")).check(matches(isDisplayed()));
+
+
+        // Shifting to Saved Experiments Fragment
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
         onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_saved_experiments));
         Thread.sleep(1000);
+        // checking Saved Experiment Fragment View
+        onView(withId(R.id.saved_experiments_elv)).check(matches(isDisplayed()));
 
+
+        // Shifting to Design Experiments Fragment
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
         onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_design_experiments));
         Thread.sleep(1000);
 
+        // Shifting to Settings Fragment
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open());
         onView(withId(R.id.nav_view)).perform(NavigationViewActions.navigateTo(R.id.nav_settings));
         Thread.sleep(1000);
+        onView(withText("Auto Start")).check(matches(isDisplayed()));
     }
 
 }


### PR DESCRIPTION
Partially Fixes issue #333 

Changes: 
- Added test to check views inside all fragments of MainActivity

P.S : would have added test for activity too but inside activity sciencelab methods are used and sciencelab is ```null``` in tests (test were failing due to null sciencelab object), would look for mocking objects in tests and add tests for each Activities. 

Screenshots for the change: 
![screenshot from 2017-07-19 21-48-44](https://user-images.githubusercontent.com/12713808/28378212-0f607606-6ccd-11e7-8de1-2667ef6dcc82.png)
