### PR TITLE
Fix #696 removed unnecessary refresh in ControlActivity

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/ControlActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/ControlActivity.java
@@ -34,20 +34,27 @@ public class ControlActivity extends AppCompatActivity {
                     @Override
                     public boolean onNavigationItemSelected(@NonNull MenuItem item) {
                         Fragment selectedFragment = null;
+                        Fragment fragment=getSupportFragmentManager().findFragmentById(R.id.frame_layout_control);
+
                         switch (item.getItemId()) {
                             case R.id.action_item1:
-                                selectedFragment = ControlFragmentMain.newInstance();
+                                if (!(fragment instanceof ControlFragmentMain))
+                                    selectedFragment = ControlFragmentMain.newInstance();
                                 break;
                             case R.id.action_item2:
-                                selectedFragment = ControlFragmentRead.newInstance();
+                                if (!(fragment instanceof ControlFragmentRead))
+                                    selectedFragment = ControlFragmentRead.newInstance();
                                 break;
                             case R.id.action_item3:
-                                selectedFragment = ControlFragmentAdvanced.newInstance();
+                                if (!(fragment instanceof ControlFragmentAdvanced))
+                                    selectedFragment = ControlFragmentAdvanced.newInstance();
                                 break;
                         }
-                        FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-                        transaction.replace(R.id.frame_layout_control, selectedFragment);
-                        transaction.commit();
+                        if (selectedFragment != null) {
+                            FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
+                            transaction.replace(R.id.frame_layout_control, selectedFragment);
+                            transaction.commit();
+                        }
                         return true;
                     }
                 });


### PR DESCRIPTION
Fixes issue #696 

Changes:  removed unnecessary refresh in ControlActivity

Screenshots for the change: 
![ezgif com-video-to-gif 32](https://user-images.githubusercontent.com/20878145/34920344-4b720e5a-f997-11e7-8341-11555974c6c4.gif)
