### PR TITLE
Fixes #453 Fixed App crash on clicking Sensor Quick View

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/SensorActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SensorActivity.java
@@ -42,9 +42,6 @@ public class SensorActivity extends AppCompatActivity {
         timegapLabel = (TextView) findViewById(R.id.tv_timegap_label);
         playPauseButton = (ImageButton) findViewById(R.id.imageButton_play_pause_sensor);
         play = false;
-
-
-        sensorDock.setVisibility(View.INVISIBLE);
         playPauseButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -57,6 +54,7 @@ public class SensorActivity extends AppCompatActivity {
                 }
             }
         });
+        sensorDock.setVisibility(View.GONE);
 
         FragmentManager fragmentManager = getSupportFragmentManager();
         FragmentTransaction transaction = fragmentManager.beginTransaction();

--- a/app/src/main/res/layout/activity_sensor.xml
+++ b/app/src/main/res/layout/activity_sensor.xml
@@ -2,7 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:focusable="true"
     android:focusableInTouchMode="true"
     app:layout_behavior="@string/appbar_scrolling_view_behavior">
@@ -41,6 +41,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_marginLeft="5dp"
+            android:layout_marginStart="5dp"
             android:layout_toEndOf="@+id/imageButton_play_pause_sensor"
             android:layout_toLeftOf="@+id/tv_timegap_label"
             android:layout_toRightOf="@+id/imageButton_play_pause_sensor"

--- a/app/src/main/res/layout/sensor_main.xml
+++ b/app/src/main/res/layout/sensor_main.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layout_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:layout_marginEnd="10dp"
         android:layout_marginLeft="10dp"
         android:layout_marginRight="10dp"
@@ -39,10 +42,10 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@drawable/control_custom_border"
-                android:textSize="@dimen/sensor_body_font"
+                android:gravity="center"
                 android:textAlignment="center"
-                android:textStyle="bold"
-                android:gravity="center"/>
+                android:textSize="@dimen/sensor_body_font"
+                android:textStyle="bold" />
         </android.support.v4.widget.NestedScrollView>
 
         <TextView
@@ -59,8 +62,7 @@
         <ListView
             android:id="@+id/lv_sensor"
             android:layout_width="match_parent"
-            android:layout_height="200dp"
-            android:layout_marginBottom="10dp"
+            android:layout_height="match_parent"
             android:layout_marginTop="10dp" />
     </LinearLayout>
-</ScrollView>
+</android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes issue #453 

Changes:
- fixed App crash on clicking Sensor Quick View tile when device isn't connected
- Added appropriate message for user when device isn't connected and trying to scan sensors
- Optimised layout a bit

Screenshots for the change: 
![screenshot_2017-08-07-11-43-25-447_org fossasia pslab](https://user-images.githubusercontent.com/12713808/29014387-64a4ea46-7b66-11e7-9faa-179fc7d4c83d.png)
