### PR TITLE
Changing different recording button logo to one in action bar of two activities.

### DIFF
--- a/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
+++ b/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
@@ -53,18 +53,11 @@ public class AccelerometerActivity extends AppCompatActivity {
 
     public boolean recordData = false;
     public boolean locationPref;
-    private boolean checkGpsOnResume = false;
-    private boolean isRecordingStarted = false;
-    private boolean isDataRecorded = false;
     public GPSLogger gpsLogger;
     public CSVLogger accLogger;
-
-    private Menu menu;
     AccelerometerAdapter adapter;
-
     BottomSheetBehavior bottomSheetBehavior;
     GestureDetector gestureDetector;
-
     @BindView(R.id.accel_toolbar)
     Toolbar mToolbar;
     @BindView(R.id.accel_coordinator_layout)
@@ -85,6 +78,10 @@ public class AccelerometerActivity extends AppCompatActivity {
     ImageView bottomSheetSchematic;
     @BindView(R.id.custom_dialog_desc)
     TextView bottomSheetDesc;
+    private boolean checkGpsOnResume = false;
+    private boolean isRecordingStarted = false;
+    private boolean isDataRecorded = false;
+    private Menu menu;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -97,7 +94,7 @@ public class AccelerometerActivity extends AppCompatActivity {
         tvShadow.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if(bottomSheetBehavior.getState()==BottomSheetBehavior.STATE_EXPANDED)
+                if (bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED)
                     bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
                 tvShadow.setVisibility(View.GONE);
             }
@@ -131,7 +128,7 @@ public class AccelerometerActivity extends AppCompatActivity {
                     return true;
                 }
                 if (recordData) {
-                    item.setIcon(R.drawable.record_icon);
+                    item.setIcon(R.drawable.ic_record_white);
                     adapter.setRecordingStatus(false);
                     recordData = false;
                     CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_paused), null, null);
@@ -163,7 +160,7 @@ public class AccelerometerActivity extends AppCompatActivity {
             case R.id.record_csv_data:
                 if (isDataRecorded) {
                     MenuItem item1 = menu.findItem(R.id.record_pause_data);
-                    item1.setIcon(R.drawable.record_icon);
+                    item1.setIcon(R.drawable.ic_record_white);
 
                     // Export Data
                     ArrayList<Entry> dataX = adapter.getEntries(0);
@@ -214,7 +211,7 @@ public class AccelerometerActivity extends AppCompatActivity {
             case R.id.delete_csv_data:
                 if (isDataRecorded) {
                     MenuItem item1 = menu.findItem(R.id.record_pause_data);
-                    item1.setIcon(R.drawable.record_icon);
+                    item1.setIcon(R.drawable.ic_record_white);
                     adapter.setRecordingStatus(false);
                     recordData = false;
                     isRecordingStarted = false;
@@ -247,7 +244,7 @@ public class AccelerometerActivity extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if(isRecordingStarted) {
+        if (isRecordingStarted) {
             accLogger.deleteFile();
             isRecordingStarted = false;
         }

--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -58,8 +58,11 @@ import it.beppi.knoblibrary.Knob;
 
 public class MultimeterActivity extends AppCompatActivity {
 
-    private ScienceLab scienceLab;
-
+    public static final String PREFS_NAME = "customDialogPreference";
+    public static final String NAME = "savingData";
+    private static final int MY_PERMISSIONS_REQUEST_STORAGE_FOR_DATA = 101;
+    public boolean recordData = false;
+    public CSVLogger multimeterLogger;
     @BindView(R.id.multimeter_toolbar)
     Toolbar mToolbar;
     @BindView(R.id.quantity)
@@ -74,7 +77,6 @@ public class MultimeterActivity extends AppCompatActivity {
     Button read;
     @BindView(R.id.selector)
     SwitchCompat aSwitch;
-
     @BindView(R.id.multimeter_coordinator_layout)
     CoordinatorLayout coordinatorLayout;
     //bottomSheet
@@ -94,26 +96,18 @@ public class MultimeterActivity extends AppCompatActivity {
     ImageView bottomSheetSchematic;
     @BindView(R.id.custom_dialog_desc)
     TextView bottomSheetDesc;
-
-    public boolean recordData = false;
-
+    BottomSheetBehavior bottomSheetBehavior;
+    GestureDetector gestureDetector;
+    SharedPreferences multimeter_data;
+    private ScienceLab scienceLab;
     private int knobState;
     private String dataRecorded;
     private String valueRecorded;
     private Menu menu;
     private Boolean switchIsChecked;
     private String[] knobMarker;
-    public CSVLogger multimeterLogger;
     private boolean isRecordingStarted = false;
     private boolean isDataRecorded = false;
-
-    BottomSheetBehavior bottomSheetBehavior;
-    GestureDetector gestureDetector;
-    public static final String PREFS_NAME = "customDialogPreference";
-    private static final int MY_PERMISSIONS_REQUEST_STORAGE_FOR_DATA = 101;
-
-    public static final String NAME = "savingData";
-    SharedPreferences multimeter_data;
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -412,7 +406,7 @@ public class MultimeterActivity extends AppCompatActivity {
                     return true;
                 }
                 if (recordData) {
-                    item.setIcon(R.drawable.record_icon);
+                    item.setIcon(R.drawable.ic_record_white);
                     recordData = false;
                     CustomSnackBar.showSnackBar(coordinatorLayout, getString(R.string.data_recording_paused), null, null);
                 } else {
@@ -429,7 +423,7 @@ public class MultimeterActivity extends AppCompatActivity {
             case R.id.record_csv_data:
                 if (isDataRecorded) {
                     MenuItem item1 = menu.findItem(R.id.record_pause_data);
-                    item1.setIcon(R.drawable.record_icon);
+                    item1.setIcon(R.drawable.ic_record_white);
                     multimeterLogger.writeCSVFile(dataRecorded + "\n" + valueRecorded + "\n");
                     dataRecorded = "Data";
                     valueRecorded = "Value";
@@ -462,7 +456,7 @@ public class MultimeterActivity extends AppCompatActivity {
             case R.id.delete_csv_data:
                 if (isDataRecorded) {
                     MenuItem item1 = menu.findItem(R.id.record_pause_data);
-                    item1.setIcon(R.drawable.record_icon);
+                    item1.setIcon(R.drawable.ic_record_white);
                     recordData = false;
                     isRecordingStarted = false;
                     isDataRecorded = false;

--- a/app/src/main/res/menu/data_log_menu.xml
+++ b/app/src/main/res/menu/data_log_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/record_pause_data"
-        android:icon="@drawable/record_icon"
+        android:icon="@drawable/ic_record_white"
         android:title="@string/record_csv_data"
         app:showAsAction="always" />
     <item

--- a/app/src/main/res/menu/multimeter_log_menu.xml
+++ b/app/src/main/res/menu/multimeter_log_menu.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/record_pause_data"
-        android:icon="@drawable/record_icon"
+        android:icon="@drawable/ic_record_white"
         android:title="@string/record_csv_data"
         app:showAsAction="always" />
     <item


### PR DESCRIPTION
Fixes #1410

**Changes**: Changes the recording button logo on Action bar of Multimeter and Accelerometer Activity same as Lux Meter Activity.

**Screenshot/s for the changes**: 
![rsz_ss1](https://user-images.githubusercontent.com/42169801/46672901-3cf6ca00-cbf6-11e8-840e-a053fd316e10.png)  ![rsz_ss2](https://user-images.githubusercontent.com/42169801/46672914-41bb7e00-cbf6-11e8-8e4d-de55828bd5ee.png)  ![rsz_ss3](https://user-images.githubusercontent.com/42169801/46673065-9232db80-cbf6-11e8-925c-e56b00e35279.png)


**Checklist**: 
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/2460383/app-debug.apk.zip)
