### PR TITLE
Solved bug in voltage measurement in Oscilloscope instrument

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/ScienceLab.java
@@ -905,8 +905,8 @@ public class ScienceLab {
             Log.v(TAG, "Channel Unavailable");
             return false;
         }
-        Log.v("fetchChannel", "samples" + samples);
-        Log.v("fetchCHannel", "dataSplitting" + this.dataSplitting);
+        Log.v("Samples", "" + samples);
+        Log.v("Data Splitting", "" + this.dataSplitting);
         ArrayList<Integer> listData = new ArrayList<>();
         try {
             for (int i = 0; i < samples / this.dataSplitting; i++) {

--- a/app/src/main/java/org/fossasia/pslab/communication/analogChannel/AnalogInputSource.java
+++ b/app/src/main/java/org/fossasia/pslab/communication/analogChannel/AnalogInputSource.java
@@ -102,8 +102,8 @@ public class AnalogInputSource {
             B /= gain;
             A /= gain;
         }
-        slope = B - A;
-        intercept = A;
+        slope = 2 * (B - A);
+        intercept = 2 * A;
         if (!calibrationReady || gain == 8) {
             calPoly10 = new PolynomialFunction(new double[]{intercept, slope / 1023, 0.});
             calPoly12 = new PolynomialFunction(new double[]{intercept, slope / 4095, 0.});


### PR DESCRIPTION
Fixes #1203 

**Changes**: Doubled the output shown by the oscilloscope to match the exact input voltage

**Screenshot/s for the changes**: 

V+
![screenshot_20180713-171615](https://user-images.githubusercontent.com/32356267/42690201-ffde5392-86c0-11e8-8f8f-5768ae6d1003.jpg)

V-
![screenshot_20180713-171621](https://user-images.githubusercontent.com/32356267/42690200-ffb1555e-86c0-11e8-8f69-e0ef54ee95ac.jpg)

VR+
![screenshot_20180713-171630](https://user-images.githubusercontent.com/32356267/42690199-ff7f77f0-86c0-11e8-8d27-beea6fb3adbb.jpg)

VR-
![screenshot_20180713-171639](https://user-images.githubusercontent.com/32356267/42690198-ff43aaa4-86c0-11e8-8010-6f9353188f34.jpg)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2192528/app-debug.zip)

