### PR TITLE
fix: removed Overriding animation

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -219,14 +219,12 @@ public class MainActivity extends AppCompatActivity {
                         break;
                     case R.id.nav_about_us:
                         startActivity(new Intent(MainActivity.this, AboutUs.class));
-                        overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
                         if (drawer != null) {
                             drawer.closeDrawers();
                         }
                         break;
                     case R.id.nav_help_feedback:
                         startActivity(new Intent(MainActivity.this, HelpAndFeedback.class));
-                        overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
                         if (drawer != null) {
                             drawer.closeDrawers();
                         }


### PR DESCRIPTION
Fixes #826 

Changes: Removed Overriding animations which caused trouble of blinking screen

Screenshots for the change: 
![20180510_133210](https://user-images.githubusercontent.com/32356267/39859189-999d046c-5456-11e8-8218-8897a59dda6c.gif)

