### PR TITLE
fix #702 add PSLab links in about us

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/AboutUs.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/AboutUs.java
@@ -38,9 +38,9 @@ public class AboutUs extends AppCompatActivity {
                 .addGroup("Connect with us")
                 .addEmail("pslab-fossasia@googlegroups.com")
                 .addWebsite("http://pslab.fossasia.org/")
-                .addGitHub("fossasia")
-                .addFacebook("fossasia")
-                .addTwitter("fossasia")
+                .addGitHub("fossasia?utf8=✓&q=pslab")
+                .addFacebook("pslabapp")
+                .addTwitter("pslabapp")
                 .addYoutube("UCQprMsG-raCIMlBudm20iLQ")
                 .create();
 


### PR DESCRIPTION
Fixes issue #702 

Changes: added PSLab links in about us

Screenshots for the change: 
![screenshot_20180124-230327](https://user-images.githubusercontent.com/20878145/35347579-8e1ed8a2-015b-11e8-8454-36645d57d215.png)
![screenshot_20180124-230432](https://user-images.githubusercontent.com/20878145/35347583-8f780872-015b-11e8-8193-c0ce3283644e.png)
![screenshot_20180124-230517](https://user-images.githubusercontent.com/20878145/35347586-90f73a38-015b-11e8-85d1-9177743923ba.png)
