### PR TITLE
fix: lux meter crash log from Google Play

### DIFF
--- a/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
+++ b/app/src/main/java/org/fossasia/pslab/fragment/LuxMeterFragmentData.java
@@ -1,5 +1,6 @@
 package org.fossasia.pslab.fragment;
 
+import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.graphics.Color;
@@ -284,6 +285,7 @@ public class LuxMeterFragmentData extends Fragment {
             unRegisterListener();
         }
 
+        @SuppressLint("SetTextI18n")
         private void visualizeData() {
             if (currentMax < data) {
                 currentMax = data;
@@ -361,7 +363,11 @@ public class LuxMeterFragmentData extends Fragment {
                         count++;
                         sum += item.getY();
                     }
-                    statMean.setText(Float.toString(Float.valueOf(df.format(sum / count))));
+                    try {
+                        statMean.setText(Float.toString(Float.valueOf(df.format(sum / count))));
+                    } catch (NumberFormatException e) {
+                        statMean.setText(getString(R.string.lux_meter_none));
+                    }
 
                     LineDataSet dataSet = new LineDataSet(entries, getString(R.string.lux));
                     LineData data = new LineData(dataSet);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -917,6 +917,7 @@
         <item>1000</item>
         <item>4000</item>
     </string-array>
+    <string name="lux_meter_none">None</string>
 
     <string name="save_csv_data">Save CSV Data</string>
     <string name="view_map">View Map</string>


### PR DESCRIPTION
Fixes #1295 

**Changes**: 
- Added a try catch to crash point logged in Google Play crash reports

**Screenshot/s for the changes**: 
> Not available

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [X] I have requested reviews from other members

**APK for testing**:
[luxfix.apk.zip](https://github.com/fossasia/pslab-android/files/2235493/luxfix.apk.zip)

