### PR TITLE
fix: Hard Coded dimensions fixed in splash screen

### DIFF
--- a/app/src/main/res/layout/splash_screen.xml
+++ b/app/src/main/res/layout/splash_screen.xml
@@ -9,14 +9,14 @@
     <ImageView
         android:id="@+id/imageView"
         android:layout_width="match_parent"
-        android:layout_height="314dp"
-        android:src="@drawable/logo"
-        android:contentDescription="@string/pocket_science_logo" />
+        android:layout_height="@dimen/splash_screen_logo_height"
+        android:contentDescription="@string/pocket_science_logo"
+        android:src="@drawable/logo" />
 
     <ImageView
         android:id="@+id/PSLabText"
-        android:layout_width="271dp"
-        android:layout_height="95dp"
+        android:layout_width="@dimen/splash_screen_name_width"
+        android:layout_height="@dimen/splash_screen_name_height"
         android:contentDescription="@string/app_name"
         app:srcCompat="@drawable/text" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -382,5 +382,8 @@
     <dimen name="range_card_margin">5dp</dimen>
     <dimen name="speedometer_height">200dp</dimen>
     <dimen name="select_sensor_margin">5dp</dimen>
+    <dimen name="splash_screen_logo_height">314dp</dimen>
+    <dimen name="splash_screen_name_width">271dp</dimen>
+    <dimen name="splash_screen_name_height">95dp</dimen>
 
 </resources>


### PR DESCRIPTION
Fixes #1395

**Changes**: Hard Coded Dimensions removed from the splash screen xml file.

**Screenshot/s for the changes**: NA

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2447585/app-debug.zip)



