### PR TITLE
feat: added switch in settings fragment to on/off location

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/LuxMeterActivity.java
@@ -3,7 +3,6 @@ package org.fossasia.pslab.activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.os.Handler;
@@ -14,6 +13,7 @@ import android.support.design.widget.CoordinatorLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
 import android.view.GestureDetector;
 import android.view.Menu;
@@ -29,6 +29,7 @@ import android.widget.Toast;
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.fragment.LuxMeterFragmentConfig;
 import org.fossasia.pslab.fragment.LuxMeterFragmentData;
+import org.fossasia.pslab.fragment.SettingsFragment;
 import org.fossasia.pslab.others.CustomSnackBar;
 import org.fossasia.pslab.others.GPSLogger;
 import org.fossasia.pslab.others.MathUtils;
@@ -70,6 +71,7 @@ public class LuxMeterActivity extends AppCompatActivity {
     public boolean saveData = false;
     public GPSLogger gpsLogger;
     private boolean checkGpsOnResume = false;
+    public boolean locationPref;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -190,20 +192,23 @@ public class LuxMeterActivity extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        gpsLogger = new GPSLogger(this, (LocationManager) getSystemService(Context.LOCATION_SERVICE));
         switch (item.getItemId()) {
             case R.id.save_csv_data:
                 if (saveData) {
                     saveData = false;
                 } else {
-                    if (gpsLogger.checkPermission()) {
+                    if (locationPref) {
+                        gpsLogger = new GPSLogger(this, (LocationManager) getSystemService(Context.LOCATION_SERVICE));
                         if (gpsLogger.isGPSEnabled()) {
                             saveData = true;
-                            CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start), null, null);
+                            CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start) + "\n" + getString(R.string.location_enabled), null, null);
                         } else {
                             checkGpsOnResume = true;
                         }
                         gpsLogger.startFetchingLocation();
+                    } else {
+                        saveData = true;
+                        CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start) + "\n" + getString(R.string.location_disabled), null, null);
                     }
                 }
                 invalidateOptionsMenu();
@@ -222,27 +227,6 @@ public class LuxMeterActivity extends AppCompatActivity {
     }
 
     @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case GPSLogger.MY_PERMISSIONS_REQUEST_LOCATION: {
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    GPSLogger.permissionAvailable = true;
-                    if (gpsLogger.isGPSEnabled()) {
-                        saveData = true;
-                        CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_start), null, null);
-                    } else {
-                        checkGpsOnResume = true;
-                    }
-                    gpsLogger.startFetchingLocation();
-                } else {
-                    GPSLogger.permissionAvailable = false;
-                }
-            }
-        }
-    }
-
-    @Override
     protected void onResume() {
         super.onResume();
         if (checkGpsOnResume) {
@@ -255,5 +239,6 @@ public class LuxMeterActivity extends AppCompatActivity {
                         Toast.LENGTH_SHORT).show();
             }
         }
+        locationPref = PreferenceManager.getDefaultSharedPreferences(getBaseContext()).getBoolean(SettingsFragment.KEY_INCLUDE_LOCATION, false);
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/activity/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/SettingsActivity.java
@@ -1,14 +1,19 @@
 package org.fossasia.pslab.activity;
 
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.PreferenceManager;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.widget.FrameLayout;
 
 import org.fossasia.pslab.R;
 import org.fossasia.pslab.fragment.SettingsFragment;
+import org.fossasia.pslab.others.GPSLogger;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -38,7 +43,9 @@ public class SettingsActivity extends AppCompatActivity {
             actionBar.setDisplayHomeAsUpEnabled(true);
             actionBar.setTitle(R.string.nav_settings);
         }
-        getSupportFragmentManager().beginTransaction().add(R.id.content, new SettingsFragment()).commit();
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction().add(R.id.content, new SettingsFragment()).commit();
+        }
     }
 
     @Override
@@ -50,8 +57,22 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     @Override
-    protected void onStop() {
-        super.onStop();
+    protected void onDestroy() {
+        super.onDestroy();
         unBinder.unbind();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case GPSLogger.MY_PERMISSIONS_REQUEST_LOCATION: {
+                if (grantResults.length <= 0
+                        || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+                    SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(getBaseContext()).edit();
+                    editor.putBoolean(SettingsFragment.KEY_INCLUDE_LOCATION, false);
+                    editor.commit();
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
@@ -326,12 +326,17 @@ public class LuxMeterFragmentData extends Fragment {
                             if (logged) {
                                 writeHeader = false;
                                 logged = false;
-                                Location location = gpsLogger.getBestLocation();
-                                if (location != null) {
-                                    String data = "\nLocation" + "," + String.valueOf(location.getLatitude()) + "," + String.valueOf(location.getLongitude() + "\n");
+                                if (parent.locationPref && gpsLogger != null) {
+                                    String data;
+                                    Location location = gpsLogger.getBestLocation();
+                                    if (location != null) {
+                                        data = "\nLocation" + "," + String.valueOf(location.getLatitude()) + "," + String.valueOf(location.getLongitude() + "\n");
+                                    } else {
+                                        data = "\nLocation" + "," + "null" + "," + "null";
+                                    }
                                     lux_logger.writeCSVFile(data);
+                                    gpsLogger.removeUpdate();
                                 }
-                                gpsLogger.removeUpdate();
                                 CustomSnackBar.showSnackBar((CoordinatorLayout) parent.findViewById(R.id.cl),
                                         getString(R.string.csv_store_text) + " " + lux_logger.getCurrentFilePath()
                                         , getString(R.string.delete_capital), new View.OnClickListener() {

--- a/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/SettingsFragment.java
@@ -1,11 +1,17 @@
 package org.fossasia.pslab.fragment;
 
+import android.Manifest;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
+import android.support.v7.preference.PreferenceManager;
 
 import org.fossasia.pslab.R;
+import org.fossasia.pslab.others.GPSLogger;
 
 /**
  * Created by viveksb007 on 15/3/17.
@@ -14,7 +20,10 @@ import org.fossasia.pslab.R;
 public class SettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
 
     public static final String KEY_EXPORT_DATA_FORMAT_LIST = "export_data_format_list";
+    public static final String KEY_INCLUDE_LOCATION = "include_location_sensor_data";
     private ListPreference listPreference;
+    private CheckBoxPreference locationPreference;
+    private SharedPreferences sharedPref ;
 
     public static SettingsFragment newInstance() {
         return new SettingsFragment();
@@ -27,12 +36,25 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.settings_preference_fragment, rootKey);
         listPreference = (ListPreference) getPreferenceScreen().findPreference(KEY_EXPORT_DATA_FORMAT_LIST);
+        locationPreference = (CheckBoxPreference) getPreferenceScreen().findPreference(KEY_INCLUDE_LOCATION);
+        sharedPref = PreferenceManager.getDefaultSharedPreferences(getActivity());
+
+        /* If permission is disabled explicitly then this will put false in location preference */
+
+        if (ContextCompat.checkSelfPermission(getActivity(),
+                Manifest.permission.ACCESS_FINE_LOCATION)
+                != PackageManager.PERMISSION_GRANTED){
+            SharedPreferences.Editor editor = sharedPref.edit();
+            editor.putBoolean(SettingsFragment.KEY_INCLUDE_LOCATION,false);
+            editor.commit();
+        }
     }
 
     @Override
     public void onResume() {
         super.onResume();
         listPreference.setSummary("Current format is " + listPreference.getEntry().toString());
+        locationPreference.setChecked(sharedPref.getBoolean(KEY_INCLUDE_LOCATION,false));
         getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
     }
 
@@ -46,6 +68,10 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Shared
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
         if (KEY_EXPORT_DATA_FORMAT_LIST.equals(key)) {
             listPreference.setSummary("Current format is " + listPreference.getEntry().toString());
+        }
+
+        if(KEY_INCLUDE_LOCATION.equals(key) && locationPreference.isChecked()){
+            new GPSLogger(getActivity()).requestPermissionIfNotGiven();
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -898,8 +898,7 @@
 
     <string name="save_csv_data">Save CSV Data</string>
     <string name="view_map">View Map</string>
-    <string name="data_recording_start">Data recording started</string>
-    <string name="data_recording_stop">Data recording stopped</string>
+    <string name="data_recording_start">Data Recording: Started</string>
     <string name="csv_store_text">CSV file stored at </string>
 
     <string name="delete_warning">Are you sure you want to delete this file?</string>
@@ -909,6 +908,8 @@
     <string name="gps_not_enabled">GPS not enabled</string>
     <string name="allow_gps">Allow GPS</string>
     <string name="allow_gps_info">Please turn on GPS to include the current location in the logged file</string>
+    <string name="location_enabled">Location: Enabled </string>
+    <string name="location_disabled">Location: Disabled </string>
 
     <string name="show_guide_text">Show Guide</string>
     <string name="hide_guide_text">Hide Guide</string>

--- a/app/src/main/res/xml/settings_preference_fragment.xml
+++ b/app/src/main/res/xml/settings_preference_fragment.xml
@@ -15,6 +15,12 @@
             android:entryValues="@array/export_data_format_values"
             android:key="@string/setting_data_format_key"
             android:title="@string/setting_data_format_title" />
+
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="include_location_sensor_data"
+            android:summary="Include the location data in the logged file"
+            android:title="Include Location Data" />
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Fixes #1195 
Next step of PR #1197 
**Changes**:

- Added checkbox in setting activity to on/off location in sensors

- Removed onRequestPermissionResult from luxmeter activity and included in setting activity so that any 
  further sensor instrument can be easily connected with GPS logger without worrying for location 
  permission.

**Screenshot/s for the changes**: 
![image](https://user-images.githubusercontent.com/20573611/42418337-768fb526-82bb-11e8-9333-08cdf7c7e735.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[switch.zip](https://github.com/fossasia/pslab-android/files/2201145/switch.zip)


