### PR TITLE
fix: Solved the issue of popping up spinner in oscilloscope instrument

### DIFF
--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -178,7 +178,6 @@ public class ChannelParametersFragment extends Fragment {
                     case 0:
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         spinnerRangeCh1.setEnabled(true);
-                        spinnerRangeCh1.performClick();
                         break;
                     case 1:
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(16, -16);


### PR DESCRIPTION
Fixes #1511 

**Changes**: Removed the onClick calling of CH1 spinner from the initiating method

**Screenshot/s for the changes**: 
![oscilloscope](https://user-images.githubusercontent.com/32356267/50764278-28c77500-1298-11e9-943f-e9dfad9a0156.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[oscilloscope_issue.apk.zip](https://github.com/fossasia/pslab-android/files/2732412/oscilloscope_issue.apk.zip)
