### PR TITLE
fix: Solved the issue of file creation on record button click in Lux Meter

### DIFF
--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -299,6 +299,15 @@ public class LuxMeterActivity extends AppCompatActivity {
     }
 
     @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if(recordingStarted) {
+            luxLogger.deleteFile();
+            recordingStarted = false;
+        }
+    }
+
+    @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == MY_PERMISSIONS_REQUEST_STORAGE_FOR_DATA) {
             if (grantResults.length > 0


### PR DESCRIPTION
Fixes #1341 

**Changes**: Added code to delete the file as soon as the instrument is closed if it isn't exported

**Screenshot/s for the changes**
![20180809_020250](https://user-images.githubusercontent.com/32356267/43862894-a716d622-9b78-11e8-8ae7-a4fed48d4837.gif)

**Checklist**: [Please tick following check boxes with `[]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2271920/app-debug.zip)


