### PR TITLE
Fixes #421 : Limit voltage values within an appropriate range

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/NFETOutputCharacteristicsExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/NFETOutputCharacteristicsExperiment.java
@@ -45,6 +45,10 @@ public class NFETOutputCharacteristicsExperiment extends Fragment {
 
     private static final String ERROR_MESSAGE = "Invalid Value";
     private static final String INVALID_VALUE = "Voltage value too low";
+    private static final String MINIMUM_VALUE_5V = "Voltage is beyond minimum of -5V";
+    private static final String MAXIMUM_VALUE_5V = "Voltage is beyond maximum of 5V";
+    private static final String MINIMUM_VALUE_3V = "Voltage is beyond minimum of -3.3V";
+    private static final String MAXIMUM_VALUE_3V = "Voltage is beyond maximum of 3.3V";
     private LineChart outputChart;
     private float initialVoltage;
     private float finalVoltage;
@@ -82,7 +86,7 @@ public class NFETOutputCharacteristicsExperiment extends Fragment {
                             public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
 
                                 View customView = dialog.getCustomView();
-
+                                assert customView != null;
                                 etInitialVoltage = (TextInputEditText) customView.findViewById(R.id.nfet_initial_voltage);
                                 etFinalVoltage = (TextInputEditText) customView.findViewById(R.id.nfet_final_voltage);
                                 etStepSize = (TextInputEditText) customView.findViewById(R.id.nfet_step_size);
@@ -91,38 +95,58 @@ public class NFETOutputCharacteristicsExperiment extends Fragment {
                                 tilFinalVoltage = (TextInputLayout) customView.findViewById(R.id.nfet_final_voltage_layout);
                                 tilStepSize = (TextInputLayout) customView.findViewById(R.id.nfet_step_size_layout);
                                 tilGateVoltage = (TextInputLayout) customView.findViewById(R.id.nfet_gate_voltage_layout);
-
+                                // Initial Voltage
                                 if (TextUtils.isEmpty(etInitialVoltage.getText().toString())) {
                                     tilInitialVoltage.setError(ERROR_MESSAGE);
+                                    return;
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) < -5.0f) {
+                                    tilInitialVoltage.setError(MINIMUM_VALUE_5V);
+                                    return;
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) > 5.0f) {
+                                    tilInitialVoltage.setError(MAXIMUM_VALUE_5V);
                                     return;
                                 } else {
                                     tilInitialVoltage.setError(null);
                                 }
                                 initialVoltage = Float.parseFloat(etInitialVoltage.getText().toString());
+                                // Final Voltage
                                 if (TextUtils.isEmpty(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(ERROR_MESSAGE);
                                     return;
                                 } else if (initialVoltage >= Float.parseFloat(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(INVALID_VALUE);
                                     return;
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) < -5.0f) {
+                                    tilFinalVoltage.setError(MINIMUM_VALUE_5V);
+                                    return;
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) > 5.0f) {
+                                    tilFinalVoltage.setError(MAXIMUM_VALUE_5V);
+                                    return;
                                 } else {
                                     tilFinalVoltage.setError(null);
                                 }
+                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
+                                // Step Size
                                 if (TextUtils.isEmpty(etStepSize.getText().toString())) {
                                     tilStepSize.setError(ERROR_MESSAGE);
                                     return;
                                 } else {
                                     tilStepSize.setError(null);
                                 }
+                                totalSteps = Float.parseFloat(etStepSize.getText().toString());
+                                // Gate Voltage
                                 if (TextUtils.isEmpty(etGateVoltage.getText().toString())) {
                                     tilGateVoltage.setError(ERROR_MESSAGE);
+                                    return;
+                                } else if (Float.parseFloat(etGateVoltage.getText().toString()) < -3.3f) {
+                                    tilGateVoltage.setError(MINIMUM_VALUE_3V);
+                                    return;
+                                } else if (Float.parseFloat(etGateVoltage.getText().toString()) > 3.3f) {
+                                    tilGateVoltage.setError(MAXIMUM_VALUE_3V);
                                     return;
                                 } else {
                                     tilGateVoltage.setError(null);
                                 }
-
-                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
-                                totalSteps = Float.parseFloat(etStepSize.getText().toString());
                                 gateVoltage = Float.parseFloat(etGateVoltage.getText().toString());
                                 stepVoltage = (finalVoltage - initialVoltage) / totalSteps;
 

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/OhmsLawSetupExperiment.java
@@ -52,8 +52,7 @@ public class OhmsLawSetupExperiment extends Fragment {
     private DecimalFormat df = new DecimalFormat("0.0000");
 
     public static OhmsLawSetupExperiment newInstance() {
-        OhmsLawSetupExperiment ohmsLawSetupExperiment = new OhmsLawSetupExperiment();
-        return ohmsLawSetupExperiment;
+        return new OhmsLawSetupExperiment();
     }
 
     @Nullable

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/TransistorCBSetup.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/TransistorCBSetup.java
@@ -41,6 +41,10 @@ public class TransistorCBSetup extends Fragment {
 
     private static final String ERROR_MESSAGE = "Invalid Value";
     private static final String INVALID_VALUE = "Voltage value too low";
+    private static final String MINIMUM_VALUE_5V = "Voltage is beyond minimum of -5V";
+    private static final String MAXIMUM_VALUE_5V = "Voltage is beyond maximum of 5V";
+    private static final String MINIMUM_VALUE_3V = "Voltage is beyond minimum of -3.3V";
+    private static final String MAXIMUM_VALUE_3V = "Voltage is beyond maximum of 3.3V";
     private LineChart outputChart;
     private float initialVoltage = 0;
     private float finalVoltage = 0;
@@ -86,32 +90,57 @@ public class TransistorCBSetup extends Fragment {
                                 tilFinalVoltage = (TextInputLayout) customView.findViewById(R.id.text_input_layout_fv);
                                 tilTotalSteps = (TextInputLayout) customView.findViewById(R.id.text_input_layout_total_steps);
                                 tilEmitterVoltage = (TextInputLayout) customView.findViewById(R.id.text_input_layout_voltage);
+                                // Initial Voltage
                                 if (TextUtils.isEmpty(etInitialVoltage.getText().toString())) {
                                     tilInitialVoltage.setError(ERROR_MESSAGE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) < -5.0f) {
+                                    tilInitialVoltage.setError(MINIMUM_VALUE_5V);
+                                    return;
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) > 5.0f) {
+                                    tilInitialVoltage.setError(MAXIMUM_VALUE_5V);
+                                    return;
+                                } else {
                                     tilInitialVoltage.setError(null);
+                                }
                                 initialVoltage = Float.parseFloat(etInitialVoltage.getText().toString());
+                                // Final Voltage
                                 if (TextUtils.isEmpty(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(ERROR_MESSAGE);
                                     return;
                                 } else if (initialVoltage >= Float.parseFloat(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(INVALID_VALUE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) < -5.0f) {
+                                    tilFinalVoltage.setError(MINIMUM_VALUE_5V);
+                                    return;
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) > 5.0f) {
+                                    tilFinalVoltage.setError(MAXIMUM_VALUE_5V);
+                                    return;
+                                } else {
                                     tilFinalVoltage.setError(null);
+                                }
+                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
+                                // Step Size
                                 if (TextUtils.isEmpty(etTotalSteps.getText().toString())) {
                                     tilTotalSteps.setError(ERROR_MESSAGE);
                                     return;
                                 } else
                                     tilTotalSteps.setError(null);
+                                totalSteps = Integer.parseInt(etTotalSteps.getText().toString());
+                                // Emitter Voltage
                                 if (TextUtils.isEmpty(etEmitterVoltage.getText().toString())) {
                                     tilEmitterVoltage.setError(ERROR_MESSAGE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etEmitterVoltage.getText().toString()) < -3.3f) {
+                                    tilEmitterVoltage.setError(MINIMUM_VALUE_3V);
+                                    return;
+                                } else if (Float.parseFloat(etEmitterVoltage.getText().toString()) > 3.3f) {
+                                    tilEmitterVoltage.setError(MAXIMUM_VALUE_3V);
+                                    return;
+                                } else {
                                     tilEmitterVoltage.setError(null);
-                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
-                                totalSteps = Integer.parseInt(etTotalSteps.getText().toString());
+                                }
                                 emitterVoltage = Float.parseFloat(etEmitterVoltage.getText().toString());
                                 stepVoltage = (finalVoltage - initialVoltage) / totalSteps;
                                 if (scienceLab.isConnected())

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/TransistorCEOutputSetup.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/TransistorCEOutputSetup.java
@@ -41,6 +41,10 @@ public class TransistorCEOutputSetup extends Fragment {
 
     private static final String ERROR_MESSAGE = "Invalid Value";
     private static final String INVALID_VALUE = "Voltage value too low";
+    private static final String MINIMUM_VALUE_5V = "Voltage is beyond minimum of -5V";
+    private static final String MAXIMUM_VALUE_5V = "Voltage is beyond maximum of 5V";
+    private static final String MINIMUM_VALUE_3V = "Voltage is beyond minimum of -3.3V";
+    private static final String MAXIMUM_VALUE_3V = "Voltage is beyond maximum of 3.3V";
     private LineChart outputChart;
     private float initialVoltage = 0;
     private float finalVoltage = 0;
@@ -86,33 +90,57 @@ public class TransistorCEOutputSetup extends Fragment {
                                 tilFinalVoltage = (TextInputLayout) customView.findViewById(R.id.text_input_layout_fv);
                                 tilTotalSteps = (TextInputLayout) customView.findViewById(R.id.text_input_layout_total_steps);
                                 tilBaseVoltage = (TextInputLayout) customView.findViewById(R.id.text_input_layout_voltage);
+                                // Initial Voltage
                                 if (TextUtils.isEmpty(etInitialVoltage.getText().toString())) {
                                     tilInitialVoltage.setError(ERROR_MESSAGE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) < -5.0f) {
+                                    tilInitialVoltage.setError(MINIMUM_VALUE_5V);
+                                    return;
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) > 5.0f) {
+                                    tilInitialVoltage.setError(MAXIMUM_VALUE_5V);
+                                    return;
+                                } else {
                                     tilInitialVoltage.setError(null);
+                                }
                                 initialVoltage = Float.parseFloat(etInitialVoltage.getText().toString());
+                                // Final Voltage
                                 if (TextUtils.isEmpty(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(ERROR_MESSAGE);
                                     return;
                                 } else if (initialVoltage >= Float.parseFloat(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(INVALID_VALUE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) < -5.0f) {
+                                    tilFinalVoltage.setError(MINIMUM_VALUE_5V);
+                                    return;
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) > 5.0f) {
+                                    tilFinalVoltage.setError(MAXIMUM_VALUE_5V);
+                                    return;
+                                } else {
                                     tilFinalVoltage.setError(null);
+                                }
+                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
+                                // Step Size
                                 if (TextUtils.isEmpty(etTotalSteps.getText().toString())) {
                                     tilTotalSteps.setError(ERROR_MESSAGE);
                                     return;
                                 } else
                                     tilTotalSteps.setError(null);
+                                totalSteps = Integer.parseInt(etTotalSteps.getText().toString());
+                                // Base Voltage
                                 if (TextUtils.isEmpty(etBaseVoltage.getText().toString())) {
                                     tilBaseVoltage.setError(ERROR_MESSAGE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etBaseVoltage.getText().toString()) < -3.3f) {
+                                    tilBaseVoltage.setError(MINIMUM_VALUE_3V);
+                                    return;
+                                } else if (Float.parseFloat(etBaseVoltage.getText().toString()) > 3.3f) {
+                                    tilBaseVoltage.setError(MAXIMUM_VALUE_3V);
+                                    return;
+                                } else {
                                     tilBaseVoltage.setError(null);
-
-                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
-                                totalSteps = Integer.parseInt(etTotalSteps.getText().toString());
+                                }
                                 baseVoltage = Float.parseFloat(etBaseVoltage.getText().toString());
                                 stepVoltage = (finalVoltage - initialVoltage) / totalSteps;
                                 if (scienceLab.isConnected())

--- a/app/src/main/java/org/fossasia/pslab/experimentsetup/ZenerSetupFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/experimentsetup/ZenerSetupFragment.java
@@ -41,6 +41,8 @@ public class ZenerSetupFragment extends Fragment {
 
     private static final String ERROR_MESSAGE = "Invalid Value";
     private static final String INVALID_VALUE = "Voltage value too low";
+    private static final String MINIMUM_VALUE = "Voltage is beyond minimum of -5V";
+    private static final String MAXIMUM_VALUE = "Voltage is beyond maximum of 5V";
     private LineChart outputChart;
     private float initialVoltage = 0;
     private float finalVoltage = 0;
@@ -82,27 +84,44 @@ public class ZenerSetupFragment extends Fragment {
                                 tilInitialVoltage = (TextInputLayout) customView.findViewById(R.id.text_input_layout_iv);
                                 tilFinalVoltage = (TextInputLayout) customView.findViewById(R.id.text_input_layout_fv);
                                 tilStepSize = (TextInputLayout) customView.findViewById(R.id.text_input_layout_ss);
+                                // Initial Voltage
                                 if (TextUtils.isEmpty(etInitialVoltage.getText().toString())) {
                                     tilInitialVoltage.setError(ERROR_MESSAGE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) < -5.0f) {
+                                    tilInitialVoltage.setError(MINIMUM_VALUE);
+                                    return;
+                                } else if (Float.parseFloat(etInitialVoltage.getText().toString()) > 5.0f) {
+                                    tilInitialVoltage.setError(MAXIMUM_VALUE);
+                                    return;
+                                } else {
                                     tilInitialVoltage.setError(null);
+                                }
                                 initialVoltage = Float.parseFloat(etInitialVoltage.getText().toString());
+                                // Final Voltage
                                 if (TextUtils.isEmpty(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(ERROR_MESSAGE);
                                     return;
                                 } else if (initialVoltage >= Float.parseFloat(etFinalVoltage.getText().toString())) {
                                     tilFinalVoltage.setError(INVALID_VALUE);
                                     return;
-                                } else
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) < -5.0f) {
+                                    tilFinalVoltage.setError(MINIMUM_VALUE);
+                                    return;
+                                } else if (Float.parseFloat(etFinalVoltage.getText().toString()) > 5.0f) {
+                                    tilFinalVoltage.setError(MAXIMUM_VALUE);
+                                    return;
+                                } else {
                                     tilFinalVoltage.setError(null);
+                                }
+                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
+                                // Step Size
                                 if (TextUtils.isEmpty(etStepSize.getText().toString())) {
                                     tilStepSize.setError(ERROR_MESSAGE);
                                     return;
-                                } else
+                                } else {
                                     tilStepSize.setError(null);
-
-                                finalVoltage = Float.parseFloat(etFinalVoltage.getText().toString());
+                                }
                                 stepVoltage = Float.parseFloat(etStepSize.getText().toString());
                                 new Handler().postDelayed(new Runnable() {
                                     @Override


### PR DESCRIPTION
Fixes issue #421 

Changes: 
- Added validation to voltage levels as follows;
  - PV1 [-5V ~ 5V]
  - PV2 [-3.3V ~ 3.3V]
  - PV3 [0 ~ 3.3V]

Screenshots for the change: 

| Minimum value | Maximum value |
| ------ | ------ |
| ![imgcheckmin](https://user-images.githubusercontent.com/14261304/28980995-65518c0a-7982-11e7-9e9d-857c1553388d.png) | ![imgcheckmax](https://user-images.githubusercontent.com/14261304/28981005-716f5c24-7982-11e7-87bc-ab25ce605607.png) |

APK for testing:
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/1201236/app-debug.apk.zip)
