### PR TITLE
fix: solved scroll issue in lux meter fragment

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/others/CustomScrollView.java
+++ b/app/src/main/java/org/fossasia/pslab/others/CustomScrollView.java
@@ -1,0 +1,42 @@
+package org.fossasia.pslab.others;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+import android.widget.ScrollView;
+
+/**
+ * Created by Avjeet on 20-07-2018.
+ */
+public class CustomScrollView extends ScrollView {
+    public CustomScrollView(Context context) {
+        super(context);
+    }
+
+    public CustomScrollView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public CustomScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public boolean onInterceptTouchEvent(MotionEvent event) {
+        return super.onInterceptTouchEvent(event);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        View view = (View) getChildAt(getChildCount() - 1);
+        int diff = (view.getBottom() - (getHeight() + getScrollY()));
+
+        if (event.getAction() == MotionEvent.ACTION_DOWN) {
+            if (diff == 0) {
+                return false;
+            }
+        }
+        return super.onTouchEvent(event);
+    }
+}

--- a/app/src/main/res/layout/fragment_lux_meter_data.xml
+++ b/app/src/main/res/layout/fragment_lux_meter_data.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<org.fossasia.pslab.others.CustomScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:id="@+id/scrollview">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -261,4 +262,4 @@
 
     </LinearLayout>
 
-</ScrollView>
+</org.fossasia.pslab.others.CustomScrollView>


### PR DESCRIPTION
Fixes #1262 

**Changes**: Created custom scroll view with overriden onTouchEvent() which passes the touch event to the parent at the bottom

**Screenshot/s for the changes**: `Not a UI change`

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[scroll_btm.zip](https://github.com/fossasia/pslab-android/files/2216038/scroll_btm.zip)
