### PR TITLE
"no log data" message visible upon deleting everything from logged data

### DIFF
--- a/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
@@ -133,6 +133,12 @@ public class SensorLoggerListAdapter extends RealmRecyclerViewAdapter<SensorData
                         }
                         LocalDataLog.with().clearSensorBlock(block.getBlock());
                         dialog.dismiss();
+                        if (LocalDataLog.with().getAllSensorBlocks().size() <= 0){
+                            context.findViewById(R.id.data_logger_blank_view).setVisibility(View.VISIBLE);
+                        }
+                        else{
+                            context.findViewById(R.id.data_logger_blank_view).setVisibility(View.GONE);
+                        }
                     }
                 })
                 .setNegativeButton(context.getString(R.string.cancel), new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Fixes #1570 

**Changes**: checking the size of log data, upon zero making the "no log data" message visible

**Screenshot/s for the changes**: 
![20190301_000051](https://user-images.githubusercontent.com/32041242/53589560-b13a0600-3bb5-11e9-85d0-2c6cef9fcb65.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

