### PR TITLE
Feat:Press back button twice to exit oscilloscope

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -27,6 +27,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.Legend;
@@ -156,6 +157,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
     private volatile boolean monitor = true;
     private BottomSheetBehavior bottomSheetBehavior;
     private GestureDetector gestureDetector;
+    private boolean doubleBackToExitPressedOnce = false;
 
     private enum CHANNEL {CH1, CH2, CH3, MIC}
 
@@ -481,8 +483,22 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
 
     @Override
     public void onBackPressed() {
-        finish();
+       if (doubleBackToExitPressedOnce) {
+            super.onBackPressed();
+            return;
+        }
+        this.doubleBackToExitPressedOnce = true;
+        Toast.makeText(this, "Press again to exit", Toast.LENGTH_SHORT)
+                .show();
+        new Handler().postDelayed(new Runnable() {
+
+            @Override
+            public void run() {
+                doubleBackToExitPressedOnce = false;
+            }
+        }, 2000);
     }
+    
 
     @Override
     protected void onDestroy() {


### PR DESCRIPTION
Fixes #1583 

**Changes**: 

Double back press to exit oscilloscope

**Screenshot/s for the changes**: 

<img width="601" alt="screenshot_2019-03-04-22-24-08-04 1" src="https://user-images.githubusercontent.com/43132209/53751115-90352600-3ed1-11e9-893e-2e3691c97709.png">


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:

[back_button.zip](https://github.com/fossasia/pslab-android/files/2927521/back_button.zip)

