### PR TITLE
fix: power source crash

### DIFF
--- a/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
+++ b/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
@@ -640,7 +640,11 @@ public class PowerSourceActivity extends AppCompatActivity {
      * @return truncated float value
      */
     private float limitDigits(float number) {
-        return Float.valueOf(String.format(Locale.getDefault(), "%.2f", number));
+        try {
+            return Float.valueOf(String.format(Locale.getDefault(), "%.2f", number));
+        } catch (NumberFormatException e) {
+            return 0.00f;
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #1461 

**Changes**: 
- Handle number format exception where the crash log of the issue states crashing. 
(Note: This issue is not recreational as user cannot type in any value to happen a number format exception. But I observed, the user device uses a different language and it might have shifted dot with comma `For input string: "-5,00"`? So anyways, this fix catches such exceptions and set to a default value rather than crashing.)

**Screenshot/s for the changes**: 
> Not available

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [X] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [X] My code does not contain any extra lines or extra spaces
- [X] I have requested reviews from other members

**APK for testing**: 
----
