### PR TITLE
Creating Oscilloscope settings menu

### DIFF
--- a/app/src/main/res/menu/oscilloscope_settings_menu
+++ b/app/src/main/res/menu/oscilloscope_settings_menu
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/action_config"
+        android:icon="@drawable/action_item_config"
+        android:title="@string/navigation_lux_meter_configure" />
+</menu>

--- a/app/src/main/res/menu/oscilloscope_settings_menu
+++ b/app/src/main/res/menu/oscilloscope_settings_menu
@@ -4,5 +4,5 @@
     <item
         android:id="@+id/action_config"
         android:icon="@drawable/action_item_config"
-        android:title="@string/navigation_lux_meter_configure" />
+        android:title="Settings" />
 </menu>

--- a/app/src/main/res/menu/oscilloscope_settings_menu
+++ b/app/src/main/res/menu/oscilloscope_settings_menu
@@ -4,5 +4,5 @@
     <item
         android:id="@+id/action_config"
         android:icon="@drawable/action_item_config"
-        android:title="Settings" />
+        android:title="@string/oscilloscope_settings" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -777,6 +777,7 @@
 
     <string name="tile_instrument_horizontal_bars">Horizontal bars to match icon</string>
     <string name="tile_instrument_vertical_bars">Verticle bars to match tile icon</string>
+    <string name="oscilloscope_settings">Configure</string>
 
     <string name="accelerometer_description">Measures the Linear acceleration in XYZ directions</string>
     <string name="web_view_link_text">What is PSLab Device?</string>


### PR DESCRIPTION
Adding an hamburger icon to display configure option for oscilloscope.

Fixes #["First steps for issue #1387 ]

**Changes**: [Adding a hamburger menu in the oscilloscope layout]

