### PR TITLE
Fix #639 app closes properly on backpress

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/SplashActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SplashActivity.java
@@ -17,13 +17,15 @@ import butterknife.ButterKnife;
 public class SplashActivity extends AppCompatActivity {
 
     private static int SPLASH_TIME_OUT = 2000;
-
+    private Handler handler;
+    private Runnable runnable;
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.splash_screen);
         ButterKnife.bind(this);
-        new Handler().postDelayed(new Runnable() {
+        handler = new Handler();
+        handler.postDelayed(runnable=new Runnable() {
             @Override
             public void run() {
                 Intent intent = new Intent(SplashActivity.this, MainActivity.class);
@@ -31,5 +33,10 @@ public class SplashActivity extends AppCompatActivity {
                 finish();
             }
         }, SPLASH_TIME_OUT);
+    }
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        handler.removeCallbacks(runnable);
     }
 }


### PR DESCRIPTION
Fixes issue #639 

Changes: app closes now on backpress

Screenshots for the change: 
![ezgif com-video-to-gif 5](https://user-images.githubusercontent.com/20878145/30926159-e30c3e0a-a3d1-11e7-81d1-600e5570990f.gif)
