### PR TITLE
Fixes #679 Removed redundant play button from the experiments screen

### DIFF
--- a/app/src/main/res/layout/activity_perform_experiment.xml
+++ b/app/src/main/res/layout/activity_perform_experiment.xml
@@ -39,16 +39,6 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:background="@color/colorAccent"
-        android:src="@drawable/ic_play_arrow_black_24dp"
-        app:layout_anchor="@id/app_bar"
-        app:layout_anchorGravity="bottom|right|end" />
-
     <android.support.v4.widget.NestedScrollView
         android:id="@+id/nestedScrollView"
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes issue #679 

Changes: Removed the redundant play button from the experiments screen by deleting it from the layout file.

Screenshots for the change: 
![](https://user-images.githubusercontent.com/21277837/33700585-1fdcabc6-db40-11e7-8acb-a16ae5ed2335.png)
