### PR TITLE
fix: resolved multiple creation of main activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,7 +35,8 @@
         </activity>
         <activity
             android:name=".activity.MainActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden">
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
             </intent-filter>

--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -33,8 +33,8 @@ import org.fossasia.pslab.R;
 import org.fossasia.pslab.communication.CommunicationHandler;
 import org.fossasia.pslab.fragment.AboutUsFragment;
 import org.fossasia.pslab.fragment.HelpAndFeedbackFragment;
-import org.fossasia.pslab.fragment.InstrumentsFragment;
 import org.fossasia.pslab.fragment.HomeFragment;
+import org.fossasia.pslab.fragment.InstrumentsFragment;
 import org.fossasia.pslab.fragment.PSLabPinLayoutFragment;
 import org.fossasia.pslab.fragment.SettingsFragment;
 import org.fossasia.pslab.others.CustomTabService;
@@ -305,8 +305,8 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
         if (fragment instanceof HomeFragment && HomeFragment.isWebViewShowing) {
-                ((HomeFragment) fragment).hideWebView();
-                 return;
+            ((HomeFragment) fragment).hideWebView();
+            return;
         }
         if (shouldLoadHomeFragOnBackPress) {
             if (navItemIndex != 0 || CURRENT_TAG.equals(TAG_PINLAYOUT)) {
@@ -457,4 +457,24 @@ public class MainActivity extends AppCompatActivity {
             }
         }
     };
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        attemptToConnectPSLab();
+        synchronized (this) {
+            UsbDevice device = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+            if (device != null && hasPermission) {
+                PSLabisConnected = mScienceLabCommon.openDevice(communicationHandler);
+                initialisationDialog.dismiss();
+                invalidateOptionsMenu();
+                if (navItemIndex == 0) {
+                    getSupportFragmentManager().beginTransaction().replace(R.id.frame, InstrumentsFragment.newInstance()).commit();
+                } else if (navItemIndex == 1) {
+                    getSupportFragmentManager().beginTransaction().replace(R.id.frame, HomeFragment.newInstance(true, true)).commitAllowingStateLoss();
+                }
+                Toast.makeText(getApplicationContext(), getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1123 

**Changes**: Made main activity launch mode "singleTask" and override the OnNewIntent method to reuse the current main activity.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2141105/app-debug.zip)
