### PR TITLE
fix: Fix configure fragment crash when using edit text box

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentConfig.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentConfig.java
@@ -88,20 +88,24 @@ public class LuxMeterFragmentConfig extends Fragment {
         highLimit.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if (!hasFocus) {
-                    String stringValue = highLimit.getText().toString();
-                    int value = 0;
-                    try {
-                        value = Integer.parseInt(stringValue);
-                    } catch (NumberFormatException e) {
-                        e.printStackTrace();
+                try {
+                    if (!hasFocus) {
+                        String stringValue = highLimit.getText().toString();
+                        int value = 0;
+                        try {
+                            value = Integer.parseInt(stringValue);
+                        } catch (NumberFormatException e) {
+                            e.printStackTrace();
+                        }
+                        if (value > highLimitMax)
+                            highLimitSeek.setProgress(highLimitMax);
+                        else if (value < 0)
+                            highLimitSeek.setProgress(0);
+                        else
+                            highLimitSeek.setProgress(value);
                     }
-                    if (value > highLimitMax)
-                        highLimitSeek.setProgress(highLimitMax);
-                    else if (value < 0)
-                        highLimitSeek.setProgress(0);
-                    else
-                        highLimitSeek.setProgress(value);
+                } catch (NullPointerException e) {
+                    e.printStackTrace();
                 }
             }
         });
@@ -127,20 +131,24 @@ public class LuxMeterFragmentConfig extends Fragment {
         updatePeriod.setOnFocusChangeListener(new View.OnFocusChangeListener() {
             @Override
             public void onFocusChange(View v, boolean hasFocus) {
-                if (!hasFocus) {
-                    String stringValue = updatePeriod.getText().toString();
-                    int value = 100;
-                    try {
-                        value = Integer.parseInt(stringValue);
-                    } catch (NumberFormatException e) {
-                        e.printStackTrace();
+                try {
+                    if (!hasFocus) {
+                        String stringValue = updatePeriod.getText().toString();
+                        int value = 100;
+                        try {
+                            value = Integer.parseInt(stringValue);
+                        } catch (NumberFormatException e) {
+                            e.printStackTrace();
+                        }
+                        if (value > updatePeriodMax)
+                            updatePeriodSeek.setProgress(updatePeriodMax + 100);
+                        else if (value < updatePeriodMin)
+                            updatePeriodSeek.setProgress(updatePeriodMin - 100);
+                        else
+                            updatePeriodSeek.setProgress(value - updatePeriodMin);
                     }
-                    if (value > updatePeriodMax)
-                        updatePeriodSeek.setProgress(updatePeriodMax + 100);
-                    else if (value < updatePeriodMin)
-                        updatePeriodSeek.setProgress(updatePeriodMin - 100);
-                    else
-                        updatePeriodSeek.setProgress(value - updatePeriodMin);
+                } catch (NullPointerException e) {
+                    e.printStackTrace();
                 }
             }
         });


### PR DESCRIPTION
Fixes #1059 

**Changes**: 
Focus changed listener has a try catch block to remove null pointer exception on destroy view

**Screenshot/s for the changes**: 
> None

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[lux_meter_fix.zip](https://github.com/fossasia/pslab-android/files/2107934/lux_meter_fix.zip)