### PR TITLE
chore: Update build tools, android version and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ jdk:
 
 env:
   global:
-    - ANDROID_API_LEVEL=25
+    - ANDROID_API_LEVEL=27
     - ANDROID_API_LEVEL_22=22
-    - ANDROID_BUILD_TOOLS_VERSION=26.0.0
+    - ANDROID_BUILD_TOOLS_VERSION=27.0.3
     - ANDROID_ABI=armeabi-v7a
     - ANDROID_TAG=google_apis
-    - ANDROID_TARGET=android-25
+    - ANDROID_TARGET=android-27
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
 
 android:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,47 +24,47 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
 
-    compile "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
-    compile "com.android.support:cardview-v7:$rootProject.supportLibraryVersion"
-    compile "com.android.support:recyclerview-v7:$rootProject.supportLibraryVersion"
-    compile "com.android.support:design:$rootProject.supportLibraryVersion"
-    compile "com.android.support:support-v4:$rootProject.supportLibraryVersion"
-    compile "com.android.support:preference-v14:$rootProject.supportLibraryVersion"
-    compile "com.android.support:customtabs:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:cardview-v7:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:design:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:support-v4:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:preference-v14:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:customtabs:$rootProject.supportLibraryVersion"
 
-    compile "com.android.support.constraint:constraint-layout:$rootProject.constraintLayoutVersion"
-    compile "com.github.PhilJay:MPAndroidChart:$rootProject.mpAndroidChartVersion"
-    compile "com.github.bmelnychuk:atv:$rootProject.atvVersion"
-    compile "de.hdodenhof:circleimageview:$rootProject.circleImageViewVersion"
-    compile "org.apache.commons:commons-math3:$rootProject.commonMathVersion"
-    compile "org.apache.commons:commons-lang3:$rootProject.commonLangVersion"
-    compile "com.squareup.picasso:picasso:$rootProject.picassoVersion"
-    compile "com.github.devlight.navigationtabstrip:navigationtabstrip:$rootProject.navTabStripVersion"
-    compile "com.afollestad.material-dialogs:core:$rootProject.materialDialogsVersion"
-    compile "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"
+    implementation "com.android.support.constraint:constraint-layout:$rootProject.constraintLayoutVersion"
+    implementation "com.github.PhilJay:MPAndroidChart:$rootProject.mpAndroidChartVersion"
+    implementation "com.github.bmelnychuk:atv:$rootProject.atvVersion"
+    implementation "de.hdodenhof:circleimageview:$rootProject.circleImageViewVersion"
+    implementation "org.apache.commons:commons-math3:$rootProject.commonMathVersion"
+    implementation "org.apache.commons:commons-lang3:$rootProject.commonLangVersion"
+    implementation "com.squareup.picasso:picasso:$rootProject.picassoVersion"
+    implementation "com.github.devlight.navigationtabstrip:navigationtabstrip:$rootProject.navTabStripVersion"
+    implementation "com.afollestad.material-dialogs:core:$rootProject.materialDialogsVersion"
+    implementation "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
-    compile 'com.github.medyo:android-about-page:1.2.1'
-    compile 'com.github.tiagohm.MarkdownView:library:0.17.0'
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.5.4'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
-    testCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
+    implementation 'com.github.medyo:android-about-page:1.2.4'
+    implementation 'com.github.tiagohm.MarkdownView:library:0.19.0'
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
+    testImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
 
-    testCompile "junit:junit:$rootProject.junitVersion"
-    androidTestCompile("com.android.support.test:runner:$rootProject.testRunnerRulesVersion") {
+    testImplementation "junit:junit:$rootProject.junitVersion"
+    androidTestImplementation("com.android.support.test:runner:$rootProject.testRunnerRulesVersion") {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile("com.android.support.test:rules:$rootProject.testRunnerRulesVersion") {
+    androidTestImplementation("com.android.support.test:rules:$rootProject.testRunnerRulesVersion") {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile("com.android.support.test.espresso:espresso-core:$rootProject.espressoVersion") {
+    androidTestImplementation("com.android.support.test.espresso:espresso-core:$rootProject.espressoVersion") {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile("com.android.support.test.espresso:espresso-intents:$rootProject.espressoVersion") {
+    androidTestImplementation("com.android.support.test.espresso:espresso-intents:$rootProject.espressoVersion") {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
-    androidTestCompile("com.android.support.test.espresso:espresso-contrib:$rootProject.espressoVersion") {
+    androidTestImplementation("com.android.support.test.espresso:espresso-contrib:$rootProject.espressoVersion") {
         exclude group: 'com.android.support', module: 'support-annotations'
         exclude group: 'com.android.support', module: 'support-v4'
         exclude group: 'com.android.support', module: 'recyclerview-v7'

--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,13 @@
 
 buildscript {
 
-    ext.support_lib_version = '25.3.1'
-
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath "io.realm:realm-gradle-plugin:3.5.0"
+        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath "io.realm:realm-gradle-plugin:5.0.1"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -18,6 +17,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google()
         maven { url "https://jitpack.io" }
     }
 }
@@ -30,26 +30,26 @@ task clean(type: Delete) {
 ext{
     //Sdk and tools
     minSdkVersion = 16
-    targetSdkVersion = 25
-    compileSdkVersion = 25
-    buildToolsVersion = '26.0.0'
+    targetSdkVersion = 27
+    compileSdkVersion = 27
+    buildToolsVersion = '27.0.3'
 
     //App dependencies
-    supportLibraryVersion = '25.3.1'
+    supportLibraryVersion = '27.1.1'
     picassoVersion = '2.5.2'
-    butterKnifeVersion = '8.6.0'
+    butterKnifeVersion = '8.8.1'
     circleImageViewVersion = '2.1.0'
-    mpAndroidChartVersion = 'v3.0.1'
+    mpAndroidChartVersion = 'v3.0.3'
     commonMathVersion = '3.6.1'
     commonLangVersion = '3.5'
-    materialDialogsVersion = '0.9.4.5'
+    materialDialogsVersion = '0.9.6.0'
     navTabStripVersion = '1.0.4'
     constraintLayoutVersion = '1.0.2'
-    atvVersion = "1.2.+"
+    atvVersion = "1.2.9"
 
     //Test dependencies
     testRunnerRulesVersion = '0.5'
     junitVersion = '4.12'
     espressoVersion = '2.2.2'
-    mockitoVersion = '2.7.1'
+    mockitoVersion = '2.8.9'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 11 02:02:43 IST 2017
+#Thu Apr 12 16:02:43 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip

--- a/upload-apk.sh
+++ b/upload-apk.sh
@@ -2,7 +2,9 @@
 #create a new directory that will contain out generated apk
 mkdir $HOME/buildApk/ 
 #copy generated apk from build folder and README.md to the folder just created
-cp -R app/build/outputs/apk/app-debug.apk $HOME/buildApk/
+cp -R app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/release/app-release-unsigned.apk $HOME/buildApk/
+cp -R app/build/outputs/apk/debug/output.json $HOME/buildApk/debug_output.json
+cp -R app/build/outputs/apk/release/output.json $HOME/buildApk/release_output.json
 cp -R README.md $HOME/buildApk/
 
 #setup git
@@ -13,6 +15,7 @@ git config --global user.name "Travis CI"
 git clone --quiet --branch=apk https://fossasia:$GITHUB_API_KEY@github.com/fossasia/pslab-android apk > /dev/null
 
 cd apk
+rm -rf *
 cp -Rf $HOME/buildApk/*  ./
 
 git checkout --orphan workaround


### PR DESCRIPTION
- Upgrade to API 27
- Upgrade to Build Tools 27.0.3
- Upgrade Gradle to 4.5.1
- Upgrade Android Gradle Plugin to 3.1.0
- Upgrade Support Lib to 27.1.1
- Upgrade Realm to 5.0.1
- Update all dependencies
- Change APK upload script accordingly

Fixes #783 
