### PR TITLE
fix: resolved spacing issue in bottomsheet

### DIFF
--- a/app/src/main/res/layout/bottom_sheet_custom.xml
+++ b/app/src/main/res/layout/bottom_sheet_custom.xml
@@ -13,7 +13,11 @@
 
     <Space
         android:layout_width="match_parent"
-        android:layout_height="@dimen/extra_space_top" />
+        android:layout_height="?attr/actionBarSize" />
+
+    <Space
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize" />
 
     <LinearLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #1246 
**Changes**: Added two space attribute in for spacing on top of custom_bottom_sheet_layout

**Screenshot/s for the changes**: 
![image](https://user-images.githubusercontent.com/20573611/42902567-bd71cde2-8aec-11e8-9280-b8371cf24382.png)




**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [spacing.zip](https://github.com/fossasia/pslab-android/files/2207018/spacing.zip)
