### PR TITLE
fix: Handled crash while only a single point is being fetched in Logic Analyzer

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
@@ -426,22 +426,25 @@ public class LALogicLinesFragment extends Fragment {
             }
 
             // Add data to axis in actual graph
-            if (yaxis.get(1).equals(yaxis.get(0)))
-                tempInput.add(new Entry(xaxis.get(0), yaxis.get(0)));
-            else {
-                tempInput.add(new Entry(xaxis.get(0), yaxis.get(0)));
-                tempInput.add(new Entry(xaxis.get(0), yaxis.get(1)));
-            }
-            for (int i = 1; i < xaxis.size() - 1; i++) {
-                if (yaxis.get(i).equals(yaxis.get(i + 1)))
-                    tempInput.add(new Entry(xaxis.get(i), yaxis.get(i)));
+            if (yaxis.size() > 1) {
+                if (yaxis.get(1).equals(yaxis.get(0)))
+                    tempInput.add(new Entry(xaxis.get(0), yaxis.get(0)));
                 else {
-                    tempInput.add(new Entry(xaxis.get(i), yaxis.get(i)));
-                    tempInput.add(new Entry(xaxis.get(i), yaxis.get(i + 1)));
+                    tempInput.add(new Entry(xaxis.get(0), yaxis.get(0)));
+                    tempInput.add(new Entry(xaxis.get(0), yaxis.get(1)));
                 }
-
+                for (int i = 1; i < xaxis.size() - 1; i++) {
+                    if (yaxis.get(i).equals(yaxis.get(i + 1)))
+                        tempInput.add(new Entry(xaxis.get(i), yaxis.get(i)));
+                    else {
+                        tempInput.add(new Entry(xaxis.get(i), yaxis.get(i)));
+                        tempInput.add(new Entry(xaxis.get(i), yaxis.get(i + 1)));
+                    }
+                }
+                tempInput.add(new Entry(xaxis.get(xaxis.size() - 1), yaxis.get(xaxis.size() - 1)));
+            } else {
+                tempInput.add(new Entry(xaxis.get(0), yaxis.get(0)));
             }
-            tempInput.add(new Entry(xaxis.get(xaxis.size() - 1), yaxis.get(xaxis.size() - 1)));
         }
     }
 
@@ -455,17 +458,19 @@ public class LALogicLinesFragment extends Fragment {
         int check = xaxis;
         int count = 0;
 
-        for (int i = 1; i < xData.length; i++) {
-            xaxis = (int) xData[i];
-            if (xaxis != check) {
-                if (count == 3) {
-                    tempInput.add(new Entry(xaxis, 0));
-                    tempInput.add(new Entry(xaxis, 1));
-                    tempInput.add(new Entry(xaxis, 0));
-                    count = 0;
-                } else
-                    count++;
-                check = xaxis;
+        if (xData.length > 1) {
+            for (int i = 1; i < xData.length; i++) {
+                xaxis = (int) xData[i];
+                if (xaxis != check) {
+                    if (count == 3) {
+                        tempInput.add(new Entry(xaxis, 0));
+                        tempInput.add(new Entry(xaxis, 1));
+                        tempInput.add(new Entry(xaxis, 0));
+                        count = 0;
+                    } else
+                        count++;
+                    check = xaxis;
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1139 

**Changes**: Handled the case of a single data point being fetched using if..else statement

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2138586/app-debug.zip)