### PR TITLE
Issue #778: Zoomable schematics

### DIFF
--- a/app/src/main/assets/DOC_HTML/apps/L_halfWave.md
+++ b/app/src/main/assets/DOC_HTML/apps/L_halfWave.md
@@ -7,7 +7,7 @@ Half-Wave Rectifier
 
 * Only a diode is needed to clip out the negative part of the input signal.
 
-![](file:///android_asset/DOC_HTML/apps/images/schematics/halfwave.svg@100%|auto)
+[![](file:///android_asset/DOC_HTML/apps/images/schematics/halfwave.svg@100%|auto)](https://svgshare.com/i/6A9.svg)
 
 * Make the Connections as shown in the figure.
 


### PR DESCRIPTION
First step for issue #778 

Changes: The schematic link was added after the source in the halfwave.md file. The changes are made only in one file for the mentors to check the working.
  
Gif for the change: 

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/32385519/38517221-d8841cbe-3c56-11e8-81f3-2fab15ea734a.gif)


APK for testing: I will provide the apk with more such links to schematics and screenshots for better testing as soon as the mentor reviews the PR.
