### PR TITLE
Added experiment setup functionality

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -44,9 +44,10 @@ import org.fossasia.pslab.others.ScienceLabCommon;
 import org.fossasia.pslab.R;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+
+import static org.fossasia.pslab.others.MathUtils.map;
 
 /**
  * Created by viveksb007 on 10/5/17.
@@ -876,7 +877,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements
             // Update chart
             List<Entry> entries = new ArrayList<>();
             for (int i = 0; i < buffer.length; i++) {
-                entries.add(new Entry(i, (float) AudioJack.map(buffer[i], -32768, 32767, -3, 3)));
+                entries.add(new Entry(i, (float) map(buffer[i], -32768, 32767, -3, 3)));
             }
             LineDataSet lineDataSet = new LineDataSet(entries, "Audio Data");
             lineDataSet.setColor(Color.WHITE);

--- a/app/src/main/java/org/fossasia/pslab/adapters/ControlMainAdapter.java
+++ b/app/src/main/java/org/fossasia/pslab/adapters/ControlMainAdapter.java
@@ -12,9 +12,12 @@ import android.widget.TextView;
 
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.communication.ScienceLab;
+import org.fossasia.pslab.others.MathUtils;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.text.DecimalFormat;
+
+import static org.fossasia.pslab.others.MathUtils.map;
 
 /**
  * Created by asitava on 6/6/17.
@@ -653,7 +656,4 @@ public class ControlMainAdapter extends RecyclerView.Adapter<ControlMainAdapter.
         return mDataset.length;
     }
 
-    private double map(int x, int in_min, int in_max, double out_min, double out_max) {
-        return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
-    }
 }

--- a/app/src/main/java/org/fossasia/pslab/adapters/ControlMainAdapter.java
+++ b/app/src/main/java/org/fossasia/pslab/adapters/ControlMainAdapter.java
@@ -12,7 +12,6 @@ import android.widget.TextView;
 
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.communication.ScienceLab;
-import org.fossasia.pslab.others.MathUtils;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.text.DecimalFormat;

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
@@ -20,7 +20,6 @@ import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 
-import org.apache.commons.math3.geometry.euclidean.threed.Line;
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.communication.ScienceLab;
 import org.fossasia.pslab.others.ScienceLabCommon;
@@ -78,12 +77,12 @@ public class OhmsLawSetupExperiment extends Fragment {
 
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) {
-
+                //
             }
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-
+                //
             }
         });
 
@@ -138,6 +137,9 @@ public class OhmsLawSetupExperiment extends Fragment {
                     break;
                 case "CH3":
                     voltageValue = scienceLab.getVoltage("CH3", 5);
+                    break;
+                default:
+                    voltageValue = scienceLab.getVoltage("CH1", 5);
             }
             x.add((float) currentValue);
             y.add((float) voltageValue);

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
@@ -25,8 +25,11 @@ import org.fossasia.pslab.R;
 import org.fossasia.pslab.communication.ScienceLab;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.fossasia.pslab.others.MathUtils.map;
 
 /**
  * Created by viveksb007 on 20/7/17.
@@ -58,6 +61,7 @@ public class OhmsLawSetupExperiment extends Fragment {
         View view = inflater.inflate(R.layout.ohms_law_setup, container, false);
         outputChart = (LineChart) view.findViewById(R.id.ohm_chart);
         tvCurrentValue = (TextView) view.findViewById(R.id.tv_current_value);
+        tvCurrentValue.setText("0");
         tvVoltageValue = (TextView) view.findViewById(R.id.tv_voltage_value);
         seekBar = (SeekBar) view.findViewById(R.id.current_seekbar);
         Button btnReadVoltage = (Button) view.findViewById(R.id.btn_read_voltage);
@@ -67,7 +71,9 @@ public class OhmsLawSetupExperiment extends Fragment {
         seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-
+                double value = map(progress, 0, 330, 0, 3.3);
+                DecimalFormat df = new DecimalFormat("0.0000");
+                tvCurrentValue.setText(df.format(value));
             }
 
             @Override
@@ -86,6 +92,8 @@ public class OhmsLawSetupExperiment extends Fragment {
             public void onClick(View v) {
                 selectedChannel = channelSelectSpinner.getSelectedItem().toString();
                 currentValue = Double.parseDouble(tvCurrentValue.getText().toString());
+                CalcDataPoint calcDataPoint = new CalcDataPoint();
+                calcDataPoint.execute();
             }
         });
         chartInit();

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
@@ -48,6 +48,7 @@ public class OhmsLawSetupExperiment extends Fragment {
     private ArrayList<Float> x = new ArrayList<>();
     private ArrayList<Float> y = new ArrayList<>();
     private LineChart outputChart;
+    private DecimalFormat df = new DecimalFormat("0.0000");
 
     public static OhmsLawSetupExperiment newInstance() {
         OhmsLawSetupExperiment ohmsLawSetupExperiment = new OhmsLawSetupExperiment();
@@ -71,7 +72,6 @@ public class OhmsLawSetupExperiment extends Fragment {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 double value = map(progress, 0, 330, 0, 3.3);
-                DecimalFormat df = new DecimalFormat("0.0000");
                 tvCurrentValue.setText(df.format(value));
             }
 
@@ -109,7 +109,7 @@ public class OhmsLawSetupExperiment extends Fragment {
     }
 
     private void updateGraph() {
-        tvVoltageValue.setText(String.valueOf(voltageValue));
+        tvVoltageValue.setText(df.format(voltageValue));
         List<ILineDataSet> dataSets = new ArrayList<>();
         List<Entry> temp = new ArrayList<>();
         for (int i = 0; i < x.size(); i++) {

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
@@ -1,5 +1,7 @@
 package org.fossasia.pslab.experimentsetup;
 
+import android.graphics.Color;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -8,10 +10,23 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.SeekBar;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.data.Entry;
+import com.github.mikephil.charting.data.LineData;
+import com.github.mikephil.charting.data.LineDataSet;
+import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
+
+import org.apache.commons.math3.geometry.euclidean.threed.Line;
 import org.fossasia.pslab.R;
+import org.fossasia.pslab.communication.ScienceLab;
+import org.fossasia.pslab.others.ScienceLabCommon;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by viveksb007 on 20/7/17.
@@ -21,9 +36,16 @@ public class OhmsLawSetupExperiment extends Fragment {
 
     private TextView tvCurrentValue;
     private TextView tvVoltageValue;
-    private Button btnReadVoltage;
     private Spinner channelSelectSpinner;
+    private SeekBar seekBar;
     private String[] channels = {"CH1", "CH2", "CH3", "CH4"};
+    private double currentValue = 0;
+    private double voltageValue = 0;
+    private ScienceLab scienceLab = ScienceLabCommon.scienceLab;
+    private String selectedChannel;
+    private ArrayList<Float> x = new ArrayList<>();
+    private ArrayList<Float> y = new ArrayList<>();
+    private LineChart outputChart;
 
     public static OhmsLawSetupExperiment newInstance() {
         OhmsLawSetupExperiment ohmsLawSetupExperiment = new OhmsLawSetupExperiment();
@@ -34,11 +56,91 @@ public class OhmsLawSetupExperiment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.ohms_law_setup, container, false);
+        outputChart = (LineChart) view.findViewById(R.id.ohm_chart);
         tvCurrentValue = (TextView) view.findViewById(R.id.tv_current_value);
         tvVoltageValue = (TextView) view.findViewById(R.id.tv_voltage_value);
-        btnReadVoltage = (Button) view.findViewById(R.id.btn_read_voltage);
+        seekBar = (SeekBar) view.findViewById(R.id.current_seekbar);
+        Button btnReadVoltage = (Button) view.findViewById(R.id.btn_read_voltage);
         channelSelectSpinner = (Spinner) view.findViewById(R.id.channel_select_spinner);
         channelSelectSpinner.setAdapter(new ArrayAdapter<>(getContext(), android.R.layout.simple_spinner_dropdown_item, channels));
+        seekBar.setMax(330);
+        seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+
+            }
+        });
+
+        btnReadVoltage.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                selectedChannel = channelSelectSpinner.getSelectedItem().toString();
+                currentValue = Double.parseDouble(tvCurrentValue.getText().toString());
+            }
+        });
+        chartInit();
         return view;
     }
+
+    private void chartInit() {
+        outputChart.setTouchEnabled(true);
+        outputChart.setDragEnabled(true);
+        outputChart.setScaleEnabled(true);
+        outputChart.setPinchZoom(true);
+        LineData data = new LineData();
+        outputChart.setData(data);
+    }
+
+    private void updateGraph() {
+        tvVoltageValue.setText(String.valueOf(voltageValue));
+        List<ILineDataSet> dataSets = new ArrayList<>();
+        List<Entry> temp = new ArrayList<>();
+        for (int i = 0; i < x.size(); i++) {
+            temp.add(new Entry(x.get(i), y.get(i)));
+        }
+        LineDataSet dataSet = new LineDataSet(temp, "I-V Characteristic");
+        dataSet.setColor(Color.RED);
+        dataSet.setDrawValues(false);
+        //dataSet.setDrawCircles(false);
+        dataSets.add(dataSet);
+        outputChart.setData(new LineData(dataSets));
+        outputChart.invalidate();
+    }
+
+    private class CalcDataPoint extends AsyncTask<Void, Void, Void> {
+
+        @Override
+        protected Void doInBackground(Void... params) {
+            switch (selectedChannel) {
+                case "CH1":
+                    voltageValue = scienceLab.getVoltage("CH1", 5);
+                    break;
+                case "CH2":
+                    voltageValue = scienceLab.getVoltage("CH2", 5);
+                    break;
+                case "CH3":
+                    voltageValue = scienceLab.getVoltage("CH3", 5);
+            }
+            x.add((float) currentValue);
+            y.add((float) voltageValue);
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            super.onPostExecute(aVoid);
+            updateGraph();
+        }
+    }
+
 }

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/TransistorCBSetup.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/TransistorCBSetup.java
@@ -1,12 +1,17 @@
 package org.fossasia.pslab.experimentsetup;
 
+import android.graphics.Color;
+import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.TextInputEditText;
 import android.support.design.widget.TextInputLayout;
 import android.support.v4.app.Fragment;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,9 +20,17 @@ import android.widget.Button;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.github.mikephil.charting.charts.LineChart;
+import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
+import com.github.mikephil.charting.data.LineDataSet;
+import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 
 import org.fossasia.pslab.R;
+import org.fossasia.pslab.communication.ScienceLab;
+import org.fossasia.pslab.others.ScienceLabCommon;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by viveksb007 on 22/7/17.
@@ -30,7 +43,13 @@ public class TransistorCBSetup extends Fragment {
     private float initialVoltage = 0;
     private float finalVoltage = 0;
     private float emitterVoltage = 0;
+    private float stepVoltage = 0;
+    private float resistance = 560;
     private int totalSteps = 0;
+    private ScienceLab scienceLab = ScienceLabCommon.scienceLab;
+    private final Object lock = new Object();
+    private ArrayList<Float> x = new ArrayList<>();
+    private ArrayList<Float> y = new ArrayList<>();
 
     public static TransistorCBSetup newInstance() {
         TransistorCBSetup transistorCBSetup = new TransistorCBSetup();
@@ -88,7 +107,8 @@ public class TransistorCBSetup extends Fragment {
                                 finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
                                 totalSteps = Integer.parseInt(etTotalSteps.getText().toString());
                                 emitterVoltage = Float.parseFloat(etEmitterVoltage.getText().toString());
-
+                                stepVoltage = (finalVoltage - initialVoltage) / totalSteps;
+                                startExperiment();
                             }
                         })
                         .negativeText("Cancel")
@@ -114,6 +134,76 @@ public class TransistorCBSetup extends Fragment {
         outputChart.setPinchZoom(true);
         LineData data = new LineData();
         outputChart.setData(data);
+    }
+
+    private void startExperiment() {
+        Runnable runnable = new Runnable() {
+            @Override
+            public void run() {
+                scienceLab.setPV2(emitterVoltage);
+                for (float i = initialVoltage; i < finalVoltage; i += stepVoltage) {
+                    CalcDataPoints dataPoint = new CalcDataPoints(i);
+                    dataPoint.execute();
+                    synchronized (lock) {
+                        try {
+                            lock.wait();
+                        } catch (InterruptedException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                }
+                new Handler(Looper.getMainLooper()).post(new Runnable() {
+                    @Override
+                    public void run() {
+                        updateChart();
+                    }
+                });
+            }
+        };
+        new Thread(runnable).start();
+    }
+
+    private void updateChart() {
+        Log.v("X-AXIS", x.toString());
+        Log.v("Y-AXIS", y.toString());
+        List<ILineDataSet> dataSets = new ArrayList<>();
+        List<Entry> temp = new ArrayList<>();
+        for (int i = 0; i < x.size(); i++) {
+            temp.add(new Entry(x.get(i), y.get(i)));
+        }
+        LineDataSet dataSet = new LineDataSet(temp, "CB Characteristics");
+        dataSet.setColor(Color.RED);
+        dataSet.setDrawValues(false);
+        dataSet.setDrawCircles(false);
+        dataSets.add(dataSet);
+        outputChart.setData(new LineData(dataSets));
+        outputChart.invalidate();
+    }
+
+    private class CalcDataPoints extends AsyncTask<Void, Void, Void> {
+
+        private float voltage;
+
+        CalcDataPoints(float volt) {
+            this.voltage = volt;
+        }
+
+        @Override
+        protected Void doInBackground(Void... params) {
+            scienceLab.setPV1(voltage);
+            float readVoltage = (float) scienceLab.getVoltage("CH1", 5);
+            x.add(readVoltage);
+            y.add((voltage - readVoltage) / resistance);
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(Void aVoid) {
+            super.onPostExecute(aVoid);
+            synchronized (lock) {
+                lock.notify();
+            }
+        }
     }
 
 }

--- a/app/src/main/java/org/fossasia/pslab/others/AudioJack.java
+++ b/app/src/main/java/org/fossasia/pslab/others/AudioJack.java
@@ -104,9 +104,4 @@ public class AudioJack {
             audioTrack.release();
         }
     }
-
-    public static double map(double x, double inMin, double inMax, double outMin, double outMax) {
-        return (x - inMin) * (outMax - outMin) / (inMax - inMin) + outMin;
-    }
-
 }

--- a/app/src/main/java/org/fossasia/pslab/others/MathUtils.java
+++ b/app/src/main/java/org/fossasia/pslab/others/MathUtils.java
@@ -1,0 +1,13 @@
+package org.fossasia.pslab.others;
+
+/**
+ * Created by viveksb007 on 28/7/17.
+ */
+
+public class MathUtils {
+
+    public static double map(int x, int in_min, int in_max, double out_min, double out_max) {
+        return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+    }
+
+}

--- a/app/src/main/res/layout/ohms_law_setup.xml
+++ b/app/src/main/res/layout/ohms_law_setup.xml
@@ -58,6 +58,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_weight="3"
+                    android:gravity="center"
                     android:background="@drawable/tv_border" />
 
                 <Button

--- a/app/src/main/res/layout/ohms_law_setup.xml
+++ b/app/src/main/res/layout/ohms_law_setup.xml
@@ -25,6 +25,7 @@
                 android:weightSum="10">
 
                 <SeekBar
+                    android:id="@+id/current_seekbar"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_weight="2" />


### PR DESCRIPTION
Partially Fixes issue #378 
Partially Fixes issue #380 

Changes:

Added experiment functionality 
- [x] diode I-V (reusing Zener I-V code as both are identical)
- [x] Ohms Law
- [x] transistor CB

Shifted **map()** function to MathUtils and modified its usages.Would gradually shift functions like **linspace()**,etc in numpy whose implementation code is repeated quite a lot of times.  

Screenshots for the change: 
Ohms experiment setup screencast : https://photos.app.goo.gl/YPXiO7i1wwyBd8uF2
![screenshot_2017-07-29-16-58-32-457_org fossasia pslab](https://user-images.githubusercontent.com/12713808/28744480-6c09b84a-747f-11e7-9ec9-5b78dc4ce5a7.png)
