### PR TITLE
fix: Solved the bug in setting mode for Single Channel in Logic Analyzer

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LALogicLinesFragment.java
@@ -595,27 +595,11 @@ public class LALogicLinesFragment extends Fragment {
         @Override
         protected Void doInBackground(String... params) {
             try {
-                scienceLab.startOneChannelLA(params[0], 1, params[0], 3);
-
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-
-                LinkedHashMap<String, Integer> data = scienceLab.getLAInitialStates();
-
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-
                 int channelNumber = scienceLab.calculateDigitalChannel(params[0]);
-
                 digitalChannel = scienceLab.getDigitalChannel(channelNumber);
                 edgeOption = params[1];
-                switch (params[1]) {
+
+                switch (edgeOption) {
                     case "EVERY EDGE":
                         digitalChannel.mode = EVERY_EDGE;
                         break;
@@ -634,6 +618,23 @@ public class LALogicLinesFragment extends Fragment {
                     default:
                         digitalChannel.mode = EVERY_EDGE;
                 }
+
+                scienceLab.startOneChannelLA(params[0], digitalChannel.mode, params[0], 3);
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+
+                LinkedHashMap<String, Integer> data = scienceLab.getLAInitialStates();
+
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+
                 holder = scienceLab.fetchLAChannel(channelNumber, data);
 
             } catch (NullPointerException e) {


### PR DESCRIPTION
Fixes #1160 

**Changes**: Solved the bug in setting mode for Single Channel in Logic Analyzer

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:  
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2150486/app-debug.zip)