### PR TITLE
refactor: Remove redundant LinearLayout

### DIFF
--- a/app/src/main/res/layout/pin_description_dialog.xml
+++ b/app/src/main/res/layout/pin_description_dialog.xml
@@ -43,20 +43,13 @@
 
     </LinearLayout>
 
-    <LinearLayout
+    <Button
+        android:id="@+id/pin_description_dismiss"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
-        android:layout_margin="@dimen/pin_description_dialog_margin">
-
-        <Button
-            android:id="@+id/pin_description_dismiss"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/ok"
-            android:textColor="@color/black" />
-
-    </LinearLayout>
+        android:layout_margin="@dimen/pin_description_dialog_margin"
+        android:text="@string/ok"
+        android:textColor="@color/black" />
 
 </LinearLayout>


### PR DESCRIPTION
Fixes #1495 

**Changes**: Redundant LinearLayout enclosing the Button is removed.

**Screenshot/s for the changes**:

![screenshot 156](https://user-images.githubusercontent.com/25201519/50217866-0f758c00-03b0-11e9-9d2d-29100f627821.png)



**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR 
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2694625/app-debug.zip)

