### PR TITLE
fixes bug in fetchChannel method

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
@@ -930,7 +930,7 @@ public class ScienceLab {
                 mPacketHandler.sendByte(mCommandsProto.ADC);
                 mPacketHandler.sendByte(mCommandsProto.GET_CAPTURE_CHANNEL);
                 mPacketHandler.sendByte(channelNumber - 1);
-                mPacketHandler.sendInt(samples * this.dataSplitting);
+                mPacketHandler.sendInt(samples % this.dataSplitting);
                 mPacketHandler.sendInt(samples - samples % this.dataSplitting);
                 byte[] data = new byte[2 * (samples % this.dataSplitting) + 1];
                 mPacketHandler.read(data, 2 * (samples % this.dataSplitting) + 1);


### PR DESCRIPTION
Fixes #383 

Changes: 
- Fixed the bug in fetchChannel method. This bug was causing the fetchChannel method to return wrong signals while capturing 1024 samples in PR #298 

Apk:
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/1184201/app-debug.apk.zip)
Capturing 1024 samples and W1 generates sinewave

Screenshots for the change: 
![screenshot_2017-07-29-02-04-29-797_org fossasia pslab](https://user-images.githubusercontent.com/26146675/28735543-4d3b4680-7403-11e7-8516-cebfc02fdd19.png)
