### PR TITLE
feat: oscilloscope bottom sheet guide

### DIFF
--- a/app/src/main/res/layout/activity_oscilloscope.xml
+++ b/app/src/main/res/layout/activity_oscilloscope.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/parent_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:keepScreenOn="true"
@@ -10,299 +9,312 @@
     android:weightSum="1">
 
     <RelativeLayout
-        android:id="@+id/layout_chart_os"
-        android:layout_width="600dp"
-        android:layout_height="300dp">
-
-        <com.github.mikephil.charting.charts.LineChart
-            android:id="@+id/chart_os"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@+id/chart_xaxis_layout"
-            android:layout_toEndOf="@+id/chart_yaxis_layout1"
-            android:layout_toLeftOf="@+id/chart_yaxis_layout2"
-            android:layout_toRightOf="@+id/chart_yaxis_layout1"
-            android:layout_toStartOf="@+id/chart_yaxis_layout2"
-            android:background="#000" />
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <RelativeLayout
-            android:id="@+id/chart_xaxis_layout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:background="#000"
-            android:orientation="vertical">
+            android:id="@+id/layout_chart_os"
+            android:layout_width="@dimen/osc_chart_width"
+            android:layout_height="@dimen/osc_chart_height">
 
-            <TextView
-                android:id="@+id/tv_graph_label_xaxis_os"
-                android:layout_width="wrap_content"
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/chart_os"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/chart_xaxis_layout"
+                android:layout_toEndOf="@+id/chart_yaxis_layout1"
+                android:layout_toLeftOf="@+id/chart_yaxis_layout2"
+                android:layout_toRightOf="@+id/chart_yaxis_layout1"
+                android:layout_toStartOf="@+id/chart_yaxis_layout2"
+                android:background="@color/black" />
+
+            <RelativeLayout
+                android:id="@+id/chart_xaxis_layout"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
                 android:layout_alignParentTop="true"
-                android:layout_centerHorizontal="true"
-                android:layout_gravity="center_vertical|center_horizontal|center"
+                android:background="@color/black"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tv_graph_label_xaxis_os"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_centerHorizontal="true"
+                    android:layout_gravity="center_vertical|center_horizontal|center"
+                    android:foregroundGravity="center_vertical"
+                    android:gravity="center_vertical|center_horizontal|center"
+                    android:text="@string/time_space"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/osc_axis_text_size"
+                    android:textStyle="normal|bold"
+                    tools:layout_editor_absoluteX="@dimen/oscilloscope_absolute_x"
+                    tools:layout_editor_absoluteY="@dimen/length_0dp" />
+
+                <TextView
+                    android:id="@+id/tv_unit_xaxis_os"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginLeft="@dimen/osc_tv_unit_margin"
+                    android:layout_marginStart="@dimen/osc_tv_unit_margin"
+                    android:layout_toEndOf="@+id/tv_graph_label_xaxis_os"
+                    android:layout_toRightOf="@+id/tv_graph_label_xaxis_os"
+                    android:text="@string/unit_μs"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/osc_axis_text_size"
+                    android:textStyle="normal|bold"
+                    app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_os"
+                    tools:layout_editor_absoluteY="@dimen/length_0dp" />
+            </RelativeLayout>
+
+
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/chart_yaxis_layout1"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_alignParentLeft="true"
+                android:layout_alignParentStart="true"
+                android:layout_alignParentTop="true"
+                android:background="@color/black"
                 android:foregroundGravity="center_vertical"
-                android:gravity="center_vertical|center_horizontal|center"
-                android:text="@string/time_space"
-                android:textColor="#ffff"
-                android:textSize="9sp"
-                android:textStyle="normal|bold"
-                tools:layout_editor_absoluteX="288dp"
-                tools:layout_editor_absoluteY="0dp" />
+                android:gravity="center_vertical"
+                android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/tv_unit_xaxis_os"
+                <TextView
+                    android:id="@+id/tv_label_left_yaxis_os"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/osc_tv_left_axis_height"
+                    android:layout_gravity="center"
+                    android:layout_marginBottom="@dimen/osc_tv_axis_margin"
+                    android:layout_marginTop="@dimen/osc_tv_axis_margin"
+                    android:foregroundGravity="center_horizontal"
+                    android:gravity="top|center_horizontal"
+                    android:includeFontPadding="false"
+                    android:rotation="-90"
+                    android:text="@string/label_ch1"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/osc_axis_text_size"
+                    android:textStyle="normal|bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_unit_left_yaxis_os"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_above="@+id/tv_label_left_yaxis_os"
+                    android:layout_marginBottom="@dimen/osc_tv_unit_margin"
+                    android:rotation="-90"
+                    android:text="@string/label_V"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/osc_axis_text_size"
+                    android:textStyle="normal|bold"
+                    app:layout_constraintBottom_toTopOf="@+id/tv_label_left_yaxis_os"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent" />
+
+            </android.support.constraint.ConstraintLayout>
+
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/chart_yaxis_layout2"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:layout_marginLeft="8dp"
-                android:layout_marginStart="8dp"
-                android:layout_toEndOf="@+id/tv_graph_label_xaxis_os"
-                android:layout_toRightOf="@+id/tv_graph_label_xaxis_os"
-                android:text="@string/unit_μs"
-                android:textColor="#ffff"
-                android:textSize="9sp"
-                android:textStyle="normal|bold"
-                app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_os"
-                tools:layout_editor_absoluteY="0dp" />
+                android:layout_height="match_parent"
+                android:layout_alignParentEnd="true"
+                android:layout_alignParentRight="true"
+                android:layout_centerVertical="true"
+                android:background="@color/black"
+                android:foregroundGravity="right"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/tv_label_right_yaxis_os"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginBottom="@dimen/osc_tv_axis_margin"
+                    android:layout_marginTop="@dimen/osc_tv_axis_margin"
+                    android:foregroundGravity="center_horizontal"
+                    android:gravity="center_horizontal"
+                    android:includeFontPadding="false"
+                    android:rotation="-90"
+                    android:text="@string/label_ch2"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/osc_axis_text_size"
+                    android:textStyle="normal|bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_unit_right_yaxis_os"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/osc_tv_unit_margin"
+                    android:rotation="-90"
+                    android:text="@string/label_V"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/osc_axis_text_size"
+                    app:layout_constraintBottom_toTopOf="@+id/tv_label_right_yaxis_os"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent" />
+
+                <ImageView
+                    android:id="@+id/imageView_led_os"
+                    android:layout_width="@dimen/osc_image_dimens"
+                    android:layout_height="@dimen/osc_image_dimens"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:srcCompat="@drawable/red_led" />
+            </android.support.constraint.ConstraintLayout>
+
         </RelativeLayout>
 
+        <LinearLayout
+            android:id="@+id/layout_dock_os1"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_toEndOf="@+id/layout_chart_os"
+            android:layout_toRightOf="@+id/layout_chart_os"
+            android:background="@drawable/rounded_custom_border_2"
+            android:orientation="vertical">
 
-        <android.support.constraint.ConstraintLayout
-            android:id="@+id/chart_yaxis_layout1"
-            android:layout_width="wrap_content"
+            <ImageButton
+                android:id="@+id/button_channel_parameters_os"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_margin="@dimen/osc_image_margin"
+                android:layout_weight="@dimen/osc_image_weight"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/channel_parameters" />
+
+            <TextView
+                android:id="@+id/tv_channel_parameters_os"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/osc_text_margin"
+                android:background="@color/colorPrimaryDark"
+                android:gravity="center"
+                android:text="@string/channel_parameters"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/osc_text_size"
+                android:textStyle="normal|bold" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/osc_divider_line"
+                android:background="@color/outline" />
+
+            <ImageButton
+                android:id="@+id/button_timebase_os"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_weight="@dimen/osc_image_weight"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/timebase" />
+
+            <TextView
+                android:id="@+id/tv_timebase_tigger_os"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/osc_text_margin"
+                android:gravity="center"
+                android:text="@string/timebase_and_trigger"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/osc_text_size"
+                android:textStyle="normal|bold" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/osc_divider_line"
+                android:background="@color/outline" />
+
+            <ImageButton
+                android:id="@+id/button_data_analysis_os"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_margin="@dimen/osc_image_margin"
+                android:layout_weight="@dimen/osc_image_weight"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/data_analysis" />
+
+            <TextView
+                android:id="@+id/tv_data_analysis_os"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/osc_text_margin"
+                android:gravity="center"
+                android:maxLines="1"
+                android:text="@string/data_analysis"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/osc_text_size"
+                android:textStyle="normal|bold" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/osc_divider_line"
+                android:background="@color/outline" />
+
+            <ImageButton
+                android:id="@+id/button_xy_plot_os"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_margin="@dimen/osc_image_margin"
+                android:layout_weight="@dimen/osc_image_weight"
+                android:scaleType="fitCenter"
+                app:srcCompat="@drawable/xymode" />
+
+            <TextView
+                android:id="@+id/tv_xy_plot_os"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/osc_text_margin"
+                android:layout_marginBottom="@dimen/osc_divider_line"
+                android:elevation="@dimen/text_elevation"
+                android:gravity="center"
+                android:text="@string/xy_plot"
+                android:textAlignment="center"
+                android:textColor="@color/black"
+                android:textSize="@dimen/osc_text_size"
+                android:textStyle="normal|bold" />
+
+        </LinearLayout>
+
+        <FrameLayout
+            android:id="@+id/layout_dock_os2"
+            android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true"
-            android:background="#000"
-            android:foregroundGravity="center_vertical"
-            android:gravity="center_vertical"
-            android:orientation="vertical">
+            android:layout_below="@+id/layout_chart_os"
+            android:layout_marginLeft="@dimen/length_0dp"
+            android:layout_marginStart="@dimen/length_0dp"
+            android:layout_toLeftOf="@+id/layout_dock_os1"
+            android:layout_toStartOf="@+id/layout_dock_os1">
 
-            <TextView
-                android:id="@+id/tv_label_left_yaxis_os"
-                android:layout_width="wrap_content"
-                android:layout_height="9dp"
-                android:layout_gravity="center"
-                android:layout_marginBottom="16dp"
-                android:layout_marginTop="16dp"
-                android:foregroundGravity="center_horizontal"
-                android:gravity="top|center_horizontal"
-                android:includeFontPadding="false"
-                android:rotation="-90"
-                android:text="@string/label_ch1"
-                android:textColor="#ffff"
-                android:textSize="8sp"
-                android:textStyle="normal|bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/tv_unit_left_yaxis_os"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_above="@+id/tv_label_left_yaxis_os"
-                android:layout_marginBottom="8dp"
-                android:rotation="-90"
-                android:text="@string/label_V"
-                android:textColor="#fff"
-                android:textSize="8sp"
-                android:textStyle="normal|bold"
-                app:layout_constraintBottom_toTopOf="@+id/tv_label_left_yaxis_os"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent" />
-
-        </android.support.constraint.ConstraintLayout>
-
-        <android.support.constraint.ConstraintLayout
-            android:id="@+id/chart_yaxis_layout2"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:layout_alignParentEnd="true"
-            android:layout_alignParentRight="true"
-            android:layout_centerVertical="true"
-            android:background="#000"
-            android:foregroundGravity="right"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/tv_label_right_yaxis_os"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginBottom="16dp"
-                android:layout_marginTop="16dp"
-                android:foregroundGravity="center_horizontal"
-                android:gravity="center_horizontal"
-                android:includeFontPadding="false"
-                android:rotation="-90"
-                android:text="@string/label_ch2"
-                android:textColor="#ffff"
-                android:textSize="8sp"
-                android:textStyle="normal|bold"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <TextView
-                android:id="@+id/tv_unit_right_yaxis_os"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:rotation="-90"
-                android:text="@string/label_V"
-                android:textColor="#fff"
-                android:textSize="8sp"
-                app:layout_constraintBottom_toTopOf="@+id/tv_label_right_yaxis_os"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent" />
-
-            <ImageView
-                android:id="@+id/imageView_led_os"
-                android:layout_width="15dp"
-                android:layout_height="15dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:srcCompat="@drawable/red_led" />
-        </android.support.constraint.ConstraintLayout>
-
+        </FrameLayout>
     </RelativeLayout>
 
-    <LinearLayout
-        android:id="@+id/layout_dock_os1"
+    <View
+        android:id="@+id/parent_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_toEndOf="@+id/layout_chart_os"
-        android:layout_toRightOf="@+id/layout_chart_os"
-        android:background="@drawable/rounded_custom_border_2"
-        android:orientation="vertical">
+        android:alpha="0"
+        android:background="@color/black" />
 
-        <ImageButton
-            android:id="@+id/button_channel_parameters_os"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="@dimen/oscilloscope_image_margin"
-            android:layout_weight="@dimen/oscilloscope_image_weight"
-            android:scaleType="fitCenter"
-            app:srcCompat="@drawable/channel_parameters" />
-
-        <TextView
-            android:id="@+id/tv_channel_parameters_os"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/oscilloscope_text_margin"
-            android:gravity="center"
-            android:text="@string/channel_parameters"
-            android:textAlignment="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/oscilloscope_text_size"
-            android:textStyle="normal|bold"
-            android:background="@color/colorPrimaryDark"/>
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/oscilloscope_divider_line"
-            android:background="@color/outline"/>
-
-        <ImageButton
-            android:id="@+id/button_timebase_os"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_weight="@dimen/oscilloscope_image_weight"
-            android:scaleType="fitCenter"
-            app:srcCompat="@drawable/timebase" />
-
-        <TextView
-            android:id="@+id/tv_timebase_tigger_os"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/oscilloscope_text_margin"
-            android:gravity="center"
-            android:text="@string/timebase_and_trigger"
-            android:textAlignment="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/oscilloscope_text_size"
-            android:textStyle="normal|bold" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/oscilloscope_divider_line"
-            android:background="@color/outline"/>
-
-        <ImageButton
-            android:id="@+id/button_data_analysis_os"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="@dimen/oscilloscope_image_margin"
-            android:layout_weight="@dimen/oscilloscope_image_weight"
-            android:scaleType="fitCenter"
-            app:srcCompat="@drawable/data_analysis" />
-
-        <TextView
-            android:id="@+id/tv_data_analysis_os"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/oscilloscope_text_margin"
-            android:gravity="center"
-            android:maxLines="1"
-            android:text="@string/data_analysis"
-            android:textAlignment="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/oscilloscope_text_size"
-            android:textStyle="normal|bold" />
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/oscilloscope_divider_line"
-            android:background="@color/outline"/>
-
-        <ImageButton
-            android:id="@+id/button_xy_plot_os"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_gravity="center_horizontal"
-            android:layout_margin="@dimen/oscilloscope_image_margin"
-            android:layout_weight="@dimen/oscilloscope_image_weight"
-            android:scaleType="fitCenter"
-            app:srcCompat="@drawable/xymode" />
-
-        <TextView
-            android:id="@+id/tv_xy_plot_os"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/oscilloscope_text_margin"
-            android:layout_marginBottom="@dimen/oscilloscope_divider_line"
-            android:elevation="@dimen/text_elevation"
-            android:gravity="center"
-            android:text="@string/xy_plot"
-            android:textAlignment="center"
-            android:textColor="@color/black"
-            android:textSize="@dimen/oscilloscope_text_size"
-            android:textStyle="normal|bold" />
-
-    </LinearLayout>
-
-    <FrameLayout
-        android:id="@+id/layout_dock_os2"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/layout_chart_os"
-        android:layout_marginLeft="0dp"
-        android:layout_marginStart="0dp"
-        android:layout_toLeftOf="@+id/layout_dock_os1"
-        android:layout_toStartOf="@+id/layout_dock_os1">
-
-    </FrameLayout>
-
-</RelativeLayout>
+    <include layout="@layout/bottom_sheet_oscilloscope" />
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/bottom_sheet_oscilloscope.xml
+++ b/app/src/main/res/layout/bottom_sheet_oscilloscope.xml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/bottom_sheet_oscilloscope"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginLeft="@dimen/bottom_sheet_side_margin"
+    android:layout_marginRight="@dimen/bottom_sheet_side_margin"
+    android:orientation="vertical"
+    app:behavior_hideable="true"
+    app:behavior_peekHeight="@dimen/peek_height"
+    app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/extra_space_top" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/btnsheet_top_section_height"
+        android:background="@drawable/btn_sheet_back"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/img_arrow_oscilloscope"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:background="@color/colorPrimary"
+            android:src="@drawable/ic_arrow_drop_up_white_24dp" />
+
+        <TextView
+            android:id="@+id/sheet_slide_text_oscilloscope"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:text="@string/show_guide_text"
+            android:textColor="@color/white" />
+
+    </LinearLayout>
+
+    <android.support.v4.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/white"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/bottom_sheet_padding">
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/space_length_btm_sheet" />
+
+            <TextView
+                android:id="@+id/guide_title_oscilloscope"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/oscilloscope"
+                android:textSize="@dimen/bottom_sheet_title_text"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/guide_intro_oscilloscope"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:text="@string/oscilloscope_intro" />
+
+            <ImageView
+                android:id="@+id/oscilloscope_schematic"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_image_height"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:contentDescription="@string/schematic_desc"
+                android:src="@drawable/oscilloscope_schematic" />
+
+            <TextView
+                android:id="@+id/guide_desc_oscilloscope"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:background="@color/white"
+                android:text="@string/oscilloscope_desc" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/space_length_btm_sheet" />
+
+            <TextView
+                android:id="@+id/guide_title_channel_parameters"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/channel_parameters"
+                android:textSize="@dimen/bottom_sheet_title_text"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/guide_intro_channel_parameters"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:text="@string/channel_param_desc" />
+
+            <ImageView
+                android:id="@+id/channel_parameters_schematic"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_image_height"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:contentDescription="@string/schematic_desc"
+                android:src="@drawable/mic_schematic" />
+
+            <TextView
+                android:id="@+id/guide_desc_channel_parameters"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:background="@color/white"
+                android:text="@string/channel_param_mic" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/space_length_btm_sheet" />
+
+            <TextView
+                android:id="@+id/guide_title_timebase"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/timebase"
+                android:textSize="@dimen/bottom_sheet_title_text"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/guide_intro_timebase"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:text="@string/timebase_desc" />
+
+            <ImageView
+                android:id="@+id/timebase_view"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_image_height"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:contentDescription="@string/schematic_desc"
+                android:src="@drawable/timebase_view" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/space_length_btm_sheet" />
+
+            <TextView
+                android:id="@+id/guide_title_data_analysis"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/data_analysis"
+                android:textSize="@dimen/bottom_sheet_title_text"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/guide_desc_data_analysis"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:text="@string/data_analysis_desc" />
+
+            <ImageView
+                android:id="@+id/data_analysis_view"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_image_height"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:contentDescription="@string/schematic_desc"
+                android:src="@drawable/data_analysis_view" />
+
+            <Space
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/space_length_btm_sheet" />
+
+            <TextView
+                android:id="@+id/guide_title_xy_plot"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/xy_plot"
+                android:textSize="@dimen/bottom_sheet_title_text"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/guide_desc_xy_plot_desc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:text="@string/xy_plot_desc" />
+
+            <ImageView
+                android:id="@+id/xy_plot_view"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/bottom_sheet_image_height"
+                android:layout_margin="@dimen/bottom_sheet_margin"
+                android:contentDescription="@string/schematic_desc"
+                android:src="@drawable/xy_plot_view" />
+        </LinearLayout>
+    </android.support.v4.widget.NestedScrollView>
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -247,11 +247,19 @@
     <dimen name="stepper_motor_margin">5dp</dimen>
     <dimen name="stepper_motor_text_size">16sp</dimen>
 
-    <dimen name="oscilloscope_text_margin">4dp</dimen>
-    <dimen name="oscilloscope_text_size">12sp</dimen>
-    <dimen name="oscilloscope_image_margin">1dp</dimen>
-    <dimen name="oscilloscope_image_weight">2</dimen>
-    <dimen name="oscilloscope_divider_line">2dp</dimen>
+    <dimen name="osc_chart_width">600dp</dimen>
+    <dimen name="osc_chart_height">300dp</dimen>
+    <dimen name="osc_axis_text_size">9sp</dimen>
+    <dimen name="osc_absolute_x">288dp</dimen>
+    <dimen name="osc_tv_unit_margin">8dp</dimen>
+    <dimen name="osc_text_margin">4dp</dimen>
+    <dimen name="osc_tv_left_axis_height">9dp</dimen>
+    <dimen name="osc_tv_axis_margin">16dp</dimen>
+    <dimen name="osc_text_size">12sp</dimen>
+    <dimen name="osc_image_dimens">15dp</dimen>
+    <dimen name="osc_image_margin">1dp</dimen>
+    <dimen name="osc_image_weight">2</dimen>
+    <dimen name="osc_divider_line">2dp</dimen>
     <dimen name="text_elevation">24dp</dimen>
 
     <dimen name="modified_spinner_height">40dp</dimen>


### PR DESCRIPTION
Fixes #1087 

**Changes**: 
Removed the existing dialog box guide for the oscilloscope and instead added the bottom sheet guide. 

**Screenshot/s for the changes**: 
![screenshot_2018-06-22-02-29-39](https://user-images.githubusercontent.com/17523141/41745508-c8f77dde-75c4-11e8-9c4f-8c720f1efe47.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[oscilloscope_bottom_sheet.zip](https://github.com/fossasia/pslab-android/files/2125324/oscilloscope_bottom_sheet.zip)
containing a demonstration]