### PR TITLE
Adding bottom sheet guide to lux meter

### DIFF
--- a/app/src/main/res/layout/activity_lux_main.xml
+++ b/app/src/main/res/layout/activity_lux_main.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/activity_lux_meter" />
+
+    <View
+        android:id="@+id/shadow"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/black"
+        android:alpha="0"/>
+
+    <include layout="@layout/bottom_sheet_custom" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -868,11 +868,10 @@
 
     <string name="lux_meter">Lux Meter</string>
     <string name="lux_meter_intro">\u2022 The Lux meter can be used to measure the ambient light intensity. This instruments
-    is compatible with either the built in light sensor in your android device or the BH-1750 light sensor.\n\n
+    is compatible with either the built in light sensor on any android device or the BH-1750 light sensor.\n\n
     \u2022 If you want to use the sensor BH-1750, connect the sensor to PSLab device as shown below</string>
     <string name="lux_meter_desc">\u2022 The above pin configuration has to be same except for the pin
-    GND. GND is meant for Ground and you can use any of the PSLab device GND pins as they are common.\n\n
-    \u2022 Then go to the Configure tab from the bottom navigation bar and choose the BH-1750 in the drop down
-    menu Select Sensor.\n</string>
+    GND. GND is meant for Ground and any of the PSLab device GND pins can be used since they are common.\n\n
+    \u2022 Select sensor by going to the Configure tab from the bottom navigation bar and choose BHT-1750 in the drop down menu under Select Sensor.\n</string>
 
 </resources>


### PR DESCRIPTION
First Step to issue #1088 

**Changes**: 
Added the code for the bottom sheet guide replacing the dialog box guide

**Screenshot/s for the changes**:
![screenshot_2018-06-22-12-52-45-497_org fossasia pslab](https://user-images.githubusercontent.com/34381723/41763461-f62ae712-761b-11e8-881c-a2320f8f018f.png)
![screenshot_2018-06-22-12-52-42-158_org fossasia pslab](https://user-images.githubusercontent.com/34381723/41763462-f654e454-761b-11e8-8bd1-8f86ebd1ad41.png)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2126687/app-debug.zip)
