### PR TITLE
Fixes #407 current change enabled in Ohm's law experiment

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
@@ -41,7 +41,7 @@ public class OhmsLawSetupExperiment extends Fragment {
     private TextView tvVoltageValue;
     private Spinner channelSelectSpinner;
     private SeekBar seekBar;
-    private String[] channels = {"CH1", "CH2", "CH3", "CH4"};
+    private String[] channels = {"CH1", "CH2", "CH3"};
     private double currentValue = 0;
     private double voltageValue = 0;
     private ScienceLab scienceLab = ScienceLabCommon.scienceLab;
@@ -133,6 +133,7 @@ public class OhmsLawSetupExperiment extends Fragment {
 
         @Override
         protected Void doInBackground(Void... params) {
+            scienceLab.setPCS((float) currentValue);
             switch (selectedChannel) {
                 case "CH1":
                     voltageValue = scienceLab.getVoltage("CH1", 5);


### PR DESCRIPTION
Fixes issue #407 

Changes:
- Current value is changed before reading voltage from channel.
