### PR TITLE
fix: Channel read errors

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/communication/CommandsProto.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/CommandsProto.java
@@ -8,7 +8,7 @@ public class CommandsProto {
 
     public int ACKNOWLEDGE = 254;
     public int MAX_SAMPLES = 10000;
-    public int DATA_SPLITTING = 200;
+    public int DATA_SPLITTING = 60;
 
     public int FLASH = 1;
     public int READ_FLASH = 1;


### PR DESCRIPTION
Fixes #1002 

**Changes**: 
The data is fetched from PSLab device block by block. The previous block size was large and hence reduced it to 60.

**Screenshot/s for the changes**: 
![screenshot_2018-06-18-03-28-11](https://user-images.githubusercontent.com/17523141/41512799-ce181018-72ad-11e8-9e2a-e5ddb3fefed0.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[Oscilloscope_channel_read.zip](https://github.com/fossasia/pslab-android/files/2109491/Oscilloscope_channel_read.zip)
