### PR TITLE
Fixed #611 modified fetch routines to prevent adding ack bytes as a data point

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
@@ -605,7 +605,7 @@ public class ScienceLab {
                 mPacketHandler.sendInt(i * this.dataSplitting);
                 byte[] data = new byte[this.dataSplitting * 2 + 1];
                 mPacketHandler.read(data, this.dataSplitting * 2 + 1);
-                for (int j = 0; j < data.length; j++)
+                for (int j = 0; j < data.length - 1; j++)
                     listData.add((int) data[j] & 0xff);
                 //mPacketHandler.getAcknowledgement();
             }
@@ -618,7 +618,7 @@ public class ScienceLab {
                 mPacketHandler.sendInt(totalSamples - totalSamples % this.dataSplitting);
                 byte[] data = new byte[2 * (totalSamples % this.dataSplitting) + 1];
                 mPacketHandler.read(data, 2 * (totalSamples % this.dataSplitting) + 1);
-                for (int j = 0; j < data.length; j++)
+                for (int j = 0; j < data.length - 1; j++)
                     listData.add((int) data[j] & 0xff);
                 //mPacketHandler.getAcknowledgement();
             }
@@ -761,7 +761,7 @@ public class ScienceLab {
                 mPacketHandler.sendInt(i * this.dataSplitting);
                 byte[] data = new byte[this.dataSplitting * 2 + 1];
                 mPacketHandler.read(data, this.dataSplitting * 2 + 1);
-                for (int j = 0; j < data.length; j++)
+                for (int j = 0; j < data.length - 1; j++)
                     listData.add((int) data[j] & 0xff);
                 //mPacketHandler.getAcknowledgement();
             }
@@ -774,7 +774,7 @@ public class ScienceLab {
                 mPacketHandler.sendInt(samples - samples % this.dataSplitting);
                 byte[] data = new byte[2 * (samples % this.dataSplitting)];
                 mPacketHandler.read(data, 2 * (samples % this.dataSplitting));
-                for (int j = 0; j < data.length; j++)
+                for (int j = 0; j < data.length - 1; j++)
                     listData.add((int) data[j] & 0xff);
                 //mPacketHandler.getAcknowledgement();
             }
@@ -917,7 +917,7 @@ public class ScienceLab {
                 mPacketHandler.sendInt(i * this.dataSplitting);
                 byte[] data = new byte[this.dataSplitting * 2 + 1];
                 mPacketHandler.read(data, this.dataSplitting * 2 + 1);
-                for (int j = 0; j < data.length; j++)
+                for (int j = 0; j < data.length - 1; j++)
                     listData.add((int) data[j] & 0xff);
                 //mPacketHandler.getAcknowledgement();
             }
@@ -930,7 +930,7 @@ public class ScienceLab {
                 mPacketHandler.sendInt(samples - samples % this.dataSplitting);
                 byte[] data = new byte[2 * (samples % this.dataSplitting) + 1];
                 mPacketHandler.read(data, 2 * (samples % this.dataSplitting) + 1);
-                for (int j = 0; j < data.length; j++)
+                for (int j = 0; j < data.length - 1; j++)
                     listData.add((int) data[j] & 0xff);
                 //mPacketHandler.getAcknowledgement();
             }


### PR DESCRIPTION
Fixes issue #611 

Changes:
- modified fetch routines to prevent adding **ack** bytes as a data point. 

Distortion is fixed now.

Apk for testing 
[app-debug.apk.tar.gz](https://github.com/fossasia/pslab-android/files/1272381/app-debug.apk.tar.gz)


Screenshots for the change: 
![screenshot_2017-09-02-23-01-49-972_org fossasia pslab](https://user-images.githubusercontent.com/12713808/29997625-61c9b494-9035-11e7-8558-3863da8d9a12.png)
![screenshot_2017-09-02-23-02-55-651_org fossasia pslab](https://user-images.githubusercontent.com/12713808/29997626-61c9d67c-9035-11e7-81ec-24da74521d0c.png)

