### PR TITLE
fix crash caused by comma in a number in local languages,

### DIFF
--- a/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
+++ b/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
@@ -23,19 +23,18 @@ import android.widget.TextView;
 import com.sdsmdg.harjot.crollerTest.Croller;
 import com.sdsmdg.harjot.crollerTest.OnCrollerChangeListener;
 
-import io.pslab.R;
-import io.pslab.communication.ScienceLab;
-import io.pslab.items.SquareImageButton;
-import io.pslab.others.ScienceLabCommon;
-import io.pslab.others.MathUtils;
-import io.pslab.others.SwipeGestureDetector;
-
 import java.util.Locale;
 import java.util.Timer;
 import java.util.TimerTask;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import io.pslab.R;
+import io.pslab.communication.ScienceLab;
+import io.pslab.items.SquareImageButton;
+import io.pslab.others.MathUtils;
+import io.pslab.others.ScienceLabCommon;
+import io.pslab.others.SwipeGestureDetector;
 
 public class PowerSourceActivity extends AppCompatActivity {
 
@@ -641,7 +640,7 @@ public class PowerSourceActivity extends AppCompatActivity {
      */
     private float limitDigits(float number) {
         try {
-            return Float.valueOf(String.format(Locale.getDefault(), "%.2f", number));
+            return Float.valueOf(String.format(Locale.US, "%.2f", number));
         } catch (NumberFormatException e) {
             return 0.00f;
         }

--- a/app/src/main/java/io/pslab/fragment/BaroMeterDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BaroMeterDataFragment.java
@@ -467,7 +467,7 @@ public class BaroMeterDataFragment extends Fragment {
         @Override
         public void onSensorChanged(SensorEvent event) {
             if (event.sensor.getType() == Sensor.TYPE_PRESSURE) {
-                baroValue = Float.valueOf(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, event.values[0] / 1000));
+                baroValue = Float.valueOf(String.format(Locale.US, PSLabSensor.BAROMETER_DATA_FORMAT, event.values[0] / 1000));
             }
         }
     };

--- a/app/src/main/java/io/pslab/others/FloatSeekBar.java
+++ b/app/src/main/java/io/pslab/others/FloatSeekBar.java
@@ -10,8 +10,6 @@ import android.util.AttributeSet;
 
 import io.pslab.R;
 
-import java.text.DecimalFormat;
-
 
 /**
  * Created by akarshan on 4/10/17.
@@ -36,9 +34,8 @@ public class FloatSeekBar extends android.support.v7.widget.AppCompatSeekBar {
     }
 
     public double getValue() {
-        DecimalFormat df = new DecimalFormat("#.##");
         Double value = (max - min) * ((float) getProgress() / (float) getMax()) + min;
-        value = Double.valueOf(df.format(value));
+        value = (double) Math.round(value * 100) / 100;
         return value;
     }
 


### PR DESCRIPTION
fix changing power source settings, barometer values, values changed by FloatSeekBar for languages with a comma separator

Fixes #1517

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [ ] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x ] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[fix_comma_crash.zip](https://github.com/fossasia/pslab-android/files/2743173/fix_comma_crash.zip)
