### PR TITLE
Fixed the guide re-open issue in accelerometer

### DIFF
--- a/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
+++ b/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
@@ -319,4 +319,10 @@ public class AccelerometerActivity extends AppCompatActivity {
         });
         gestureDetector = new GestureDetector(this, new SwipeGestureDetector(bottomSheetBehavior));
     }
+    
+     @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        gestureDetector.onTouchEvent(event);                 //Gesture detector need this to transfer touch event to the gesture detector.
+        return super.onTouchEvent(event);
+    }
 }


### PR DESCRIPTION
Fixes #1459

**Changes**: onTouchEvent method added in the AccelerometerActivity

**Screenshot/s for the changes**: 
![accelerometer](https://user-images.githubusercontent.com/37077735/49694583-08ca6600-fbb3-11e8-9bdd-d4ade377bc78.gif)


**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications are done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 

[accelerometer_guide_re-open.zip](https://github.com/fossasia/pslab-android/files/2660334/accelerometer_guide_re-open.zip)

