### PR TITLE
fix: crash in Luxmeter when no data is saved

### DIFF
--- a/app/src/main/java/io/pslab/fragment/LuxMeterDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LuxMeterDataFragment.java
@@ -160,12 +160,17 @@ public class LuxMeterDataFragment extends Fragment {
 
     private void playRecordedData() {
         recordedLuxArray.addAll(luxSensor.recordedLuxData);
-        if (recordedLuxArray.size() > 1) {
-            LuxData i = recordedLuxArray.get(1);
-            long timeGap = i.getTime() - i.getBlock();
-            processRecordedData(timeGap);
-        } else {
-            processRecordedData(0);
+        try {
+            if (recordedLuxArray.size() > 1) {
+                LuxData i = recordedLuxArray.get(1);
+                long timeGap = i.getTime() - i.getBlock();
+                processRecordedData(timeGap);
+            } else {
+                processRecordedData(0);
+            }
+        } catch (IllegalArgumentException e) {
+            Toast.makeText(getActivity(),
+                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
         }
     }
 


### PR DESCRIPTION
Fixes #1452 

**Changes**: 
- When there were no recorded data as user closes the app quickly, app crashed. It was fixed and a message is displayed

**Screenshot/s for the changes**: 
> Not available

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[LuxMeterFix.zip](https://github.com/fossasia/pslab-android/files/2650067/LuxMeterFix.zip)

