### PR TITLE
fix: Problem with oscilloscope activity solved

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/OscilloscopeActivity.java
@@ -3,6 +3,7 @@ package org.fossasia.pslab.activity;
 
 import android.app.AlertDialog;
 import android.content.DialogInterface;
+import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.os.AsyncTask;
@@ -604,6 +605,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
     @Override
     public void onBackPressed() {
         finish();
+        setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }
 
     @Override


### PR DESCRIPTION
Fixes #856 

Changes: Changed orientation of the screen after closing of oscilloscope activity so that the screen doesn't remain as it is and there are no memory leaks.

Screenshots for the change: 
![20180511_161535](https://user-images.githubusercontent.com/32356267/39920959-aff8de44-5536-11e8-9213-9f2e3e6e305f.gif)

APK for testing: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/1994989/app-debug.zip)