### PR TITLE
Fixes #490 created UI to view locally logged data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         </activity>
         <activity android:name=".activity.AboutUs" />
         <activity android:name=".activity.HelpAndFeedback" />
+        <activity android:name=".activity.ShowLoggedData"/>
         <activity
             android:name=".activity.PerformExperimentActivity"
             android:configChanges="orientation|screenSize|keyboardHidden" />

--- a/app/src/main/java/org/fossasia/pslab/activity/SensorDataLoggerActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SensorDataLoggerActivity.java
@@ -2,6 +2,7 @@ package org.fossasia.pslab.activity;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
 import android.os.AsyncTask;
@@ -18,6 +19,8 @@ import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
@@ -290,5 +293,24 @@ public class SensorDataLoggerActivity extends AppCompatActivity {
                 Toast.makeText(this, "Can't log data", Toast.LENGTH_SHORT).show();
             }
         }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.activity_sensor_data_logger, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case R.id.menu_logged_data:
+                Intent activityLoggedData = new Intent(this, ShowLoggedData.class);
+                startActivity(activityLoggedData);
+                break;
+            default:
+                //
+        }
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/ShowLoggedData.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/ShowLoggedData.java
@@ -1,0 +1,55 @@
+package org.fossasia.pslab.activity;
+
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.Menu;
+import android.view.MenuItem;
+
+import org.fossasia.pslab.R;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Created by viveksb007 on 12/8/17.
+ */
+
+public class ShowLoggedData extends AppCompatActivity {
+
+
+    @BindView(R.id.toolbar)
+    Toolbar toolbar;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_show_logged_data);
+        ButterKnife.bind(this);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setTitle(getResources().getString(R.string.sensor_logged_data));
+        }
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.activity_show_logged_data, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()){
+            case R.id.export_logged_data:
+                // Exporting locally logged data
+                break;
+            case android.R.id.home:
+                onBackPressed();
+                break;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/res/layout/activity_show_logged_data.xml
+++ b/app/src/main/res/layout/activity_show_logged_data.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <LinearLayout
+        android:id="@+id/layout_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <ListView
+            android:id="@+id/list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/menu/activity_sensor_data_logger.xml
+++ b/app/src/main/res/menu/activity_sensor_data_logger.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/menu_logged_data"
+        android:title="@string/view_logged_data" />
+
+</menu>

--- a/app/src/main/res/menu/activity_show_logged_data.xml
+++ b/app/src/main/res/menu/activity_show_logged_data.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/export_logged_data"
+        android:title="@string/export_logged_data" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -404,6 +404,9 @@
     <string name="stop_logging">Stop Logging</string>
     <string name="cancel">Cancel</string>
     <string name="save_data">Save Data</string>
+    <string name="view_logged_data">View Logged Data</string>
+    <string name="export_logged_data">Export Logged Data</string>
+    <string name="sensor_logged_data">Sensor Logged Data</string>
 
 
 </resources>


### PR DESCRIPTION
Fixes issue #490 

Changes:
- Added menu to View Logged Data which directs to ShowLoggedData Activity.
- In ShowLoggedData Activity there is ListView to show logged data and a menu Item to export Logged Data.

Would open other issues for below tasks.
There should be two more layers between DataLoggerActivity and ShowLoggedData Activity:
1. To Select which sensors logged data user wants to see.
2. Which trial of that sensors logged data user wants to see. ( In case when user logged same sensor's data at different times ).  