### PR TITLE
refactor:reduced the decimal places of voltage reading to two

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MultimeterActivity.java
@@ -19,6 +19,7 @@ import org.fossasia.pslab.communication.ScienceLab;
 import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.text.DecimalFormat;
+import java.util.Locale;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -148,7 +149,7 @@ public class MultimeterActivity extends AppCompatActivity {
                     }
                 } else {
                     if (scienceLab.isConnected()) {
-                        quantity.setText(String.valueOf(scienceLab.getVoltage(knobMarker[knobState], 1)));
+                        quantity.setText(String.format(Locale.ENGLISH, "%.2f", scienceLab.getVoltage(knobMarker[knobState], 1)));
                         unit.setText(R.string.multimeter_voltage_unit);
                     }
                 }


### PR DESCRIPTION
Fixes #1017 

**Changes**:
The readings of voltage is now rounded to two decimal places.

**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/2093860/app-debug.apk.zip)

