### PR TITLE
chore: updated app version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.fossasia.pslab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 6
-        versionName "1.1.4"
+        versionCode 7
+        versionName "1.1.5"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {


### PR DESCRIPTION
Fixes #988 

Changes: 
- Upgraded the app version to `1.1.5`

Screenshots for the change: 
> Not applicable

APK for testing: 
> Not applicable
