### PR TITLE
Fixes Issue #727 : Inverting Op-Amp and Non Inverting Op-Amp not showing up

### DIFF
--- a/app/src/main/assets/DOC_HTML/apps/L_Inverting1.md
+++ b/app/src/main/assets/DOC_HTML/apps/L_Inverting1.md
@@ -1,0 +1,20 @@
+Inverting Op-Amp
+---
+
+### Study an inverting Op-Amp
+
+* Inverting amplifier is one in which the output is exactly 180 degree out of phase with respect to input. Output is an inverted amplified version of input.
+
+* Assuming the OpAmp is ideal and applying the concept of virtual short at the input terminals of OpAmp, the voltage at the inverting terminal is equal to the non inverting terminal.
+
+* Make the Connections as shown in the figure.
+
+* CH1 monitors the original waveform output from W1.
+
+* CH2 monitors the rectified waveform .
+
+* Observe various gains by changing Rf/Ri Ratio.
+
+* If gain is greater than 2x , reduce the input waveform amplitude by turning the amplitude knob next to W1 so that the output voltage does not exceed limits.
+
+* Enter Resistance values in the following boxes and click to calculate the theoretical gain.

--- a/app/src/main/assets/DOC_HTML/apps/L_NonInverting1.md
+++ b/app/src/main/assets/DOC_HTML/apps/L_NonInverting1.md
@@ -1,0 +1,20 @@
+NonInverting Op-Amp
+---
+
+### Study Op-Amps : Non-Inverting configuration
+
+* Non Inverting amplifier is one in which the output is in phase with respect to input. Output is an Non Inverted amplified version of input.
+
+* Assuming the opamp is ideal and applying the concept of virtual short, the voltage at the inverting terminal is equal to non inverting terminal.
+
+* Make the Connections as shown in the figure.
+
+* CH1 monitors the original waveform output from W1.
+
+* CH2 monitors the amplifier output. 
+
+* Observe various gains by changing Rf/Ri Ratio.
+
+* If gain is greater than 2x , reduce the input waveform amplitude by turning the amplitude knob next to W1 so that the output voltage does not exceed limits.
+
+* Enter Resistance values in the following boxes and click to calculate the theoretical gain.

--- a/app/src/main/java/org/fossasia/pslab/adapters/PerformExperimentAdapter.java
+++ b/app/src/main/java/org/fossasia/pslab/adapters/PerformExperimentAdapter.java
@@ -127,9 +127,9 @@ public class PerformExperimentAdapter extends FragmentPagerAdapter {
                     case "Diode Clamping":
                         return ExperimentDocMdFragment.newInstance("L_DiodeClamping.md");
                     case "Inverting Op-Amp":
-                        return ExperimentDocFragment.newInstance("L_Inverting.html");
+                        return ExperimentDocMdFragment.newInstance("L_Inverting1.md");
                     case "Non Inverting Op-Amp":
-                        return ExperimentDocFragment.newInstance("L_NonInverting.html");
+                        return ExperimentDocMdFragment.newInstance("L_NonInverting1.md");
                     case "Precision Rectifier":
                         return ExperimentDocMdFragment.newInstance("Precision_Rectifier.md");
                     case "Capacitor Discharge":


### PR DESCRIPTION
Fixes issue #727 

Changes: The PeformExperimentAdapter had two cases which returned wrong instances. Two markdown files are created for the same which were missing.

Screenshots for the change: 
![Uploading Screenshot_2018-03-07-22-39-15-388_org.fossasia.pslab.png…]()
![Uploading Screenshot_2018-03-07-22-39-21-270_org.fossasia.pslab.png…]()
