### PR TITLE
added command for UI check in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ jdk:
 env:
   global:
     - ANDROID_API_LEVEL=25
+    - ANDROID_API_LEVEL_22=22
     - ANDROID_BUILD_TOOLS_VERSION=25.0.2
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
@@ -13,13 +14,15 @@ env:
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:
+  update_sdk: true 
   components:
     - tools
     - platform-tools
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
     - android-$ANDROID_API_LEVEL
+    - android-$ANDROID_API_LEVEL_22
     # For Google APIs
-    - addon-google_apis-google-$ANDROID_API_LEVEL
+    - addon-$ANDROID_TAG-google-$ANDROID_API_LEVEL
     # Google Play Services
     - extra-google-google_play_services
     # Support library
@@ -29,7 +32,7 @@ android:
     - extra-android-m2repository
 
     # Specify at least one system image
-    - sys-img-armeabi-v7a-$ANDROID_TARGET
+    - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL_22
     
     
 licenses:
@@ -55,10 +58,14 @@ before_install:
  - echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$ANDROID_HOME/licenses/android-sdk-preview-license"
 
 before_script:
-
+  - android list targets
+  - echo no | android create avd --force --name test --target android-22 --abi $ANDROID_ABI
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
 
 script:
- - ./gradlew build
+ - ./gradlew build connectedAndroidTest --stacktrace
 
 after_success:
   - chmod +x upload-apk.sh

--- a/app/src/androidTest/java/org/fossasia/pslab/MainActivityTest.java
+++ b/app/src/androidTest/java/org/fossasia/pslab/MainActivityTest.java
@@ -48,7 +48,6 @@ public class MainActivityTest {
         onView(withText("Control")).check(matches(isDisplayed()));
         onView(withText("Logical Analyzer")).check(matches(isDisplayed()));
         onView(withText("Data Sensor Logger")).check(matches(isDisplayed()));
-        onView(withText("Wireless Sensor")).check(matches(isDisplayed()));
         onView(withText("Sensor QuickView")).check(matches(isDisplayed()));
 
 


### PR DESCRIPTION
Fixes issue #591 

Changes:
- Added command to enable UI test during travis build
- Modified MainActivity test

P.S: emulator with API 25 had some no abi issue, so used api level 22 emulator for UI tests on app.