### PR TITLE
refactor: fixed configure tab data pass

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/LuxMeterActivity.java
@@ -25,12 +25,9 @@ import butterknife.BindView;
 import butterknife.ButterKnife;
 
 
-public class LuxMeterActivity extends AppCompatActivity implements LuxMeterFragmentConfig.OnDataPass {
+public class LuxMeterActivity extends AppCompatActivity {
     private static final String PREF_NAME = "customDialogPreference";
     private static final String KEY = "skipLuxMeterDialog";
-    private int sensorType = 0;
-    private int highLimit = 1000;
-    private int updatePeriod = 100;
 
     @BindView(R.id.navigation_lux_meter)
     BottomNavigationView bottomNavigationView;
@@ -51,7 +48,7 @@ public class LuxMeterActivity extends AppCompatActivity implements LuxMeterFragm
                         switch (item.getItemId()) {
                             case R.id.action_data:
                                 if (!(fragment instanceof LuxMeterFragmentData))
-                                    selectedFragment = LuxMeterFragmentData.newInstance(sensorType, highLimit, updatePeriod);
+                                    selectedFragment = LuxMeterFragmentData.newInstance();
                                 break;
                             case R.id.action_config:
                                 if (!(fragment instanceof LuxMeterFragmentConfig))
@@ -62,7 +59,7 @@ public class LuxMeterActivity extends AppCompatActivity implements LuxMeterFragm
                         }
                         if (selectedFragment != null) {
                             FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-                            transaction.replace(R.id.frame_layout_lux_meter, selectedFragment);
+                            transaction.replace(R.id.frame_layout_lux_meter, selectedFragment, selectedFragment.getTag());
                             transaction.commit();
                         }
                         return true;
@@ -71,7 +68,8 @@ public class LuxMeterActivity extends AppCompatActivity implements LuxMeterFragm
         howToConnectDialog(getString(R.string.lux_meter), getString(R.string.lux_meter_intro), R.drawable.bh1750_schematic, getString(R.string.lux_meter_desc));
         try {
             FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-            transaction.replace(R.id.frame_layout_lux_meter, LuxMeterFragmentData.newInstance(sensorType, highLimit, updatePeriod));
+            Fragment selectedFragment = LuxMeterFragmentData.newInstance();
+            transaction.replace(R.id.frame_layout_lux_meter, selectedFragment, selectedFragment.getTag());
             transaction.commit();
         } catch (Exception e) {
             e.printStackTrace();
@@ -115,12 +113,5 @@ public class LuxMeterActivity extends AppCompatActivity implements LuxMeterFragm
         } catch (Exception e) {
             e.printStackTrace();
         }
-    }
-
-    @Override
-    public void onDataPass(int sensor, int updatePeriod, int highValue) {
-        this.sensorType = sensor;
-        this.updatePeriod = updatePeriod;
-        this.highLimit = highValue;
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentConfig.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentConfig.java
@@ -21,44 +21,43 @@ import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.io.IOException;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
+
 public class LuxMeterFragmentConfig extends Fragment {
     private static BH1750 bh1750;
     private final int highLimitMax = 10000;
     private final int updatePeriodMax = 900;
     private final int updatePeriodMin = 100;
     private static int selectedSensor = 0; //0 for built in and 1 for BH1750
-    private static int highValue = 0;
-    private static int updatePeriodValue = 100;
+    private int highValue = 0;
+    private int updatePeriodValue = 100;
+    private Unbinder unbinder;
 
-    private EditText highLimit;
-    private EditText updatePeriod;
-    private CardView gainRangeCard;
-    private Spinner gainValue;
+    @BindView(R.id.lux_hight_limit_text)
+    EditText highLimit;
+    @BindView(R.id.lux_update_period_text)
+    EditText updatePeriod;
+    @BindView(R.id.cardview_gain_range)
+    CardView gainRangeCard;
+    @BindView(R.id.spinner_bh1750_gain)
+    Spinner gainValue;
 
     private static ScienceLab scienceLab;
 
-    private OnDataPass dataParser;
-
     public static LuxMeterFragmentConfig newInstance() {
         return new LuxMeterFragmentConfig();
-    }
-
-    public void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_lux_meter_config, container, false);
-
-        highLimit = (EditText) view.findViewById(R.id.lux_hight_limit_text);
+        unbinder = ButterKnife.bind(this, view);
         final SeekBar highLimitSeek = (SeekBar) view.findViewById(R.id.lux_hight_limit_seekbar);
-        updatePeriod = (EditText) view.findViewById(R.id.lux_update_period_text);
         final SeekBar updatePeriodSeek = (SeekBar) view.findViewById(R.id.lux_update_period_seekbar);
-        gainValue = (Spinner) view.findViewById(R.id.spinner_bh1750_gain);
         final Spinner selectSensor = (Spinner) view.findViewById(R.id.spinner_select_light);
-        gainRangeCard = (CardView) view.findViewById(R.id.cardview_gain_range);
 
         highLimitSeek.setMax(highLimitMax);
         updatePeriodSeek.setMax(updatePeriodMax);
@@ -207,7 +206,6 @@ public class LuxMeterFragmentConfig extends Fragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        dataParser = (OnDataPass) context;
     }
 
     @Override
@@ -215,12 +213,8 @@ public class LuxMeterFragmentConfig extends Fragment {
         super.onDestroyView();
         highValue = getValueFromText(highLimit, 0, highLimitMax);
         updatePeriodValue = getValueFromText(updatePeriod, updatePeriodMin, updatePeriodMax + 100);
-
-        dataParser.onDataPass(selectedSensor, updatePeriodValue, highValue);
-    }
-
-    public interface OnDataPass {
-        void onDataPass(int sensor, int updatePeriod, int highValue);
+        LuxMeterFragmentData.setParameters(selectedSensor, highValue, updatePeriodValue);
+        unbinder.unbind();
     }
 
     public int getValueFromText(EditText editText, int lowerBound, int upperBound) {

--- a/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
@@ -33,37 +33,46 @@ import org.fossasia.pslab.others.ScienceLabCommon;
 
 import java.util.ArrayList;
 
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
+
 import static android.content.Context.SENSOR_SERVICE;
 
 public class LuxMeterFragmentData extends Fragment {
 
-    private static int sensorType;
-    private static int highLimit;
-    private static int updatePeriod;
+    private static int sensorType = 0;
+    private static int highLimit = 1000;
+    private static int updatePeriod = 100;
     private SensorDataFetch sensorDataFetch;
-    private TextView statMax;
-    private TextView statMin;
-    private TextView statMean;
+
+    @BindView(R.id.lux_stat_max)
+    TextView statMax;
+    @BindView(R.id.lux_stat_min)
+    TextView statMin;
+    @BindView(R.id.lux_stat_mean)
+    TextView statMean;
+    @BindView(R.id.chart_lux_meter)
+    LineChart mChart;
+    @BindView(R.id.light_meter)
+    PointerSpeedometer lightMeter;
+
     private BH1750 sensorBH1750 = null;
     private SensorManager sensorManager;
     private Sensor sensor;
     private ScienceLab scienceLab;
-    private LineChart mChart;
     private long startTime;
     private int flag;
     private ArrayList<Entry> entries;
-    private PointerSpeedometer lightMeter;
     private float currentMin;
     private float currentMax;
     private YAxis y;
     private volatile boolean monitor = true;
+    private Unbinder unbinder;
 
     private final Object lock = new Object();
 
-    public static LuxMeterFragmentData newInstance(int sensorType, int highLimit, int updatePeriod) {
-        LuxMeterFragmentData.sensorType = sensorType;
-        LuxMeterFragmentData.highLimit = highLimit;
-        LuxMeterFragmentData.updatePeriod = updatePeriod;
+    public static LuxMeterFragmentData newInstance() {
         return new LuxMeterFragmentData();
     }
 
@@ -90,7 +99,7 @@ public class LuxMeterFragmentData extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_lux_meter_data, container, false);
-
+        unbinder = ButterKnife.bind(this, view);
         Runnable runnable = new Runnable() {
             @Override
             public void run() {
@@ -147,14 +156,8 @@ public class LuxMeterFragmentData extends Fragment {
         Thread dataThread = new Thread(runnable);
         dataThread.start();
 
-        statMax = (TextView) view.findViewById(R.id.lux_stat_max);
-        statMin = (TextView) view.findViewById(R.id.lux_stat_min);
-        statMean = (TextView) view.findViewById(R.id.lux_stat_mean);
-        lightMeter = (PointerSpeedometer) view.findViewById(R.id.light_meter);
-
         lightMeter.setMaxSpeed(10000);
 
-        mChart = view.findViewById(R.id.chart_lux_meter);
         XAxis x = mChart.getXAxis();
         this.y = mChart.getAxisLeft();
         YAxis y2 = mChart.getAxisRight();
@@ -189,6 +192,12 @@ public class LuxMeterFragmentData extends Fragment {
         y2.setDrawGridLines(false);
 
         return view;
+    }
+
+    public static void setParameters(int sensorType, int highLimit, int updatePeriod) {
+        LuxMeterFragmentData.sensorType = sensorType;
+        LuxMeterFragmentData.highLimit = highLimit;
+        LuxMeterFragmentData.updatePeriod = updatePeriod;
     }
 
     private class SensorDataFetch extends AsyncTask<Void, Void, Void> implements SensorEventListener {
@@ -284,5 +293,6 @@ public class LuxMeterFragmentData extends Fragment {
             sensorManager.unregisterListener(sensorDataFetch);
             sensorDataFetch.cancel(true);
         }
+        unbinder.unbind();
     }
 }


### PR DESCRIPTION
Fixes #1029 

**Changes**: 
Passing data from fragment config to fragment data in the lux meter instrument using a method when fragment gets destroyed.

**Screenshot/s for the changes**: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/17523141/41380514-d15c186a-6f82-11e8-9bb0-f66ea6d4bce4.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[lux_meter_data.zip](https://github.com/fossasia/pslab-android/files/2100056/lux_meter_data.zip)

