### PR TITLE
Fixes #730: Add APK requirement to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -3,3 +3,5 @@ Fixes issue #[Add issue number here. Note: This will automatically close the iss
 Changes: [Add here what changes were made in this issue and if possible provide links.]
 
 Screenshots for the change: 
+
+APK for testing: [Compress the *.apk file into a rar or zip file and upload it here]


### PR DESCRIPTION
Fixes issue #730 

Changes: 
- Added a section to upload APK file along with the PR

Screenshots for the change: 
> Not available
