### PR TITLE
fix: New design for lux meter tile

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/InstrumentsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/InstrumentsFragment.java
@@ -147,7 +147,7 @@ public class InstrumentsFragment extends Fragment {
                     getResources().getString(R.string.power_source), R.drawable.tile_icon_power_source, getResources().getString(descriptions[5]))
             );
             applicationItemList.add(new ApplicationItem(
-                    getResources().getString(R.string.lux_meter), R.drawable.tile_icon_oscilloscope, getResources().getString(descriptions[6]))
+                    getResources().getString(R.string.lux_meter), R.drawable.tile_icon_lux_meter, getResources().getString(descriptions[6]))
             );
             return null;
         }

--- a/app/src/main/res/drawable/tile_icon_lux_meter.xml
+++ b/app/src/main/res/drawable/tile_icon_lux_meter.xml
@@ -1,0 +1,83 @@
+<vector android:height="24dp" android:viewportHeight="15.0"
+    android:viewportWidth="15.0" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:pathData="m7.5,0.196a7.304,7.304 0,0 0,-7.304 7.304,7.304 7.304,0 0,0 7.304,7.304 7.304,7.304 0,0 0,7.304 -7.304,7.304 7.304,0 0,0 -7.304,-7.304z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="0.39164442"/>
+    <path android:fillColor="#00000000" android:pathData="m12.5,0v2.25"
+        android:strokeAlpha="1" android:strokeColor="#fff9f9"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.40000001"/>
+    <path android:fillColor="#00000000" android:pathData="m-0,12.5h2.25"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.40000001"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="M5.724,4.886L9.276,4.886A0.232,0.232 0,0 1,9.508 5.118L9.508,7.766A0.232,0.232 0,0 1,9.276 7.998L5.724,7.998A0.232,0.232 0,0 1,5.492 7.766L5.492,5.118A0.232,0.232 0,0 1,5.724 4.886z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.47654763"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="m6.241,3.398a2.015,1.259 90,0 1,0.629 -1.745,2.015 1.259,90 0,1 1.259,0 2.015,1.259 90,0 1,0.629 1.745l-1.259,0z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.484"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="M9.671,9.566m-0.624,0a0.624,0.624 0,1 1,1.248 0a0.624,0.624 0,1 1,-1.248 0"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.49620253"/>
+    <path android:fillColor="#FFFFFFFF" android:pathData="M7.5,2.025C7.282,2.025 7.105,2.202 7.105,2.42 7.105,2.638 7.282,2.815 7.5,2.815 7.718,2.815 7.895,2.638 7.895,2.42 7.895,2.202 7.718,2.025 7.5,2.025ZM7.5,2.736C7.326,2.736 7.184,2.594 7.184,2.42 7.184,2.246 7.326,2.104 7.5,2.104c0.174,0 0.316,0.142 0.316,0.316 0,0.174 -0.142,0.316 -0.316,0.316zM7.619,2.42c0,0.066 -0.053,0.119 -0.119,0.119 -0.066,0 -0.119,-0.053 -0.119,-0.119 0,-0.066 0.053,-0.119 0.119,-0.119 0.066,0 0.119,0.053 0.119,0.119z"/>
+    <path android:fillColor="#FFFFFFFF" android:pathData="M6.519,8.881L5.838,8.881c-0.188,0 -0.34,0.152 -0.34,0.34 0,0.188 0.152,0.34 0.34,0.34l0.681,0c0.188,0 0.34,-0.152 0.34,-0.34C6.859,9.034 6.707,8.881 6.519,8.881ZM5.838,9.426C5.725,9.426 5.634,9.335 5.634,9.222 5.634,9.109 5.725,9.018 5.838,9.018c0.113,0 0.204,0.091 0.204,0.204 0,0.113 -0.091,0.204 -0.204,0.204z"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.304,10.043 L6.125,10.667 7.304,11.29Z" android:strokeWidth="0.37020066"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.156,10.277L7.156,11.057L6.419,10.667Z" android:strokeWidth="1.39918363"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.696,11.307 L8.875,10.683 7.696,10.06Z" android:strokeWidth="5.18280935"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.844,11.073L7.844,10.293L8.581,10.683Z" android:strokeWidth="5.18280935"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="M5.168,3.967L9.832,3.967A0.526,0.526 0,0 1,10.358 4.493L10.358,11.503A0.526,0.526 0,0 1,9.832 12.029L5.168,12.029A0.526,0.526 0,0 1,4.642 11.503L4.642,4.493A0.526,0.526 0,0 1,5.168 3.967z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.51630878"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:pathData="m7.5,0.196a7.304,7.304 0,0 0,-7.304 7.304,7.304 7.304,0 0,0 7.304,7.304 7.304,7.304 0,0 0,7.304 -7.304,7.304 7.304,0 0,0 -7.304,-7.304z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="0.39164442"/>
+    <path android:fillColor="#00000000" android:pathData="m12.5,0v2.25"
+        android:strokeAlpha="1" android:strokeColor="#fff9f9"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.40000001"/>
+    <path android:fillColor="#00000000" android:pathData="m-0,12.5h2.25"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.40000001"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="M5.724,4.886L9.276,4.886A0.232,0.232 0,0 1,9.508 5.118L9.508,7.766A0.232,0.232 0,0 1,9.276 7.998L5.724,7.998A0.232,0.232 0,0 1,5.492 7.766L5.492,5.118A0.232,0.232 0,0 1,5.724 4.886z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.47654763"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="m6.241,3.398a2.015,1.259 90,0 1,0.629 -1.745,2.015 1.259,90 0,1 1.259,0 2.015,1.259 90,0 1,0.629 1.745l-1.259,0z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.484"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="M9.671,9.566m-0.624,0a0.624,0.624 0,1 1,1.248 0a0.624,0.624 0,1 1,-1.248 0"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.49620253"/>
+    <path android:fillColor="#FFFFFFFF" android:pathData="M7.5,2.025C7.282,2.025 7.105,2.202 7.105,2.42 7.105,2.638 7.282,2.815 7.5,2.815 7.718,2.815 7.895,2.638 7.895,2.42 7.895,2.202 7.718,2.025 7.5,2.025ZM7.5,2.736C7.326,2.736 7.184,2.594 7.184,2.42 7.184,2.246 7.326,2.104 7.5,2.104c0.174,0 0.316,0.142 0.316,0.316 0,0.174 -0.142,0.316 -0.316,0.316zM7.619,2.42c0,0.066 -0.053,0.119 -0.119,0.119 -0.066,0 -0.119,-0.053 -0.119,-0.119 0,-0.066 0.053,-0.119 0.119,-0.119 0.066,0 0.119,0.053 0.119,0.119z"/>
+    <path android:fillColor="#FFFFFFFF" android:pathData="M6.519,8.881L5.838,8.881c-0.188,0 -0.34,0.152 -0.34,0.34 0,0.188 0.152,0.34 0.34,0.34l0.681,0c0.188,0 0.34,-0.152 0.34,-0.34C6.859,9.034 6.707,8.881 6.519,8.881ZM5.838,9.426C5.725,9.426 5.634,9.335 5.634,9.222 5.634,9.109 5.725,9.018 5.838,9.018c0.113,0 0.204,0.091 0.204,0.204 0,0.113 -0.091,0.204 -0.204,0.204z"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.304,10.043 L6.125,10.667 7.304,11.29Z" android:strokeWidth="0.37020066"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.156,10.277L7.156,11.057L6.419,10.667Z" android:strokeWidth="1.39918363"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.696,11.307 L8.875,10.683 7.696,10.06Z" android:strokeWidth="5.18280935"/>
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M7.844,11.073L7.844,10.293L8.581,10.683Z" android:strokeWidth="5.18280935"/>
+    <path android:fillAlpha="1" android:fillColor="#00000000"
+        android:fillType="evenOdd"
+        android:pathData="M5.168,3.967L9.832,3.967A0.526,0.526 0,0 1,10.358 4.493L10.358,11.503A0.526,0.526 0,0 1,9.832 12.029L5.168,12.029A0.526,0.526 0,0 1,4.642 11.503L4.642,4.493A0.526,0.526 0,0 1,5.168 3.967z"
+        android:strokeAlpha="1" android:strokeColor="#ffffff"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.51630878"/>
+</vector>


### PR DESCRIPTION
Fixes #1046

**Changes**: 
New vector drawable for the tile lux meter added. 

**Screenshot/s for the changes**: 
![screenshot_2018-06-16-12-28-30](https://user-images.githubusercontent.com/17523141/41496591-d745da7e-7160-11e8-8652-0f99f4bca268.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[luxmeter_card_icon.zip](https://github.com/fossasia/pslab-android/files/2107922/luxmeter_card_icon.zip)
