### PR TITLE
Fixes #471 Used Appetize API to update apk preview

### DIFF
--- a/upload-apk.sh
+++ b/upload-apk.sh
@@ -29,3 +29,8 @@ git branch -m apk
 
 #push to the branch apk
 git push origin apk --force --quiet> /dev/null
+
+if [ "$TRAVIS_PULL_REQUEST" == "false" ]
+then 
+curl https://$APPETIZE_API_TOKEN@api.appetize.io/v1/apps/4eqye6ea422e5np0gp2jfpemgm -H 'Content-Type: application/json' -d '{"url":"https://github.com/fossasia/pslab-android/blob/apk/app-debug.apk", "note": "PSLab Android App Update"}' 
+fi


### PR DESCRIPTION
Fixes issue #471 

Changes:
- Added API Token in travis settings and made an api call to update apk on Appetize.io

Reference : [Appetize docs](https://appetize.io/docs)