### PR TITLE
feat: use of white space under Luxmeter

### DIFF
--- a/app/src/main/res/layout/fragment_lux_meter_data.xml
+++ b/app/src/main/res/layout/fragment_lux_meter_data.xml
@@ -1,143 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/scrollview"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
-    <LinearLayout
+    <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:layout_margin="@dimen/card_margin">
 
-        <android.support.v7.widget.CardView
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_margin="@dimen/card_margin">
+            android:baselineAligned="false">
 
             <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:baselineAligned="false">
+                android:layout_weight="3"
+                android:gravity="center_horizontal|center_vertical"
+                android:orientation="vertical">
 
-                <LinearLayout
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="3"
-                    android:gravity="center_horizontal|center_vertical"
-                    android:orientation="vertical">
+                <TextView
+                    android:id="@+id/label_lux_sensor"
+                    style="@style/lux_meter_stat_heading"
+                    android:paddingBottom="5dp"
+                    android:textSize="@dimen/lux_sensor_label_title_size" />
 
-                    <TextView
-                        android:id="@+id/label_lux_sensor"
-                        style="@style/lux_meter_stat_heading"
-                        android:paddingBottom="5dp"
-                        android:textSize="@dimen/lux_sensor_label_title_size" />
+                <TextView
+                    android:id="@+id/label_lux_stat_max"
+                    style="@style/lux_meter_stat_heading"
+                    android:text="@string/max_lx" />
 
-                    <TextView
-                        android:id="@+id/label_lux_stat_max"
-                        style="@style/lux_meter_stat_heading"
-                        android:text="@string/max_lx" />
+                <TextView
+                    android:id="@+id/lux_max"
+                    style="@style/lux_meter_stat_display" />
 
-                    <TextView
-                        android:id="@+id/lux_max"
-                        style="@style/lux_meter_stat_display" />
+                <TextView
+                    android:id="@+id/label_lux_stat_min"
+                    style="@style/lux_meter_stat_heading"
+                    android:text="@string/min_lx" />
 
-                    <TextView
-                        android:id="@+id/label_lux_stat_min"
-                        style="@style/lux_meter_stat_heading"
-                        android:text="@string/min_lx" />
+                <TextView
+                    android:id="@+id/lux_min"
+                    style="@style/lux_meter_stat_display" />
 
-                    <TextView
-                        android:id="@+id/lux_min"
-                        style="@style/lux_meter_stat_display" />
+                <TextView
+                    android:id="@+id/label_lux_stat_avg"
+                    style="@style/lux_meter_stat_heading"
+                    android:text="@string/avg_lx" />
 
-                    <TextView
-                        android:id="@+id/label_lux_stat_avg"
-                        style="@style/lux_meter_stat_heading"
-                        android:text="@string/avg_lx" />
-
-                    <TextView
-                        android:id="@+id/lux_avg"
-                        style="@style/lux_meter_stat_display" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="@dimen/length_0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="5"
-                    android:orientation="vertical">
-
-                    <com.github.anastr.speedviewlib.PointerSpeedometer
-                        android:id="@+id/light_meter"
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/speedometer_height"
-                        android:padding="15dp"
-                        app:sv_speedTextColor="@color/black"
-                        app:sv_speedTextPosition="BOTTOM_CENTER"
-                        app:sv_speedTextSize="@dimen/lux_display_font_size"
-                        app:sv_speedometerMode="NORMAL"
-                        app:sv_textSize="@dimen/lux_guage_font_size"
-                        app:sv_unit="@string/lux"
-                        app:sv_unitTextColor="@color/black" />
-
-                </LinearLayout>
+                <TextView
+                    android:id="@+id/lux_avg"
+                    style="@style/lux_meter_stat_display" />
 
             </LinearLayout>
 
-        </android.support.v7.widget.CardView>
+            <LinearLayout
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="5"
+                android:orientation="vertical">
 
-        <android.support.v7.widget.CardView
+                <com.github.anastr.speedviewlib.PointerSpeedometer
+                    android:id="@+id/light_meter"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/speedometer_height"
+                    android:padding="15dp"
+                    app:sv_speedTextColor="@color/black"
+                    app:sv_speedTextPosition="BOTTOM_CENTER"
+                    app:sv_speedTextSize="@dimen/lux_display_font_size"
+                    app:sv_speedometerMode="NORMAL"
+                    app:sv_textSize="@dimen/lux_guage_font_size"
+                    app:sv_unit="@string/lux"
+                    app:sv_unitTextColor="@color/black" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="@dimen/card_margin">
+
+        <RelativeLayout
             android:layout_width="match_parent"
-            android:layout_height="@dimen/lux_chart_height"
-            android:layout_margin="@dimen/card_margin">
+            android:layout_height="match_parent"
+            android:layout_weight="4">
 
             <RelativeLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_weight="4">
+                android:id="@+id/chart_xaxis_layout"
+                style="@style/graph_x_axis_title_block">
 
-                <RelativeLayout
-                    android:id="@+id/chart_xaxis_layout"
-                    style="@style/graph_x_axis_title_block">
+                <TextView
+                    android:id="@+id/tv_graph_label_xaxis_hmc"
+                    style="@style/graph_x_axis_title_text"
+                    android:text="@string/time"
+                    tools:layout_editor_absoluteX="288dp"
+                    tools:layout_editor_absoluteY="0dp" />
 
-                    <TextView
-                        android:id="@+id/tv_graph_label_xaxis_hmc"
-                        style="@style/graph_x_axis_title_text"
-                        android:text="@string/time"
-                        tools:layout_editor_absoluteX="288dp"
-                        tools:layout_editor_absoluteY="0dp" />
-
-                </RelativeLayout>
-
-                <android.support.constraint.ConstraintLayout
-                    android:id="@+id/chart_yaxis_layout_hmc"
-                    style="@style/graph_y_axis_title_block">
-
-                    <TextView
-                        android:id="@+id/tv_label_left_yaxis_hmc"
-                        style="@style/graph_y_axis_title_text"
-                        android:text="@string/lux"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintLeft_toLeftOf="parent"
-                        app:layout_constraintRight_toRightOf="parent"
-                        app:layout_constraintTop_toTopOf="parent" />
-
-                </android.support.constraint.ConstraintLayout>
-
-                <com.github.mikephil.charting.charts.LineChart
-                    android:id="@+id/chart_lux_meter"
-                    android:layout_width="match_parent"
-                    android:layout_height="match_parent"
-                    android:layout_below="@+id/chart_xaxis_layout"
-                    android:layout_toEndOf="@+id/chart_yaxis_layout_hmc"
-                    android:layout_toRightOf="@+id/chart_yaxis_layout_hmc"
-                    android:background="@color/black" />
             </RelativeLayout>
 
-        </android.support.v7.widget.CardView>
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/chart_yaxis_layout_hmc"
+                style="@style/graph_y_axis_title_block">
 
-    </LinearLayout>
+                <TextView
+                    android:id="@+id/tv_label_left_yaxis_hmc"
+                    style="@style/graph_y_axis_title_text"
+                    android:text="@string/lux"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-</ScrollView>
+            </android.support.constraint.ConstraintLayout>
+
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/chart_lux_meter"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/chart_xaxis_layout"
+                android:layout_toEndOf="@+id/chart_yaxis_layout_hmc"
+                android:layout_toRightOf="@+id/chart_yaxis_layout_hmc"
+                android:background="@color/black" />
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>


### PR DESCRIPTION
Fixes #1462 

**Changes**: 
- Extended view to use graph in white space

**Screenshot/s for the changes**: 
![view_lux_meter](https://user-images.githubusercontent.com/14261304/49706187-49c18980-fc4a-11e8-9213-f3c6b9af59d0.png)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [X] I have requested reviews from other members

**APK for testing**: 
[Lux.apk.zip](https://github.com/fossasia/pslab-android/files/2661269/Lux.apk.zip)

