### PR TITLE
Fix #1568 #1569 recording snackbar "open" button takes to data logger activity

### DIFF
--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -404,12 +404,8 @@ public abstract class PSLabSensor extends AppCompatActivity {
                 new View.OnClickListener() {
                     @Override
                     public void onClick(View view) {
-                        Uri selectedUri = Uri.parse(logDirectory.getAbsolutePath());
-                        Intent intent = new Intent(Intent.ACTION_VIEW);
-                        intent.setDataAndType(selectedUri, "resource/folder");
-                        if (intent.resolveActivityInfo(getPackageManager(), 0) != null) {
-                            startActivity(intent);
-                        }
+                        Intent intent = new Intent(PSLabSensor.this, DataLoggerActivity.class);
+                        startActivity(intent);
                     }
                 }, Snackbar.LENGTH_INDEFINITE);
     }


### PR DESCRIPTION
Fixes #1569 #1568

**Changes**: OPen button snackbar takes to data logger activity

**Screenshot/s for the changes**: 
![20190306_192700](https://user-images.githubusercontent.com/32041242/53886615-6cdfb780-4046-11e9-8a2d-afe82d110082.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

