### PR TITLE
fix: smoothing lux meter data plot

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
@@ -162,6 +162,7 @@ public class LuxMeterFragmentData extends Fragment {
         dataThread.start();
 
         lightMeter.setMaxSpeed(10000);
+        lightMeter.setWithTremble(false);
 
         XAxis x = mChart.getXAxis();
         this.y = mChart.getAxisLeft();
@@ -220,7 +221,7 @@ public class LuxMeterFragmentData extends Fragment {
                     data = sensorBH1750.getRaw().floatValue();
                     sensorManager.unregisterListener(this);
                 } else if (sensor != null) {
-                    sensorManager.registerListener(this, sensor, SensorManager.SENSOR_DELAY_NORMAL);
+                    sensorManager.registerListener(this, sensor, updatePeriod);
                 }
             } catch (IOException e) {
                 e.printStackTrace();
@@ -239,7 +240,6 @@ public class LuxMeterFragmentData extends Fragment {
         @Override
         public void onSensorChanged(SensorEvent event) {
             data = Float.valueOf(df.format(event.values[0]));
-            visualizeData();
             unRegisterListener();
         }
 
@@ -291,8 +291,6 @@ public class LuxMeterFragmentData extends Fragment {
 
             mChart.setData(data);
             mChart.notifyDataSetChanged();
-            mChart.setVisibleXRangeMaximum(10);
-            mChart.moveViewToX(data.getEntryCount());
             mChart.invalidate();
         }
 


### PR DESCRIPTION
Fixes #1170 

**Changes**: 
- Smooth plot according to the given update period. 
- Chart shows full history rather than showing only 10 data points 

**Screenshot/s for the changes**: 
![screenshot_2018-07-06-09-59-43](https://user-images.githubusercontent.com/17523141/42360098-3324dea0-8104-11e8-9a84-c198335bc5ef.png)


**Checklist**: 
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [ ] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [ ] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[lux_meter_smoothing.zip](https://github.com/fossasia/pslab-android/files/2169030/lux_meter_smoothing.zip)
