### PR TITLE
chore: app version updated

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.fossasia.pslab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4
-        versionName "1.1.2"
+        versionCode 5
+        versionName "1.1.3"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {


### PR DESCRIPTION
Fixes #956 

Changes: 
Updated version to `1.1.3` and versioncode to `5`

Screenshots for the change: 
> Not applicable

APK for testing: 
> Not applicable
