### PR TITLE
Fix #1558 status bar bug fixed, status bar doesnt reappear on opening spinners

### DIFF
--- a/app/src/main/java/io/pslab/activity/LogicalAnalyzerActivity.java
+++ b/app/src/main/java/io/pslab/activity/LogicalAnalyzerActivity.java
@@ -13,6 +13,7 @@ import android.view.GestureDetector;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.Window;
 import android.view.WindowManager;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -56,6 +57,8 @@ public class LogicalAnalyzerActivity extends AppCompatActivity {
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_logic_analyzer);
         scienceLab = ScienceLabCommon.scienceLab;
         ButterKnife.bind(this);

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -20,6 +20,8 @@ import android.view.Display;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
@@ -161,6 +163,8 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_oscilloscope);
         ButterKnife.bind(this);
 
@@ -395,6 +399,8 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
         monitorThread = new Thread(runnable);
         monitorThread.start();
     }
+
+
 
     @Override
     public void onClick(View v) {

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -400,8 +400,6 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
         monitorThread.start();
     }
 
-
-
     @Override
     public void onClick(View v) {
         switch (v.getId()) {

--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -181,6 +181,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,WindowManager.LayoutParams.FLAG_FULLSCREEN);
         setContentView(R.layout.activity_wave_generator_main);
         ButterKnife.bind(this);
 


### PR DESCRIPTION
Fixes #1558  
**Changes**: widow full screen flag set in onCreate method

**Screenshot/s for the changes**: 
![screenshot_20190220-165309](https://user-images.githubusercontent.com/32041242/53088587-37a87500-3530-11e9-83b0-94862745e2e1.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: 
[statusbar_bug.zip](https://github.com/fossasia/pslab-android/files/2884414/statusbar_bug.zip)

