### PR TITLE
fix: resolved empty data bug in lux meter

### DIFF
--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -201,11 +201,14 @@ public class LuxMeterActivity extends AppCompatActivity {
                     ((LuxMeterFragmentData) selectedFragment).stopSensorFetching();
                     invalidateOptionsMenu();
                     Long uniqueRef = realmPreferences.getLong("uniqueCount", 0);
-                    selectedFragment.saveDataInRealm(uniqueRef, locationPref, gpsLogger);
-                    CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.exp_data_saved), null, null);
-                    SharedPreferences.Editor editor = realmPreferences.edit();
-                    editor.putLong("uniqueCount", uniqueRef + 1);
-                    editor.commit();
+                    if (selectedFragment.saveDataInRealm(uniqueRef, locationPref, gpsLogger)) {
+                        CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.exp_data_saved), null, null);
+                        SharedPreferences.Editor editor = realmPreferences.edit();
+                        editor.putLong("uniqueCount", uniqueRef + 1);
+                        editor.commit();
+                    } else {
+                        CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.no_data_fetched), null, null);
+                    }
                     recordData = false;
                 } else {
                     if (locationPref) {

--- a/app/src/main/java/io/pslab/others/GPSLogger.java
+++ b/app/src/main/java/io/pslab/others/GPSLogger.java
@@ -26,7 +26,7 @@ import io.pslab.activity.LuxMeterActivity;
 public class GPSLogger {
 
     public static final int MY_PERMISSIONS_REQUEST_LOCATION = 99;
-    private static final int UPDATE_INTERVAL_IN_MILLISECONDS = 1000;
+    private static final int UPDATE_INTERVAL_IN_MILLISECONDS = 400;
     private static final int MIN_DISTANCE_CHANGE_FOR_UPDATES = 1;
     private LocationManager locationManager;
     private Context context;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1036,5 +1036,6 @@
     GND. GND is meant for Ground and any of the PSLab device GND pins can be used since they are common.\n\n
     \u2022 Select sensor by going to the Configure tab from the bottom navigation bar and choose BHT-1750 in the drop down menu under Select Sensor.\n</string>
     <string name="lux_meter_settings">Lux Meter Settings</string>
+    <string name="no_data_fetched">No Data Fetched</string>
 
 </resources>


### PR DESCRIPTION
Fixes #1400 

**Changes**: 
Added if-else in lux meter fragment to check for empty data before storing in the realm database in the form of record.

**Screenshot/s for the changes**:Not a UI change

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[emptyfix.zip](https://github.com/fossasia/pslab-android/files/2433551/emptyfix.zip)

