### PR TITLE
Fix #694 cursor is positioned at the end of editText

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/others/EditTextWidget.java
+++ b/app/src/main/java/org/fossasia/pslab/others/EditTextWidget.java
@@ -75,8 +75,10 @@ public class EditTextWidget extends LinearLayout{
                     data = data > maxima ? maxima : data;
                     data = data < minima ? minima : data;
                     editText.setText(String.valueOf(data));
+                    editText.setSelection(String.valueOf(data).length());
                 } catch (Exception e) {
                     editText.setText("0");
+                    editText.setSelection(1);
                 }
             }
         });
@@ -90,8 +92,10 @@ public class EditTextWidget extends LinearLayout{
                     data = data > maxima ? maxima : data;
                     data = data < minima ? minima : data;
                     editText.setText(String.valueOf(data));
+                    editText.setSelection(String.valueOf(data).length());
                 } catch (Exception e) {
                     editText.setText("0");
+                    editText.setSelection(1);
                 }
             }
         });
@@ -122,5 +126,6 @@ public class EditTextWidget extends LinearLayout{
 
     public void setText(String text) {
         editText.setText(text);
+        editText.setSelection(text.length());
     }
 }


### PR DESCRIPTION
Fixes issue #694 

Changes:Cursor is positioned at the end of editText

Screenshots for the change: 
![ezgif com-video-to-gif 30](https://user-images.githubusercontent.com/20878145/34879310-cfc9fbe8-f7d2-11e7-94a3-375b484d58b4.gif)
