### PR TITLE
FIx #1559 Lux Meter/Barometer configuration titles fixed

### DIFF
--- a/app/src/main/java/io/pslab/activity/SettingsActivity.java
+++ b/app/src/main/java/io/pslab/activity/SettingsActivity.java
@@ -54,10 +54,10 @@ public class SettingsActivity extends AppCompatActivity {
 
         Fragment fragment;
         switch (title) {
-            case PSLabSensor.LUXMETER:
+            case PSLabSensor.LUXMETER_CONFIGURATIONS:
                 fragment = new LuxMeterSettingFragment();
                 break;
-            case PSLabSensor.BAROMETER:
+            case PSLabSensor.BAROMETER_CONFIGURATIONS:
                 fragment = new BaroMeterSettingsFragment();
                 break;
             default:

--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -88,8 +88,10 @@ public abstract class PSLabSensor extends AppCompatActivity {
     public final String DATA_BLOCK = "data_block";
 
     public static final String LUXMETER = "Lux Meter";
+    public static final String LUXMETER_CONFIGURATIONS = "Lux Meter Configurations";
     public static final String LUXMETER_DATA_FORMAT = "%.2f";
     public static final String BAROMETER = "Barometer";
+    public static final String BAROMETER_CONFIGURATIONS = "Barometer Configurations";
     public static final String BAROMETER_DATA_FORMAT = "%.5f";
 
     @BindView(R.id.sensor_toolbar)
@@ -333,7 +335,7 @@ public abstract class PSLabSensor extends AppCompatActivity {
                 break;
             case R.id.settings:
                 Intent settingIntent = new Intent(this, SettingsActivity.class);
-                settingIntent.putExtra("title", getSensorName());
+                settingIntent.putExtra("title", getSensorName() + " Configurations");
                 startActivity(settingIntent);
                 break;
             case R.id.show_logged_data:


### PR DESCRIPTION
Fixes #1559  

**Changes**: 
String sent to settingsActivity with intent changed

**Screenshot/s for the changes**:

![screenshot_20190220-141517](https://user-images.githubusercontent.com/32041242/53078459-497f1d80-351a-11e9-9261-e393c8876a61.png)
![screenshot_20190220-141504](https://user-images.githubusercontent.com/32041242/53078462-4a17b400-351a-11e9-98d3-4daf09437f63.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[configuration_title.zip](https://github.com/fossasia/pslab-android/files/2883749/configuration_title.zip)
