### PR TITLE
Fixes #692 Inclusion of warning dialogs

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/ControlActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/ControlActivity.java
@@ -1,11 +1,13 @@
 package org.fossasia.pslab.activity;
 
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomNavigationView;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 
@@ -53,5 +55,21 @@ public class ControlActivity extends AppCompatActivity {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
         transaction.replace(R.id.frame_layout_control, ControlFragmentMain.newInstance());
         transaction.commit();
+    }
+
+    @Override
+    public void onBackPressed() {
+        new AlertDialog.Builder(this)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle(R.string.closing_control_title)
+                .setMessage(R.string.closing_control_message)
+                .setPositiveButton(R.string.dialog_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish();
+                    }
+                })
+                .setNegativeButton(R.string.dialog_no, null)
+                .show();
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/LogicalAnalyzerActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/LogicalAnalyzerActivity.java
@@ -1,5 +1,7 @@
 package org.fossasia.pslab.activity;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentTransaction;
@@ -58,4 +60,19 @@ public class LogicalAnalyzerActivity extends AppCompatActivity
         return super.onOptionsItemSelected(item);
     }
 
+    @Override
+    public void onBackPressed() {
+        new AlertDialog.Builder(this)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle(R.string.closing_logical_analyzer_title)
+                .setMessage(R.string.closing_logical_analyzer_message)
+                .setPositiveButton(R.string.dialog_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish();
+                    }
+                })
+                .setNegativeButton(R.string.dialog_no, null)
+                .show();
+    }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -592,16 +592,16 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
     public void onBackPressed() {
         new AlertDialog.Builder(this)
                 .setIcon(android.R.drawable.ic_dialog_alert)
-                .setTitle("Closing Oscilloscope")
-                .setMessage("Are you sure you want to close the Oscilloscope?")
-                .setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+                .setTitle(R.string.closing_oscilloscope_title)
+                .setMessage(R.string.closing_oscilloscope_message)
+                .setPositiveButton(R.string.dialog_yes, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         finish();
                     }
 
                 })
-                .setNegativeButton("No", null)
+                .setNegativeButton(R.string.dialog_no, null)
                 .show();
     }
 

--- a/app/src/main/java/org/fossasia/pslab/activity/SensorActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SensorActivity.java
@@ -1,5 +1,7 @@
 package org.fossasia.pslab.activity;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
@@ -124,5 +126,21 @@ public class SensorActivity extends AppCompatActivity {
         } else {
             return false;
         }
+    }
+
+    @Override
+    public void onBackPressed() {
+        new AlertDialog.Builder(this)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle(R.string.closing_sensor_title)
+                .setMessage(R.string.closing_sensor_message)
+                .setPositiveButton(R.string.dialog_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish();
+                    }
+                })
+                .setNegativeButton(R.string.dialog_no, null)
+                .show();
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/SensorDataLoggerActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SensorDataLoggerActivity.java
@@ -1,7 +1,9 @@
 package org.fossasia.pslab.activity;
 
 import android.Manifest;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Color;
@@ -329,5 +331,21 @@ public class SensorDataLoggerActivity extends AppCompatActivity {
                 //
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void onBackPressed() {
+        new AlertDialog.Builder(this)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle(R.string.closing_sensor_data_logger_title)
+                .setMessage(R.string.closing_sensor_data_logger_message)
+                .setPositiveButton(R.string.dialog_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish();
+                    }
+                })
+                .setNegativeButton(R.string.dialog_no, null)
+                .show();
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/WavegenActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/WavegenActivity.java
@@ -1,5 +1,7 @@
 package org.fossasia.pslab.activity;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
@@ -18,4 +20,19 @@ public class WavegenActivity extends AppCompatActivity {
         setContentView(R.layout.activity_wave_gen);
     }
 
+    @Override
+    public void onBackPressed() {
+        new AlertDialog.Builder(this)
+                .setIcon(android.R.drawable.ic_dialog_alert)
+                .setTitle(R.string.closing_wave_generator_title)
+                .setMessage(R.string.closing_wave_generator_message)
+                .setPositiveButton(R.string.dialog_yes, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        finish();
+                    }
+                })
+                .setNegativeButton(R.string.dialog_no, null)
+                .show();
+    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -533,4 +533,19 @@
     <string name="plot_object_temperature">Plot - Object Temperature</string>
     <string name="plot_ambient_temperature">Plot - Ambient Temperature</string>
 
+    <string name="dialog_yes">Yes</string>
+    <string name="dialog_no">No</string>
+    <string name="closing_control_title">Closing Control</string>
+    <string name="closing_control_message">Are you sure you want to close the Control?</string>
+    <string name="closing_sensor_title">Closing Sensor QuickView</string>
+    <string name="closing_sensor_message">Are you sure you want to close the Sensor QuickView?</string>
+    <string name="closing_logical_analyzer_title">Closing Logical Analyzer</string>
+    <string name="closing_logical_analyzer_message">Are you sure you want to close the Logical Analyzer?</string>
+    <string name="closing_sensor_data_logger_title">Closing Sensor Data Logger</string>
+    <string name="closing_sensor_data_logger_message">Are you sure you want to close the Sensor Data Logger?</string>
+    <string name="closing_wave_generator_title">Closing Wave Generator</string>
+    <string name="closing_wave_generator_message">Are you sure you want to close the Wave Generator?</string>
+    <string name="closing_oscilloscope_title">Closing Oscilloscope</string>
+    <string name="closing_oscilloscope_message">Are you sure you want to close the Oscilloscope?</string>
+
 </resources>


### PR DESCRIPTION
Fixes issue #692

Changes:  Included warning dialog when the back button is pressed for Applications

Screenshots for the change: 

![screenshot_2018-01-09-22-14-34-969_org fossasia pslab](https://user-images.githubusercontent.com/26908195/34732394-28ece612-f58b-11e7-8747-549b79393199.png)
![screenshot_2018-01-09-22-13-47-493_org fossasia pslab](https://user-images.githubusercontent.com/26908195/34732397-29c22412-f58b-11e7-9cc0-7402f83ff93e.png)
![screenshot_2018-01-09-22-14-25-273_org fossasia pslab](https://user-images.githubusercontent.com/26908195/34732401-2c77e52a-f58b-11e7-8f44-954164da6ec3.png)
![screenshot_2018-01-09-22-14-01-491_org fossasia pslab](https://user-images.githubusercontent.com/26908195/34732403-2d711c80-f58b-11e7-8513-e258fbae2df8.png)
![screenshot_2018-01-09-22-14-45-005_org fossasia pslab](https://user-images.githubusercontent.com/26908195/34732404-2f041994-f58b-11e7-924b-fa95035c96c2.png)

APK FILE
[app-debug.zip](https://github.com/fossasia/pslab-android/files/1615921/app-debug.zip)


