### PR TITLE
fix: Solved issue of GPS disabled by default

### DIFF
--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -89,7 +89,7 @@ public class LuxMeterActivity extends AppCompatActivity {
         ButterKnife.bind(this);
         setSupportActionBar(toolbar);
         realmPreferences = getSharedPreferences(NAME, Context.MODE_PRIVATE);
-
+        new GPSLogger(this).requestPermissionIfNotGiven();
         setUpBottomSheet();
         tvShadow.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/app/src/main/java/io/pslab/fragment/LuxMeterSettingFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LuxMeterSettingFragment.java
@@ -39,7 +39,7 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
                 Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
             SharedPreferences.Editor editor = sharedPref.edit();
-            editor.putBoolean(LuxMeterSettingFragment.KEY_INCLUDE_LOCATION, false);
+            editor.putBoolean(LuxMeterSettingFragment.KEY_INCLUDE_LOCATION, true);
             editor.commit();
         }
 
@@ -48,7 +48,7 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
     @Override
     public void onResume() {
         super.onResume();
-        locationPreference.setChecked(sharedPref.getBoolean(KEY_INCLUDE_LOCATION, false));
+        locationPreference.setChecked(sharedPref.getBoolean(KEY_INCLUDE_LOCATION, true));
         updatePeriodPref.setSummary("Update Period is " + updatePeriodPref.getText() + " ms");
         higLimitPref.setSummary("High Limit is " + higLimitPref.getText());
         getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);

--- a/app/src/main/res/xml/lux_meter_settings.xml
+++ b/app/src/main/res/xml/lux_meter_settings.xml
@@ -17,7 +17,7 @@
             android:summary="High Limit is 2000 Lux"/>
 
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="include_location_sensor_data"
             android:summary="Include the location data in the logged file"
             android:title="Include Location Data" />


### PR DESCRIPTION
Fixes #1421

**Changes**: Enabled/Permission GPS in LuxMeter by default.

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2528759/app-debug.zip)
