### PR TITLE
fix : implemented setting fragment inside setting activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,7 +11,6 @@
     <uses-feature
         android:name="android.hardware.sensor.light"
         android:required="true" />
-
     <uses-feature android:name="android.hardware.usb.host" />
 
     <application
@@ -26,13 +25,11 @@
             android:name=".activity.SplashActivity"
             android:screenOrientation="portrait"
             android:theme="@style/AppThemeSplash">
-
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
         </activity>
         <activity
             android:name=".activity.MainActivity"
@@ -46,6 +43,9 @@
                 android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
                 android:resource="@xml/device_filter" />
         </activity>
+
+        <activity android:name=".activity.SettingsActivity"/>
+
         <activity android:name=".activity.ShowLoggedData" />
         <activity
             android:name=".activity.PerformExperimentActivity"
@@ -61,25 +61,22 @@
         <activity
             android:name=".activity.LogicalAnalyzerActivity"
             android:configChanges="screenSize|orientation"
-            android:screenOrientation="landscape"/>
+            android:screenOrientation="landscape" />
         <activity android:name=".activity.SensorDataLoggerActivity" />
-
-        <activity android:name=".activity.MultimeterActivity"
-            android:screenOrientation="portrait"/>
-
+        <activity
+            android:name=".activity.MultimeterActivity"
+            android:screenOrientation="portrait" />
         <activity
             android:name=".activity.PowerSourceActivity"
-            android:windowSoftInputMode="stateHidden|adjustResize"
-            android:screenOrientation="portrait" />
-
-        <activity android:name=".activity.WaveGeneratorActivity"
-            android:screenOrientation="userLandscape"/>
-
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="stateHidden|adjustResize" />
+        <activity
+            android:name=".activity.WaveGeneratorActivity"
+            android:screenOrientation="userLandscape" />
         <activity
             android:name=".activity.LuxMeterActivity"
             android:configChanges="orientation|screenSize|keyboardHidden" />
-
-        <activity android:name=".activity.AccelerometerActivity"/>
+        <activity android:name=".activity.AccelerometerActivity" />
 
         <activity
             android:name=".activity.Barometer_activity"

--- a/app/src/main/java/org/fossasia/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/LuxMeterActivity.java
@@ -69,7 +69,7 @@ public class LuxMeterActivity extends AppCompatActivity {
 
     public boolean saveData = false;
     public GPSLogger gpsLogger;
-    private boolean isloggingLocation = false;
+    private boolean checkGpsOnResume = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -201,7 +201,7 @@ public class LuxMeterActivity extends AppCompatActivity {
                             saveData = true;
                             CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start), null, null);
                         } else {
-                            isloggingLocation = true;
+                            checkGpsOnResume = true;
                         }
                         gpsLogger.startFetchingLocation();
                     }
@@ -211,6 +211,9 @@ public class LuxMeterActivity extends AppCompatActivity {
             case R.id.show_map:
                 Intent MAP = new Intent(getApplicationContext(), MapsActivity.class);
                 startActivity(MAP);
+                break;
+            case R.id.settings:
+                startActivity(new Intent(this, SettingsActivity.class));
                 break;
             default:
                 break;
@@ -229,7 +232,7 @@ public class LuxMeterActivity extends AppCompatActivity {
                         saveData = true;
                         CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start), null, null);
                     } else {
-                        isloggingLocation = true;
+                        checkGpsOnResume = true;
                     }
                     gpsLogger.startFetchingLocation();
                 } else {
@@ -242,7 +245,7 @@ public class LuxMeterActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        if (isloggingLocation) {
+        if (checkGpsOnResume) {
             if (gpsLogger.isGPSEnabled()) {
                 saveData = true;
                 CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start), null, null);

--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -36,7 +36,6 @@ import org.fossasia.pslab.fragment.HelpAndFeedbackFragment;
 import org.fossasia.pslab.fragment.HomeFragment;
 import org.fossasia.pslab.fragment.InstrumentsFragment;
 import org.fossasia.pslab.fragment.PSLabPinLayoutFragment;
-import org.fossasia.pslab.fragment.SettingsFragment;
 import org.fossasia.pslab.others.CustomTabService;
 import org.fossasia.pslab.others.InitializationVariable;
 import org.fossasia.pslab.others.ScienceLabCommon;
@@ -185,7 +184,7 @@ public class MainActivity extends AppCompatActivity {
             case 1:
                 return HomeFragment.newInstance(ScienceLabCommon.scienceLab.isConnected(), ScienceLabCommon.scienceLab.isDeviceFound());
             case 2:
-                return SettingsFragment.newInstance();
+                return null;
             case 3:
                 return AboutUsFragment.newInstance();
             case 4:
@@ -218,7 +217,9 @@ public class MainActivity extends AppCompatActivity {
             }
         }
         switch (navItemIndex) {
-            case 0: case 1: case 2:
+            case 0:
+            case 1:
+            case 2:
                 navigationView.getMenu().getItem(navItemIndex).setChecked(true);
                 break;
             case 3:
@@ -247,9 +248,11 @@ public class MainActivity extends AppCompatActivity {
                         CURRENT_TAG = TAG_DEVICE;
                         break;
                     case R.id.nav_settings:
-                        navItemIndex = 2;
-                        CURRENT_TAG = TAG_SETTINGS;
-                        break;
+                        if (drawer != null) {
+                            drawer.closeDrawers();
+                        }
+                        startActivity(new Intent(MainActivity.this, SettingsActivity.class));
+                        return true;
                     case R.id.nav_about_us:
                         navItemIndex = 3;
                         CURRENT_TAG = TAG_ABOUTUS;
@@ -476,5 +479,11 @@ public class MainActivity extends AppCompatActivity {
                 Toast.makeText(getApplicationContext(), getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
             }
         }
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
+        selectNavMenu();
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SettingsActivity.java
@@ -1,0 +1,57 @@
+package org.fossasia.pslab.activity;
+
+import android.os.Bundle;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
+import android.widget.FrameLayout;
+
+import org.fossasia.pslab.R;
+import org.fossasia.pslab.fragment.SettingsFragment;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.Unbinder;
+
+/**
+ * Created by Avjeet on 7/7/18.
+ */
+
+public class SettingsActivity extends AppCompatActivity {
+    @BindView(R.id.setting_toolbar)
+    Toolbar toolbar;
+    @BindView(R.id.content)
+    FrameLayout content;
+    private Unbinder unBinder;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+        unBinder = ButterKnife.bind(this);
+
+        setSupportActionBar(toolbar);
+        ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeAsUpIndicator(R.drawable.ic_arrow_back_white_24dp);
+            actionBar.setDisplayHomeAsUpEnabled(true);
+            actionBar.setTitle(R.string.nav_settings);
+        }
+        getSupportFragmentManager().beginTransaction().add(R.id.content, new SettingsFragment()).commit();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        unBinder.unbind();
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_back_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#F9FBFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <android.support.design.widget.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/AppTheme.AppBarOverlay">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/setting_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/AppTheme.PopupOverlay" />
+
+    </android.support.design.widget.AppBarLayout>
+
+    <FrameLayout
+        android:id="@+id/content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/menu/data_log_menu.xml
+++ b/app/src/main/res/menu/data_log_menu.xml
@@ -11,4 +11,9 @@
         android:icon="@drawable/menu_icon_map"
         android:title="@string/view_map"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/settings"
+        android:title="@string/nav_settings"
+        app:showAsAction="never" />
 </menu>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,12 @@
     <string name="power_source">Power Source</string>
     <string name="coming_soon">Coming Soon!</string>
 
+    <string name="setting_auto_start_key">setting_auto_start</string>
+    <string name="setting_auto_start_summary">Auto start app when PSLab device is connected</string>
+    <string name="settting_auto_start_title">Auto Start</string>
+    <string name="setting_data_format_key">export_data_format_list</string>
+    <string name="setting_data_format_title">Export Data Format</string>
+
     <string name="control_item_1">Control</string>
     <string name="control_item_2">Read</string>
     <string name="control_item_3">Advanced</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -18,7 +18,13 @@
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light">
+        <item name="android:actionOverflowButtonStyle">@style/actionOverflowButtonStyle</item>
+    </style>
+
+    <style name="actionOverflowButtonStyle" parent="@style/Widget.AppCompat.ActionButton.Overflow">
+        <item name="android:tint">@color/white</item>
+    </style>
 
     <style name="AppTheme.BottomNavigationBar" parent="Theme.AppCompat.Light">
         <item name="colorControlHighlight">@color/black</item>

--- a/app/src/main/res/xml/settings_preference_fragment.xml
+++ b/app/src/main/res/xml/settings_preference_fragment.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-    <PreferenceCategory android:title="App Settings">
+    <PreferenceCategory android:title="General">
         <CheckBoxPreference
             android:defaultValue="true"
-            android:key="setting_auto_start"
-            android:summary="Auto start app when PSLab device is connected"
-            android:title="Auto Start" />
+            android:key="@string/setting_auto_start_key"
+            android:summary="@string/setting_auto_start_summary"
+            android:title="@string/settting_auto_start_title" />
     </PreferenceCategory>
 
-    <ListPreference
-        android:defaultValue="0"
-        android:entries="@array/export_data_format_list"
-        android:entryValues="@array/export_data_format_values"
-        android:key="export_data_format_list"
-        android:title="Export Data Format" />
+    <PreferenceCategory android:title="Data Logging">
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/export_data_format_list"
+            android:entryValues="@array/export_data_format_values"
+            android:key="@string/setting_data_format_key"
+            android:title="@string/setting_data_format_title" />
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #1196 
First steps in #1195 

**Changes**: 

- Created new setting activity
- Implemented setting fragment inside setting activity
- Created setting option in menu for lux meter
- Clicking setting in navigation now opens setting activity

Now setting activity can be opened through any activity by simply using intents.

**To do in further PR**

- Create checkbox option in settings fragment to include the location in the csv file for sensors

**Screenshot/s for the changes**: 
setting option in overflow menu
![image](https://user-images.githubusercontent.com/20573611/42410729-3d56c6aa-820c-11e8-9c95-0967b4749ef4.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[avi_setting.zip](https://github.com/fossasia/pslab-android/files/2173511/avi_setting.zip)


