### PR TITLE
feat: Add image to empty datalogger view

### DIFF
--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -8,7 +8,7 @@ import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.TextView;
+import android.widget.LinearLayout;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -29,7 +29,7 @@ public class DataLoggerActivity extends AppCompatActivity {
     @BindView(R.id.recycler_view)
     RecyclerView recyclerView;
     @BindView(R.id.data_logger_blank_view)
-    TextView blankView;
+    LinearLayout blankView;
 
     @BindView(R.id.toolbar)
     Toolbar toolbar;

--- a/app/src/main/res/layout/activity_data_logger.xml
+++ b/app/src/main/res/layout/activity_data_logger.xml
@@ -26,12 +26,25 @@
         android:layout_height="match_parent"
         android:layout_below="@id/top_app_bar_layout">
 
-        <TextView
+        <LinearLayout
             android:id="@+id/data_logger_blank_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center"
-            android:text="@string/no_logs_to_display" />
+            android:orientation="vertical">
+
+            <ImageView
+                android:layout_width="96dp"
+                android:layout_height="96dp"
+                android:layout_marginBottom="16dp"
+                android:src="@drawable/ic_wifi_tethering_black_24dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/no_logs_to_display" />
+
+        </LinearLayout>
 
         <android.support.v7.widget.RecyclerView
             android:id="@+id/recycler_view"


### PR DESCRIPTION
Fixes #1497 

**Changes**: ImageView was added for empty datalogger view

**Screenshot/s for the changes**: 

<img src="https://user-images.githubusercontent.com/25201519/50271968-4f924880-045c-11e9-8d5f-a69c4a883b40.jpeg" width="250">


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR 
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[app-debug.zip](https://github.com/fossasia/pslab-android/files/2697868/app-debug.zip)