### PR TITLE
Setting option added on appbar

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -21,6 +21,8 @@ import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
@@ -138,6 +140,32 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.activity_main_setting, menu);
+        MenuItem item = menu.findItem(R.id.action_settings);
+        if(navItemIndex==4)
+            item.setVisible(false);
+        else
+            item.setVisible(true);
+        return true;
+    }
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            // action with ID action_settings was selected
+            case R.id.action_settings:
+                navItemIndex = 4;
+                CURRENT_TAG = TAG_SETTINGS;
+                loadHomeFragment();
+                break;
+            default:
+                break;
+        }
+        return true;
+    }
+
     private void loadHomeFragment() {
         selectNavMenu();
         setToolbarTitle();
@@ -214,10 +242,10 @@ public class MainActivity extends AppCompatActivity {
                         navItemIndex = 3;
                         CURRENT_TAG = TAG_DESIGN_EXPERIMENTS;
                         break;
-                    case R.id.nav_settings:
+                   /* case R.id.nav_settings:
                         navItemIndex = 4;
                         CURRENT_TAG = TAG_SETTINGS;
-                        break;
+                        break;*/
                     case R.id.nav_about_us:
                         startActivity(new Intent(MainActivity.this, AboutUs.class));
                         if (drawer != null) {

--- a/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
@@ -4,8 +4,12 @@ import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import org.fossasia.pslab.R;
+
+import static org.fossasia.pslab.activity.MainActivity.navItemIndex;
 
 /**
  * Created by viveksb007 on 15/3/17.
@@ -48,4 +52,5 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
             listPreference.setSummary("Current format is " + listPreference.getEntry().toString());
         }
     }
+
 }

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -18,10 +18,10 @@
             android:icon="@drawable/ic_explore_black_24dp"
             android:title="@string/nav_design_experiment" />
 
-        <item
+        <!--<item
             android:id="@+id/nav_settings"
             android:icon="@drawable/ic_settings_black_24dp"
-            android:title="@string/nav_settings" />
+            android:title="@string/nav_settings" />-->
     </group>
 
     <item android:title="@string/other">

--- a/app/src/main/res/menu/activity_main_setting.xml
+++ b/app/src/main/res/menu/activity_main_setting.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <item
+        android:id="@+id/action_settings"
+        android:title="Settings">
+    </item>
+
+</menu>


### PR DESCRIPTION
Fixes issue #774 

Changes: The settings option was removed from the drawer and added to the appbar. This will allow user to access not only settings but many other options from any fragments (which will be added later). Back button functionality also works and the menu option become invisible when on settings fragment.

Screenshots for the change: 
![20180330_154920](https://user-images.githubusercontent.com/32385519/38134956-0d75ed48-3433-11e8-845f-daacaaa0efe5.gif)

APK for testing: [Compress the *.apk file into a rar or zip file and upload it here]
[app-debug.zip](https://github.com/fossasia/pslab-android/files/1863378/app-debug.zip)
