### PR TITLE
fix: hide status bar in splash screen

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/SplashActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SplashActivity.java
@@ -5,6 +5,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
+import android.view.Window;
+import android.view.WindowManager;
 
 import org.fossasia.pslab.R;
 
@@ -21,6 +23,8 @@ public class SplashActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.splash_screen);
         ButterKnife.bind(this);
         new Handler().postDelayed(new Runnable() {


### PR DESCRIPTION
fixes #643

Changes: 
Removed status bar in splash screen.

Screenshots for the change: 

<img src=https://user-images.githubusercontent.com/21264401/30983065-eff61322-a4a6-11e7-8864-82c6ac260ca1.jpeg width="300" height="500">

