### PR TITLE
Fix #1553 Made wave 1/2 labels clickable in Wave Generator

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -184,9 +184,6 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         setContentView(R.layout.activity_wave_generator_main);
         ButterKnife.bind(this);
 
-
-        waveMonWave1.setEnabled(true);
-        waveMonWave2.setEnabled(true);
         if (Build.VERSION.SDK_INT < 16) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
@@ -231,7 +228,6 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 }
             }
         });
-        //wave1 label clickable
         waveMonWave1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -250,7 +246,6 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 }
             }
         });
-        //wave2 label clickable
         waveMonWave2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {

--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -184,6 +184,9 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         setContentView(R.layout.activity_wave_generator_main);
         ButterKnife.bind(this);
 
+
+        waveMonWave1.setEnabled(true);
+        waveMonWave2.setEnabled(true);
         if (Build.VERSION.SDK_INT < 16) {
             getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                     WindowManager.LayoutParams.FLAG_FULLSCREEN);
@@ -228,7 +231,16 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 }
             }
         });
-
+        //wave1 label clickable
+        waveMonWave1.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!waveBtnActive.equals(WaveConst.WAVE1)) {
+                    waveMonSelected = true;
+                    selectBtn(WaveConst.WAVE1);
+                }
+            }
+        });
         btnCtrlWave2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -238,7 +250,16 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 }
             }
         });
-
+        //wave2 label clickable
+        waveMonWave2.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (!waveBtnActive.equals(WaveConst.WAVE2)) {
+                    waveMonSelected = true;
+                    selectBtn(WaveConst.WAVE2);
+                }
+            }
+        });
         imgBtnSin.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -455,7 +476,6 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             }
         });
     }
-
     public void selectBtn(WaveConst btn_selected) {
 
         switch (btn_selected) {
@@ -463,8 +483,9 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             case WAVE1:
 
                 waveBtnActive = WaveConst.WAVE1;
-                waveMonWave1.setEnabled(true);
-                waveMonWave2.setEnabled(false);
+
+                waveMonWave1.setTextColor(getResources().getColor(R.color.orange));
+                waveMonWave2.setTextColor(getResources().getColor(R.color.dark_grey));
 
                 btnCtrlPhase.setEnabled(false);  //disable phase for wave
                 wavePhaseValue.setText("--");
@@ -477,8 +498,9 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             case WAVE2:
 
                 waveBtnActive = WaveConst.WAVE2;
-                waveMonWave1.setEnabled(false);
-                waveMonWave2.setEnabled(true);
+
+                waveMonWave2.setTextColor(getResources().getColor(R.color.orange));
+                waveMonWave1.setTextColor(getResources().getColor(R.color.dark_grey));
 
                 btnCtrlPhase.setEnabled(true); // enable phase for wave2
 
@@ -535,8 +557,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
             default:
                 waveBtnActive = WaveConst.WAVE1;
-                waveMonWave1.setEnabled(true);
-                waveMonWave2.setEnabled(false);
+                waveMonWave1.setTextColor(getResources().getColor(R.color.orange));
+                waveMonWave2.setTextColor(getResources().getColor(R.color.dark_grey));
                 btnCtrlPhase.setEnabled(false);  //disable phase for wave
                 wavePhaseValue.setText("--");
                 selectWaveform(WaveGeneratorCommon.wave.get(waveBtnActive).get(WaveConst.WAVETYPE));

--- a/app/src/main/res/layout/activity_wave_generator.xml
+++ b/app/src/main/res/layout/activity_wave_generator.xml
@@ -86,15 +86,17 @@
                 android:layout_marginEnd="@dimen/mon_title_sep_margin"
                 android:layout_marginRight="@dimen/mon_title_sep_margin"
                 android:text="@string/wave1"
-                android:textColor="@drawable/text_color_selector"
+                android:textColor="@color/dark_grey"
                 android:textSize="@dimen/text_size_wavegen"
                 android:textStyle="bold"
-                android:enabled="false"
                 app:layout_constraintBottom_toTopOf="@+id/fguideline3"
                 app:layout_constraintEnd_toStartOf="@+id/fguideline2"
                 app:layout_constraintHorizontal_bias="0.9"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                android:clickable="true"
+                android:focusable="true"
+                />
 
             <TextView
                 android:id="@+id/wave_mon_wave2"
@@ -103,15 +105,17 @@
                 android:layout_marginLeft="@dimen/mon_title_sep_margin"
                 android:layout_marginStart="@dimen/mon_title_sep_margin"
                 android:text="@string/wave2"
-                android:textColor="@drawable/text_color_selector"
+                android:textColor="@color/dark_grey"
                 android:textSize="@dimen/text_size_wavegen"
                 android:textStyle="bold"
-                android:enabled="false"
                 app:layout_constraintBottom_toBottomOf="@+id/wave_mon_wave1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.10"
                 app:layout_constraintStart_toStartOf="@+id/fguideline2"
-                app:layout_constraintTop_toTopOf="@+id/wave_mon_wave1" />
+                app:layout_constraintTop_toTopOf="@+id/wave_mon_wave1"
+                android:clickable="true"
+                android:focusable="true"
+                />
 
             <TextView
                 android:id="@+id/wave_mon_select_wave"


### PR DESCRIPTION
Fixes #1553 

**Changes**:

Wave Labels in wave generator are now clickable

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[wave_labels.zip](https://github.com/fossasia/pslab-android/files/2881082/wave_labels.zip)
