### PR TITLE
fix: removed redundant appetize.io calls

### DIFF
--- a/upload-apk.sh
+++ b/upload-apk.sh
@@ -52,11 +52,6 @@ git branch -m apk
 #push to the branch apk
 git push origin apk --force --quiet> /dev/null
 
-if [ "$TRAVIS_PULL_REQUEST" == "false" ]
-then 
-curl https://$APPETIZE_API_TOKEN@api.appetize.io/v1/apps/4eqye6ea422e5np0gp2jfpemgm -H 'Content-Type: application/json' -d '{"url":"https://github.com/fossasia/pslab-android/blob/apk/app-debug.apk", "note": "PSLab Android App Update"}' 
-fi
-
 # Publish App to Play Store
 if [ "$TRAVIS_BRANCH" != "$PUBLISH_BRANCH" ]; then
     exit 0


### PR DESCRIPTION
Fixes #1263 

**Changes**:
- Appetize io has been removed from usage and the reference was still there in travis build scripts. Removed it in this fix

**Screenshot/s for the changes**: 
> Not available

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [X] I have requested reviews from other members

**APK for testing**: 
> Not available
