### PR TITLE
 Fixes #684 Enhancement of layouts for Tablet view

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -10,6 +10,7 @@ import android.hardware.usb.UsbManager;
 import android.net.Uri;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -50,7 +51,7 @@ public class MainActivity extends AppCompatActivity {
 
     @BindView(R.id.nav_view)
     NavigationView navigationView;
-    @BindView(R.id.drawer_layout)
+    @Nullable @BindView(R.id.drawer_layout)
     DrawerLayout drawer;
     @BindView(R.id.toolbar)
     Toolbar toolbar;
@@ -140,7 +141,7 @@ public class MainActivity extends AppCompatActivity {
     private void loadHomeFragment() {
         selectNavMenu();
         setToolbarTitle();
-        if (getSupportFragmentManager().findFragmentByTag(CURRENT_TAG) != null) {
+        if (drawer != null && getSupportFragmentManager().findFragmentByTag(CURRENT_TAG) != null) {
             drawer.closeDrawers();
             return;
         }
@@ -163,8 +164,10 @@ public class MainActivity extends AppCompatActivity {
         if (mPendingRunnable != null) {
             mHandler.post(mPendingRunnable);
         }
-        drawer.closeDrawers();
-        invalidateOptionsMenu();
+        if(drawer != null) {
+            drawer.closeDrawers();
+            invalidateOptionsMenu();
+        }
     }
 
     private Fragment getHomeFragment() throws IOException {
@@ -217,15 +220,21 @@ public class MainActivity extends AppCompatActivity {
                         break;
                     case R.id.nav_about_us:
                         startActivity(new Intent(MainActivity.this, AboutUs.class));
-                        drawer.closeDrawers();
+                        if (drawer != null) {
+                            drawer.closeDrawers();
+                        }
                         break;
                     case R.id.nav_help_feedback:
                         startActivity(new Intent(MainActivity.this, HelpAndFeedback.class));
-                        drawer.closeDrawers();
+                        if (drawer != null) {
+                            drawer.closeDrawers();
+                        }
                         break;
                     case R.id.nav_report_us:
                         customTabService.launchUrl("https://github.com/fossasia/pslab-android/issues");
-                        drawer.closeDrawers();
+                        if (drawer != null) {
+                            drawer.closeDrawers();
+                        }
                         break;
                     default:
                         navItemIndex = 0;
@@ -236,19 +245,21 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-        ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(this, drawer, toolbar, org.fossasia.pslab.R.string.openDrawer, org.fossasia.pslab.R.string.closeDrawer) {
-            @Override
-            public void onDrawerClosed(View drawerView) {
-                super.onDrawerClosed(drawerView);
-            }
+        if (drawer != null) {
+            ActionBarDrawerToggle actionBarDrawerToggle = new ActionBarDrawerToggle(this, drawer, toolbar, org.fossasia.pslab.R.string.openDrawer, org.fossasia.pslab.R.string.closeDrawer) {
+                @Override
+                public void onDrawerClosed(View drawerView) {
+                    super.onDrawerClosed(drawerView);
+                }
 
-            @Override
-            public void onDrawerOpened(View drawerView) {
-                super.onDrawerOpened(drawerView);
-            }
-        };
-        drawer.setDrawerListener(actionBarDrawerToggle);
-        actionBarDrawerToggle.syncState();
+                @Override
+                public void onDrawerOpened(View drawerView) {
+                    super.onDrawerOpened(drawerView);
+                }
+            };
+            drawer.setDrawerListener(actionBarDrawerToggle);
+            actionBarDrawerToggle.syncState();
+        }
     }
 
     private void loadNavHeader() {
@@ -258,7 +269,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onBackPressed() {
         Fragment fragment = getSupportFragmentManager().findFragmentById(R.id.frame);
-        if (drawer.isDrawerOpen(GravityCompat.START)) {
+        if (drawer != null && drawer.isDrawerOpen(GravityCompat.START)) {
             drawer.closeDrawers();
             return;
         }

--- a/app/src/main/res/layout-sw600dp/activity_main.xml
+++ b/app/src/main/res/layout-sw600dp/activity_main.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
+        android:orientation="horizontal">
+
+
+        <android.support.design.widget.NavigationView
+            android:id="@+id/nav_view"
+            android:layout_width="@dimen/navigation_drawer_width"
+            android:layout_height="match_parent"
+            android:layout_gravity="start"
+            android:fitsSystemWindows="true"
+            app:headerLayout="@layout/nav_header_main"
+            app:menu="@menu/activity_main_drawer" />
+
+        <include
+            layout="@layout/app_bar_main"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </LinearLayout>
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -41,5 +41,6 @@
     <dimen name="reading_box_height">40dp</dimen>
     <dimen name="card_elevation">2dp</dimen>
     <dimen name="card_title_margin">16dp</dimen>
+    <dimen name="navigation_drawer_width">300dp</dimen>
 
 </resources>


### PR DESCRIPTION
Fixes issue #684 

Changes: Redefined activity_main.xml such that the Navigation Drawer always remains open when viewed on devices with screen widths greater than 600

Screenshots for the change: 

![screenshot_1514218729](https://user-images.githubusercontent.com/26908195/34341801-4a2e2ea2-e9c5-11e7-8e08-20443feb9e6d.png)

![screenshot_1514218746](https://user-images.githubusercontent.com/26908195/34341802-4a83828a-e9c5-11e7-88e4-73785b0b2157.png)

![screenshot_1514218752](https://user-images.githubusercontent.com/26908195/34341804-4bca130c-e9c5-11e7-95ea-02d71c52e279.png)

