### PR TITLE
fix: added permission check for storage in lux meter

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -910,6 +910,7 @@
     <string name="allow_gps_info">Please turn on GPS to include the current location in the logged file</string>
     <string name="location_enabled">Location: Enabled </string>
     <string name="location_disabled">Location: Disabled </string>
+    <string name="prmsn_denied_storage">Permission denied for storage</string>
 
     <string name="show_guide_text">Show Guide</string>
     <string name="hide_guide_text">Hide Guide</string>


### PR DESCRIPTION
Fixes #1202 

**Changes**: 
Added check for permission when the save button is clicked, if permission is not given it will prompt the user to give the permission.

**Screenshot/s for the changes**: 
![image](https://user-images.githubusercontent.com/20573611/42564716-1fedb6f8-851f-11e8-8e61-2346c5845c20.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[storage.zip](https://github.com/fossasia/pslab-android/files/2209656/storage.zip)

