### PR TITLE
Fixes #356 audio buffer processed and plotted successfully

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -866,7 +866,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
         @Override
         protected Void doInBackground(Void... params) {
             buffer = audioJack.read();
-            Log.v("AudioBuffer", Arrays.toString(buffer));
+            //Log.v("AudioBuffer", Arrays.toString(buffer));
             return null;
         }
 
@@ -874,7 +874,17 @@ public class OscilloscopeActivity extends AppCompatActivity implements
         protected void onPostExecute(Void aVoid) {
             super.onPostExecute(aVoid);
             // Update chart
-            Log.v("Execution Done", "Completed");
+            List<Entry> entries = new ArrayList<>();
+            for (int i = 0; i < buffer.length; i++) {
+                entries.add(new Entry(i, (float) AudioJack.map(buffer[i], -32768, 32767, -3, 3)));
+            }
+            LineDataSet lineDataSet = new LineDataSet(entries, "Audio Data");
+            lineDataSet.setColor(Color.WHITE);
+            lineDataSet.setDrawCircles(false);
+            mChart.setData(new LineData(lineDataSet));
+            mChart.notifyDataSetChanged();
+            mChart.invalidate();
+            //Log.v("Execution Done", "Completed");
             synchronized (lock) {
                 lock.notify();
             }

--- a/app/src/main/java/org/fossasia/pslab/others/AudioJack.java
+++ b/app/src/main/java/org/fossasia/pslab/others/AudioJack.java
@@ -105,4 +105,8 @@ public class AudioJack {
         }
     }
 
+    public static double map(double x, double inMin, double inMax, double outMin, double outMax) {
+        return (x - inMin) * (outMax - outMin) / (inMax - inMin) + outMin;
+    }
+
 }


### PR DESCRIPTION
Fixes issue #356 

Changes:
- audio buffer read is processed and plotted successfully.
- Currently I mapped the signed 16 bit value to -3 to 3 V and x axis as 1,2,3,.. (Refer [post](https://docs.google.com/document/d/1lXNzQfmXNBjjDyTzHT_q7gO3b7JWyr2_0oCFqavEZqM/edit?usp=sharing) for technical details)

X axis values (time-axis) needs to be calculated using current sampling rate of audio data and Y-axis values need to be calibrated using multi-meter. I don't have instruments to calibrate right now.

Screencast : https://photos.app.goo.gl/tp2N9uAwX1xvamAI3

![screenshot_2017-07-21-14-05-30-630_org fossasia pslab](https://user-images.githubusercontent.com/12713808/28455853-1f1c6666-6e1e-11e7-9ea3-7d1a8f8ed322.png)

