### PR TITLE
refractor: Changed Settings label to Configurations in Lux Meter instrument

### DIFF
--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -243,7 +243,7 @@ public class LuxMeterActivity extends AppCompatActivity {
                 break;
             case R.id.settings:
                 Intent settingIntent = new Intent(this, SettingsActivity.class);
-                settingIntent.putExtra("title", "Lux Meter Settings");
+                settingIntent.putExtra("title", getResources().getString(R.string.lux_meter_configurations));
                 startActivity(settingIntent);
                 break;
             case R.id.show_logged_data:

--- a/app/src/main/java/io/pslab/activity/SettingsActivity.java
+++ b/app/src/main/java/io/pslab/activity/SettingsActivity.java
@@ -52,7 +52,7 @@ public class SettingsActivity extends AppCompatActivity {
 
         Fragment fragment;
         switch (title) {
-            case "Lux Meter Settings":
+            case "Lux Meter Configurations":
                 fragment = new LuxMeterSettingFragment();
                 break;
             default:

--- a/app/src/main/res/menu/lux_data_log_menu.xml
+++ b/app/src/main/res/menu/lux_data_log_menu.xml
@@ -21,7 +21,7 @@
         app:showAsAction="never" />
     <item
         android:id="@+id/settings"
-        android:title="@string/lux_meter_settings"
+        android:title="@string/lux_meter_configurations"
         app:showAsAction="never" />
 </menu>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1035,7 +1035,7 @@
     <string name="lux_meter_desc">\u2022 The above pin configuration has to be same except for the pin
     GND. GND is meant for Ground and any of the PSLab device GND pins can be used since they are common.\n\n
     \u2022 Select sensor by going to the Configure tab from the bottom navigation bar and choose BHT-1750 in the drop down menu under Select Sensor.\n</string>
-    <string name="lux_meter_settings">Lux Meter Settings</string>
+    <string name="lux_meter_configurations">Lux Meter Configurations</string>
     <string name="no_data_fetched">No Data Fetched</string>
 
 </resources>


### PR DESCRIPTION
Fixes #1420 

**Changes**: Changed the label from Settings to Configurations

**Screenshot/s for the changes**: 
<img width="318" alt="screenshot 2018-10-22 at 12 56 07" src="https://user-images.githubusercontent.com/32356267/47281716-0491bb80-d5fa-11e8-870c-236802b20b93.png">
<img width="318" alt="screenshot 2018-10-22 at 12 56 23" src="https://user-images.githubusercontent.com/32356267/47281718-052a5200-d5fa-11e8-9294-15c04b136123.png">


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.apk.zip](https://github.com/fossasia/pslab-android/files/2500475/app-debug.apk.zip)

