### PR TITLE
fix #700 dialogs get cancelled on backPress

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/ControlFragmentAdvanced.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/ControlFragmentAdvanced.java
@@ -416,7 +416,6 @@ public class ControlFragmentAdvanced extends Fragment {
         userInput.setText(et.getText().toString());
 
         alertDialogBuilder
-                .setCancelable(false)
                 .setPositiveButton("OK",
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int id) {


### PR DESCRIPTION
Fixes issue #700 

Changes: dialogs get cancelled on backPress in controlFragmentAdvanced

Screenshots for the change: 
![ezgif com-video-to-gif 33](https://user-images.githubusercontent.com/20878145/35298761-2ff49468-00a9-11e8-9c33-30dae1890f0e.gif)
