### PR TITLE
Dialog box in wave generator is now closing properly

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -877,6 +877,7 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 startActivity(new Intent(WaveGeneratorActivity.this, OscilloscopeActivity.class));
+                waveDialog.cancel();
             }
         });
 
@@ -884,6 +885,7 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             @Override
             public void onClick(View view) {
                 startActivity(new Intent(WaveGeneratorActivity.this, LogicalAnalyzerActivity.class));
+                waveDialog.cancel();
             }
         });
 


### PR DESCRIPTION
Fixes #1396 

**Changes**:
Added code for canceling dialog box in wave generator before navigating to another instrument.

**Screenshot/s for the changes**: Not a UI change

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[dialog_wave.zip](https://github.com/fossasia/pslab-android/files/2433044/dialog_wave.zip)

