### PR TITLE
Fixes #451 : Exported string resources in saved experiments

### DIFF
--- a/app/src/main/res/layout/diode_configure_dialog.xml
+++ b/app/src/main/res/layout/diode_configure_dialog.xml
@@ -24,7 +24,7 @@
                     android:id="@+id/et_initial_voltage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Initial Voltage (V)"
+                    android:hint="@string/initial_voltage_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -40,7 +40,7 @@
                     android:id="@+id/et_final_voltage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Final Voltage (V)"
+                    android:hint="@string/final_voltage_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -56,7 +56,7 @@
                     android:id="@+id/et_step_size"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Step Size (V)"
+                    android:hint="@string/step_size_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 

--- a/app/src/main/res/layout/nfet_output_characteristic_dialog.xml
+++ b/app/src/main/res/layout/nfet_output_characteristic_dialog.xml
@@ -13,7 +13,7 @@
             android:id="@+id/nfet_initial_voltage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Initial Voltage (V)"
+            android:hint="@string/initial_voltage_v"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1" />
 
@@ -28,7 +28,7 @@
             android:id="@+id/nfet_final_voltage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Final Voltage (V)"
+            android:hint="@string/final_voltage_v"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1" />
 
@@ -43,7 +43,7 @@
             android:id="@+id/nfet_step_size"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Step Size (V)"
+            android:hint="@string/step_size_v"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1" />
 
@@ -58,7 +58,7 @@
             android:id="@+id/nfet_gate_voltage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Gate Voltage (V)"
+            android:hint="@string/gate_voltage_v"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1" />
 

--- a/app/src/main/res/layout/ohms_law_setup.xml
+++ b/app/src/main/res/layout/ohms_law_setup.xml
@@ -66,7 +66,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_weight="4"
-                    android:text="Read" />
+                    android:text="@string/read" />
             </LinearLayout>
 
         </LinearLayout>

--- a/app/src/main/res/layout/transistor_cb_configure_dialog.xml
+++ b/app/src/main/res/layout/transistor_cb_configure_dialog.xml
@@ -17,7 +17,7 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Collector Sweep (PV1)"
+                android:text="@string/collector_sweep_pv1"
                 android:textSize="16sp" />
 
             <android.support.design.widget.TextInputLayout
@@ -31,7 +31,7 @@
                     android:id="@+id/et_initial_voltage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Initial Voltage (V)"
+                    android:hint="@string/initial_voltage_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -47,7 +47,7 @@
                     android:id="@+id/et_final_voltage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Final Voltage (V)"
+                    android:hint="@string/final_voltage_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -63,7 +63,7 @@
                     android:id="@+id/et_total_steps"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Total Steps"
+                    android:hint="@string/step_size_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -84,7 +84,7 @@
             android:id="@+id/et_emitter_voltage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Emitter Voltage (PV2)"
+            android:hint="@string/emitter_voltage_pv2"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1" />
 

--- a/app/src/main/res/layout/transistor_ce_output_configure_dialog.xml
+++ b/app/src/main/res/layout/transistor_ce_output_configure_dialog.xml
@@ -17,7 +17,7 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Collector Sweep (PV1)"
+                android:text="@string/collector_sweep_pv1"
                 android:textSize="16sp" />
 
             <android.support.design.widget.TextInputLayout
@@ -31,7 +31,7 @@
                     android:id="@+id/et_initial_voltage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Initial Voltage (V)"
+                    android:hint="@string/initial_voltage_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -47,7 +47,7 @@
                     android:id="@+id/et_final_voltage"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Final Voltage (V)"
+                    android:hint="@string/final_voltage_v"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -63,7 +63,7 @@
                     android:id="@+id/et_total_steps"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="Total Steps"
+                    android:hint="@string/total_steps"
                     android:inputType="numberSigned|numberDecimal"
                     android:maxLines="1" />
 
@@ -84,7 +84,7 @@
             android:id="@+id/et_base_voltage"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="Base Voltage (PV2)"
+            android:hint="@string/base_voltage_pv2"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,4 +348,12 @@
     <string name="lux2">(Lux)</string>
     <string name="acceleration">Acc.</string>
     <string name="acceleration_unit">(m/s²)</string>
+    <string name="initial_voltage_v">Initial Voltage (V)</string>
+    <string name="final_voltage_v">Final Voltage (V)</string>
+    <string name="step_size_v">Step Size (V)</string>
+    <string name="gate_voltage_v">Gate Voltage (V)</string>
+    <string name="collector_sweep_pv1">Collector Sweep (PV1)</string>
+    <string name="emitter_voltage_pv2">Emitter Voltage (PV2)</string>
+    <string name="total_steps">Total Steps</string>
+    <string name="base_voltage_pv2">Base Voltage (PV2)</string>
 </resources>


### PR DESCRIPTION
Fixes issue #451 

Changes: 
- Exported hardcoded string resources to `strings.xml` file

Screenshots for the change: 
> Not available