### PR TITLE
Fix #353 : Removed default selection CH1 in OSC

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -148,7 +148,6 @@ public class OscilloscopeActivity extends AppCompatActivity implements
         triggerChannel = "CH1";
         trigger = 0;
         timebase = 875;
-        //isCH1Selected = true;
         graph = new Plot2D(this, new float[]{}, new float[]{}, 1);
         xyPlotXAxisChannel = "CH1";
         xyPlotYAxisChannel = "CH2";

--- a/app/src/main/res/layout-sw600dp/fragment_channel_parameters.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_channel_parameters.xml
@@ -13,7 +13,6 @@
         android:layout_marginLeft="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
-        android:checked="true"
         android:text="CH1"
         android:textSize="18sp"
         android:textStyle="normal|bold"

--- a/app/src/main/res/layout/fragment_channel_parameters.xml
+++ b/app/src/main/res/layout/fragment_channel_parameters.xml
@@ -13,7 +13,6 @@
         android:layout_marginLeft="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:checked="true"
         android:text="CH1"
         android:textStyle="normal|bold"
         app:layout_constraintLeft_toLeftOf="parent"


### PR DESCRIPTION
Fixes issue #353 

Changes: 
- Removed default selection from xml files related to oscilloscope activity

Screenshots for the change: 
![screenshot](https://user-images.githubusercontent.com/14261304/28451653-11cd080a-6e21-11e7-9865-871088f72cc4.png)
