### PR TITLE
fix: Fixed onBackPressed method to come to instrument activity

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/LogicalAnalyzerActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/LogicalAnalyzerActivity.java
@@ -26,9 +26,9 @@ import butterknife.ButterKnife;
 public class LogicalAnalyzerActivity extends AppCompatActivity
         implements LAChannelModeFragment.OnChannelSelectedListener {
 
-    private ScienceLab scienceLab;
     @BindView(R.id.logical_analyzer_toolbar)
     Toolbar toolbar;
+    private ScienceLab scienceLab;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -47,7 +47,9 @@ public class LogicalAnalyzerActivity extends AppCompatActivity
     public void channelSelectedNowAnalyze(Bundle params) {
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.setCustomAnimations(android.R.anim.fade_in, android.R.anim.fade_out);
-        ft.replace(R.id.la_frame_layout, LALogicLinesFragment.newInstance(params, this)).commit();
+        ft.replace(R.id.la_frame_layout, LALogicLinesFragment.newInstance(params, this), "logic_analyzer");
+        ft.addToBackStack("logic_analyzer");
+        ft.commit();
     }
 
     @Override
@@ -62,6 +64,9 @@ public class LogicalAnalyzerActivity extends AppCompatActivity
 
     @Override
     public void onBackPressed() {
-       finish();
+        if (getSupportFragmentManager().getBackStackEntryCount() > 0)
+            getSupportFragmentManager().popBackStackImmediate();
+        else
+            finish();
     }
 }


### PR DESCRIPTION
Fixes #907 

Changes: Changed onBackPressed method to come to Instrument Activity rather than going to Main Activity

Screenshots for the change: 
![20180524_023050](https://user-images.githubusercontent.com/32356267/40450929-b4937018-5efa-11e8-94fb-65c5b9682e64.gif)

APK for testing: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2042453/app-debug.zip)