### PR TITLE
Solved issue of active screen while bottom sheet is up

### DIFF
--- a/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
+++ b/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
@@ -94,6 +94,14 @@ public class AccelerometerActivity extends AppCompatActivity {
         setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
         setSupportActionBar(mToolbar);
 
         adapter = new AccelerometerAdapter(new String[]{"X axis", "Y axis", "Z axis"}, getApplicationContext());
@@ -258,6 +266,7 @@ public class AccelerometerActivity extends AppCompatActivity {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -292,12 +301,14 @@ public class AccelerometerActivity extends AppCompatActivity {
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }

--- a/app/src/main/java/io/pslab/activity/BarometerActivity.java
+++ b/app/src/main/java/io/pslab/activity/BarometerActivity.java
@@ -114,6 +114,14 @@ public class BarometerActivity extends AppCompatActivity {
         setContentView(R.layout.activity_barometer_main);
         ButterKnife.bind(this);
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
         BarometerActivity.newInstance();
 
         currentMin = 10000;
@@ -366,6 +374,7 @@ public class BarometerActivity extends AppCompatActivity {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -407,6 +416,7 @@ public class BarometerActivity extends AppCompatActivity {
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }

--- a/app/src/main/java/io/pslab/activity/CompassActivity.java
+++ b/app/src/main/java/io/pslab/activity/CompassActivity.java
@@ -129,6 +129,15 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
                 direction = 2;
             }
         });
+
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
     }
 
     @Override
@@ -200,13 +209,6 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
         compass.startAnimation(ra);
     }
 
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.activity_compass_help_menu, menu);
-        return true;
-    }
-
     /**
      * Initiates bottom sheet to display guide on how to use Compass instrument
      */
@@ -217,6 +219,7 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -249,12 +252,13 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
                         break;
 
                     case BottomSheetBehavior.STATE_COLLAPSED:
-                        handler.postDelayed(runnable, 1000);
+                        handler.postDelayed(runnable, 2000);
                         break;
 
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
@@ -262,6 +266,7 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0,
                         0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }
@@ -274,6 +279,13 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
     public boolean onTouchEvent(MotionEvent event) {
         gestureDetector.onTouchEvent(event);
         return super.onTouchEvent(event);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater inflater = getMenuInflater();
+        inflater.inflate(R.menu.activity_compass_help_menu, menu);
+        return true;
     }
 
     @Override

--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -94,7 +94,17 @@ public class LuxMeterActivity extends AppCompatActivity {
         ButterKnife.bind(this);
         setSupportActionBar(toolbar);
         realmPreferences = getSharedPreferences(NAME, Context.MODE_PRIVATE);
+
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
+
         bottomNavigationView.setOnNavigationItemSelectedListener
                 (new BottomNavigationView.OnNavigationItemSelectedListener() {
                     @Override
@@ -145,6 +155,7 @@ public class LuxMeterActivity extends AppCompatActivity {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -179,12 +190,14 @@ public class LuxMeterActivity extends AppCompatActivity {
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }

--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -92,7 +92,17 @@ public class MultimeterActivity extends AppCompatActivity {
         scienceLab = ScienceLabCommon.scienceLab;
         knobMarker = getResources().getStringArray(io.pslab.R.array.multimeter_knob_states);
         setSupportActionBar(mToolbar);
+
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
+
         multimeter_data = this.getSharedPreferences(NAME, MODE_PRIVATE);
         knobState = multimeter_data.getInt("KnobState", 2);
         switchIsChecked = multimeter_data.getBoolean("SwitchState", false);
@@ -243,6 +253,7 @@ public class MultimeterActivity extends AppCompatActivity {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -277,12 +288,14 @@ public class MultimeterActivity extends AppCompatActivity {
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -185,7 +185,17 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_oscilloscope);
         ButterKnife.bind(this);
+
         setUpBottomSheet();
+        parentLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                parentLayout.setVisibility(View.GONE);
+            }
+        });
+
         scienceLab = ScienceLabCommon.scienceLab;
         x1 = mChart.getXAxis();
         y1 = mChart.getAxisLeft();
@@ -703,6 +713,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            parentLayout.setVisibility(View.VISIBLE);
             parentLayout.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -737,12 +748,14 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                parentLayout.setVisibility(View.VISIBLE);
                 parentLayout.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }

--- a/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
+++ b/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
@@ -129,6 +129,14 @@ public class PowerSourceActivity extends AppCompatActivity {
         powerPreferences = getSharedPreferences(POWER_PREFERENCES, MODE_PRIVATE);
 
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
 
         autoSize(displayPV1);
         autoSize(displayPV2);
@@ -179,6 +187,7 @@ public class PowerSourceActivity extends AppCompatActivity {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -217,6 +226,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
@@ -224,6 +234,7 @@ public class PowerSourceActivity extends AppCompatActivity {
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0,
                         0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }
@@ -244,6 +255,7 @@ public class PowerSourceActivity extends AppCompatActivity {
         inflater.inflate(R.menu.power_source_menu, menu);
         return true;
     }
+
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {

--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -185,7 +185,17 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         if (!WaveGeneratorCommon.isInitialized) {
             new WaveGeneratorCommon(true);
         }
+
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
+
         enableInitialState();
         waveDialog = createIntentDialog();
 
@@ -697,6 +707,7 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -731,12 +742,14 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }

--- a/app/src/main/java/io/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LALogicLinesFragment.java
@@ -215,6 +215,14 @@ public class LALogicLinesFragment extends Fragment {
         // Inflating bottom sheet dialog on how to use Logic Analyzer
         bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet);
         setUpBottomSheet();
+        tvShadow.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+                tvShadow.setVisibility(View.GONE);
+            }
+        });
         v.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
@@ -805,6 +813,7 @@ public class LALogicLinesFragment extends Fragment {
 
         if (isFirstTime) {
             bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+            tvShadow.setVisibility(View.VISIBLE);
             tvShadow.setAlpha(0.8f);
             arrowUpDown.setRotation(180);
             bottomSheetSlideText.setText(R.string.hide_guide_text);
@@ -839,12 +848,14 @@ public class LALogicLinesFragment extends Fragment {
                     default:
                         handler.removeCallbacks(runnable);
                         bottomSheetSlideText.setText(R.string.show_guide_text);
+                        break;
                 }
             }
 
             @Override
             public void onSlide(@NonNull View bottomSheet, float slideOffset) {
                 Float value = (float) MathUtils.map((double) slideOffset, 0.0, 1.0, 0.0, 0.8);
+                tvShadow.setVisibility(View.VISIBLE);
                 tvShadow.setAlpha(value);
                 arrowUpDown.setRotation(slideOffset * 180);
             }


### PR DESCRIPTION
Fixes #1329 

**Changes**: Added code to close the bottom sheet when the window behind it is clicked

**Screenshot/s for the changes**:
![20180811_145438](https://user-images.githubusercontent.com/32356267/43990230-95723560-9d76-11e8-9c70-4d114d48550f.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2282890/app-debug.zip)