### PR TITLE
Fixes #545 Added data format option in app settings

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
@@ -1,6 +1,8 @@
 package org.fossasia.pslab.fragment;
 
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 
 import org.fossasia.pslab.R;
@@ -9,11 +11,13 @@ import org.fossasia.pslab.R;
  * Created by viveksb007 on 15/3/17.
  */
 
-public class SettingsFragment extends PreferenceFragmentCompat {
+public class SettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
+
+    public static final String KEY_EXPORT_DATA_FORMAT_LIST = "export_data_format_list";
+    private ListPreference listPreference;
 
     public static SettingsFragment newInstance() {
-        SettingsFragment settingsFragment = new SettingsFragment();
-        return settingsFragment;
+        return new SettingsFragment();
     }
 
 
@@ -24,6 +28,26 @@ public class SettingsFragment extends PreferenceFragmentCompat {
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.settings_preference_fragment, rootKey);
+        listPreference = (ListPreference) getPreferenceScreen().findPreference(KEY_EXPORT_DATA_FORMAT_LIST);
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        listPreference.setSummary("Current format is " + listPreference.getEntry().toString());
+        getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+    }
+
+    @Override
+    public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+        if (KEY_EXPORT_DATA_FORMAT_LIST.equals(key)) {
+            listPreference.setSummary("Current format is " + listPreference.getEntry().toString());
+        }
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -443,4 +443,13 @@
         <item>Share Data</item>
     </string-array>
 
+    <string-array name="export_data_format_list">
+        <item>TXT Format</item>
+        <item>CSV Format</item>
+    </string-array>
+    <string-array name="export_data_format_values">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+
 </resources>

--- a/app/src/main/res/xml/settings_preference_fragment.xml
+++ b/app/src/main/res/xml/settings_preference_fragment.xml
@@ -1,9 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="App Settings">
-    <CheckBoxPreference
-        android:key="setting_auto_start"
-        android:summary="Auto start app when PSLab device is connected"
-        android:title="Auto Start" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="setting_auto_start"
+            android:summary="Auto start app when PSLab device is connected"
+            android:title="Auto Start" />
     </PreferenceCategory>
+
+    <ListPreference
+        android:defaultValue="0"
+        android:entries="@array/export_data_format_list"
+        android:entryValues="@array/export_data_format_values"
+        android:key="export_data_format_list"
+        android:title="Export Data Format" />
+
 </PreferenceScreen>


### PR DESCRIPTION
Fixes issue #545 

Changes: 
- Added preference for exporting sensor data `.txt` or `.csv`.
- Based on this preference data would be exported in Data Sensor Logger Activity.

Screenshots for the change: 
<table>
    <tr>
     <td><img src="https://user-images.githubusercontent.com/12713808/29485387-a695ad46-84ee-11e7-8edb-59066e55992d.png"></td>
     <td><img src="https://user-images.githubusercontent.com/12713808/29485388-a6968e14-84ee-11e7-8f51-3eb7efd6ca9b.png"></td>
    </tr>
  </table>
