### PR TITLE
fix: snackbar now show proper info 

### DIFF
--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -233,6 +233,7 @@ public class LuxMeterActivity extends AppCompatActivity {
                         if (gpsLogger.isGPSEnabled()) {
                             recordData = true;
                             ((LuxMeterFragmentData) selectedFragment).startSensorFetching();
+                            CustomSnackBar.showSnackBar(coordinatorLayout,getString(R.string.data_recording_start)+"\n"+getString(R.string.location_enabled) , null, null);
                             invalidateOptionsMenu();
                         } else {
                             checkGpsOnResume = true;
@@ -241,10 +242,9 @@ public class LuxMeterActivity extends AppCompatActivity {
                     } else {
                         recordData = true;
                         ((LuxMeterFragmentData) selectedFragment).startSensorFetching();
+                        CustomSnackBar.showSnackBar(coordinatorLayout,getString(R.string.data_recording_start)+"\n"+getString(R.string.location_disabled) , null, null);
                         invalidateOptionsMenu();
                     }
-                    String snackText = getString(R.string.data_recording_start)+"\n"+(locationPref?getString(R.string.location_enabled):getString(R.string.location_disabled));
-                    CustomSnackBar.showSnackBar(coordinatorLayout, snackText, null, null);
                 }
                 break;
             case R.id.show_map:
@@ -279,10 +279,10 @@ public class LuxMeterActivity extends AppCompatActivity {
         if (checkGpsOnResume) {
             if (gpsLogger.isGPSEnabled()) {
                 recordData = true;
+                gpsLogger.startFetchingLocation();
                 ((LuxMeterFragmentData) selectedFragment).startSensorFetching();
                 invalidateOptionsMenu();
-                gpsLogger.startFetchingLocation();
-                CustomSnackBar.showSnackBar(coordinatorLayout,getString(R.string.data_recording_start)+getString(R.string.location_enabled) , null, null);
+                CustomSnackBar.showSnackBar(coordinatorLayout,getString(R.string.data_recording_start)+"\n"+getString(R.string.location_enabled) , null, null);
             } else {
                 recordData = false;
                 Toast.makeText(getApplicationContext(), getString(R.string.gps_not_enabled),


### PR DESCRIPTION
Fixes #1361 

**Changes**: 
fixed the info and position of snack bars


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[snack.zip](https://github.com/fossasia/pslab-android/files/2281089/snack.zip)


