### PR TITLE
Barometer's orientation fixed(#1533)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -78,7 +78,8 @@
         <activity android:name=".activity.DataLoggerActivity" />
         <activity
             android:name=".activity.BarometerActivity"
-            android:configChanges="keyboardHidden|screenSize|orientation" />
+            android:configChanges="keyboardHidden|screenSize|orientation"
+            android:screenOrientation="portrait"/>
         <activity
             android:name=".activity.CompassActivity"
             android:screenOrientation="portrait" />


### PR DESCRIPTION
Fixes #1533 

**Changes**: Added screen orientation to barometer activity and set it to portrait.   

**Screenshot/s for the changes**: 
![capture12](https://user-images.githubusercontent.com/37181637/51162569-b4ef2300-18bc-11e9-9c20-eec7d5cbbbff.PNG)

