### PR TITLE
fix: gradle versions in config files

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -44,15 +44,14 @@ dependencies {
     implementation "com.github.devlight.navigationtabstrip:navigationtabstrip:$rootProject.navTabStripVersion"
     implementation "com.afollestad.material-dialogs:core:$rootProject.materialDialogsVersion"
     implementation "com.jakewharton:butterknife:$rootProject.butterKnifeVersion"
-    implementation 'com.android.support:support-v4:27.1.1'
+    implementation "com.android.support:support-v4:$rootProject.supportLibraryVersion"
     annotationProcessor "com.jakewharton:butterknife-compiler:$rootProject.butterKnifeVersion"
-    implementation 'com.github.medyo:android-about-page:1.2.4'
-    implementation 'com.github.tiagohm.MarkdownView:library:0.19.0'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
-    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
-    testImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.5.4'
-
-    compile 'com.github.mirrajabi:search-dialog:1.1'
+    implementation "com.github.medyo:android-about-page:$rootProject.androidAboutPageVersion"
+    implementation "com.github.tiagohm.MarkdownView:library:$rootProject.markDownViewVersion"
+    implementation "com.github.mirrajabi:search-dialog:$rootProject.searchDialogVersion"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:$rootProject.leakCanaryVersion"
+    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
+    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$rootProject.leakCanaryVersion"
 
     testImplementation "junit:junit:$rootProject.junitVersion"
     androidTestImplementation("com.android.support.test:runner:$rootProject.testRunnerRulesVersion") {

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,11 @@ ext{
     materialDialogsVersion = '0.9.6.0'
     navTabStripVersion = '1.0.4'
     constraintLayoutVersion = '1.0.2'
-    atvVersion = "1.2.9"
+    atvVersion = '1.2.9'
+    androidAboutPageVersion = '1.2.4'
+    markDownViewVersion = '0.19.0'
+    searchDialogVersion = '1.1'
+    leakCanaryVersion = '1.5.4'
 
     //Test dependencies
     testRunnerRulesVersion = '0.5'


### PR DESCRIPTION
Fixes #883 

Changes:
- Added versions to config file and called from there

Screenshots for the change: 

> Not available

APK for testing: 
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/2017629/app-debug.apk.zip)

