### PR TITLE
Fix #1550 multimeter crash bug fixed

### DIFF
--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -96,7 +96,7 @@ public class MultimeterActivity extends AppCompatActivity {
     private int knobState;
     private String dataRecorded;
     private String valueRecorded;
-    private String defaultValue = getString(R.string.multimeter_default_value);
+    private String defaultValue;
     private Menu menu;
     private Boolean switchIsChecked;
     private String[] knobMarker;
@@ -107,6 +107,7 @@ public class MultimeterActivity extends AppCompatActivity {
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_multimeter_main);
+        defaultValue = getString(R.string.multimeter_default_value);
         ButterKnife.bind(this);
         scienceLab = ScienceLabCommon.scienceLab;
         knobMarker = getResources().getStringArray(io.pslab.R.array.multimeter_knob_states);


### PR DESCRIPTION
Fixes #1550 
**Changes**: assigned the value of "defaultValue" string inside the onCreate() function



**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[multimeter_bug_fix.zip](https://github.com/fossasia/pslab-android/files/2880257/multimeter_bug_fix.zip)

