### PR TITLE
feat: empty datalogger view

### DIFF
--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -7,6 +7,8 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -26,6 +28,8 @@ public class DataLoggerActivity extends AppCompatActivity {
 
     @BindView(R.id.recycler_view)
     RecyclerView recyclerView;
+    @BindView(R.id.data_logger_blank_view)
+    TextView blankView;
 
     @BindView(R.id.toolbar)
     Toolbar toolbar;
@@ -59,14 +63,20 @@ public class DataLoggerActivity extends AppCompatActivity {
                 getSupportActionBar().setTitle(getString(R.string.logged_data));
         }
 
-        SensorLoggerListAdapter adapter = new SensorLoggerListAdapter(categoryData, this);
-        LinearLayoutManager linearLayoutManager = new LinearLayoutManager(
-                this, LinearLayoutManager.VERTICAL, false);
-        recyclerView.setLayoutManager(linearLayoutManager);
+        if (categoryData.size() > 0) {
+            blankView.setVisibility(View.GONE);
+            SensorLoggerListAdapter adapter = new SensorLoggerListAdapter(categoryData, this);
+            LinearLayoutManager linearLayoutManager = new LinearLayoutManager(
+                    this, LinearLayoutManager.VERTICAL, false);
+            recyclerView.setLayoutManager(linearLayoutManager);
 
-        DividerItemDecoration itemDecor = new DividerItemDecoration(this, DividerItemDecoration.HORIZONTAL);
-        recyclerView.addItemDecoration(itemDecor);
-        recyclerView.setAdapter(adapter);
+            DividerItemDecoration itemDecor = new DividerItemDecoration(this, DividerItemDecoration.HORIZONTAL);
+            recyclerView.addItemDecoration(itemDecor);
+            recyclerView.setAdapter(adapter);
+        } else {
+            recyclerView.setVisibility(View.GONE);
+            blankView.setVisibility(View.VISIBLE);
+        }
     }
 
     @Override

--- a/app/src/main/res/layout/activity_data_logger.xml
+++ b/app/src/main/res/layout/activity_data_logger.xml
@@ -21,10 +21,22 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <android.support.v7.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/top_app_bar_layout" />
+        android:layout_height="match_parent"
+        android:layout_below="@id/top_app_bar_layout">
+
+        <TextView
+            android:id="@+id/data_logger_blank_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/no_logs_to_display" />
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1046,6 +1046,7 @@
     <string name="dev_android_sdk">Device Android SDK</string>
 
     <string name="logged_data">Logged Data</string>
+    <string name="no_logs_to_display">There are no data logs to display</string>
     <string name="show_logged_data">Show Logged Data</string>
     <string name="time_elapsed">Time Elapsed</string>
     <string name="exp_data_saved">Experiment Logged Data Saved</string>


### PR DESCRIPTION
Fixes #1447 

**Changes**: 
- Added blank view notifying there is no log if the log list is empty

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/14261304/50062286-5f93f900-01cc-11e9-9177-fbcb46d35856.png" width = "300">

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [X] I have requested reviews from other members

**APK for testing**: 
[DataLogger.apk.zip](https://github.com/fossasia/pslab-android/files/2684204/DataLogger.apk.zip)

