### PR TITLE
Solved issue of convention in compass

### DIFF
--- a/app/src/main/java/io/pslab/activity/CompassActivity.java
+++ b/app/src/main/java/io/pslab/activity/CompassActivity.java
@@ -152,9 +152,13 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
         switch (direction) {
             case 0:
                 degree = Math.round(event.values[1]);
+                if (degree < 0)
+                    degree += 360;
                 break;
             case 1:
                 degree = Math.round(event.values[2]);
+                if (degree < 0)
+                    degree += 360;
                 break;
             case 2:
                 degree = Math.round(event.values[0]);


### PR DESCRIPTION
Fixes #1335 

**Changes**:
Solved the problem of convention in compass

**Screenshot/s for the changes**: [Add screenshot/s of the layout where you made changes or a `*.gif` containing a demonstration]
<img src="https://user-images.githubusercontent.com/32960257/43721225-de998088-99af-11e8-90f3-f6f15778af2b.png" width="300px"/> 



**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [Compress the `app-debug.apk` file into a `<feature>.rar` or `<feature>.zip` file and upload it here]
[compass.apk.zip](https://github.com/fossasia/pslab-android/files/2262850/compass.apk.zip)
