### PR TITLE
Adding app version in the drawer menu

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
+++ b/app/src/main/java/org/fossasia/pslab/activity/MainActivity.java
@@ -267,6 +267,15 @@ public class MainActivity extends AppCompatActivity {
                             drawer.closeDrawers();
                         }
                         break;
+                    case R.id.nav_app_version:
+                        setTitleColor(R.color.gray);
+                        getTitle();
+                        try {
+                            setTitle(scienceLab.getVersion());
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                        break;
                     default:
                         navItemIndex = 0;
                 }

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -4,7 +4,7 @@
         <item
             android:id="@+id/nav_instruments"
             android:icon="@drawable/ic_apps_black_24dp"
-            android:title="@string/nav_instruments"/>
+            android:title="@string/nav_instruments" />
         <item
             android:id="@+id/nav_device"
             android:icon="@drawable/ic_developer_board_black_24dp"
@@ -29,6 +29,11 @@
                 android:id="@+id/nav_report_us"
                 android:icon="@drawable/ic_bug_report_black_24dp"
                 android:title="@string/nav_report" />
+            <item
+                android:id="@+id/nav_app_version"
+                android:checkable="false"
+                android:icon="@drawable/about_icon_google_play"
+                android:title="@string/app_version" />
         </menu>
     </item>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <string name="app_name">PSLab</string>
+    <string name="app_version">Version: 1.1.14</string>
     <string name="navigation_drawer_open">Open navigation drawer</string>
     <string name="navigation_drawer_close">Close navigation drawer</string>
     <string name="openDrawer">open_drawer</string>


### PR DESCRIPTION
Fixes #1231 

**Changes**: 
Added app version in the drawer menu of the app

**Screenshot/s for the changes**: 
<img src = "https://user-images.githubusercontent.com/34381723/42998653-7e21edbe-8c38-11e8-912b-9fd6301f7875.png" width = "300">

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app_version.zip](https://github.com/fossasia/pslab-android/files/2213551/app_version.zip)
