### PR TITLE
Fixes #535 generated different apk for master branch

### DIFF
--- a/upload-apk.sh
+++ b/upload-apk.sh
@@ -3,6 +3,7 @@
 mkdir $HOME/buildApk/ 
 #copy generated apk from build folder and README.md to the folder just created
 cp -R app/build/outputs/apk/app-debug.apk $HOME/buildApk/
+mv $HOME/buildApk/app-debug.apk $HOME/buildApk/app-release.apk 
 cp -R README.md $HOME/buildApk/
 
 #setup git


### PR DESCRIPTION
Fixes issue #535 

Changes: 
- renamed apk from master branch to apk-release.apk

This should create `apk-release.apk` when there is commit on master branch and `app-debug.apk` when there is commit on development branch.