### PR TITLE
feat:Toast message for Lux Meter data recording

### DIFF
--- a/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/LuxMeterActivity.java
@@ -1,8 +1,10 @@
 package io.pslab.activity;
 
 import android.content.SharedPreferences;
+import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v7.preference.PreferenceManager;
+import android.widget.Toast;
 
 import io.pslab.R;
 import io.pslab.fragment.LuxMeterDataFragment;
@@ -19,6 +21,13 @@ public class LuxMeterActivity extends PSLabSensor {
     private static final String PREF_NAME = "customDialogPreference";
     public final String LUXMETER_LIMIT = "luxmeter_limit";
     public RealmResults<LuxData> recordedLuxData;
+    
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Toast.makeText(getApplicationContext(), getString(R.string.rec_msg), Toast.LENGTH_SHORT)
+                .show();
+    }
 
     @Override
     public int getMenu() {
@@ -77,6 +86,8 @@ public class LuxMeterActivity extends PSLabSensor {
         realm.beginTransaction();
         realm.copyToRealm((LuxData) sensorData);
         realm.commitTransaction();
+         Toast.makeText(getApplicationContext(), getString(R.string.stoprec_msg), Toast.LENGTH_SHORT)
+                .show();
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,10 @@
     <string name="closeDrawer">close_drawer</string>
 
     <string name="Toast_double_tap">Press again to close PSLab</string>
+    
+    <string name="rec_msg">Tap on REC to start data recording</string>
+    <string name="stoprec_msg">Tap on STOP to stop data recording</string>
+
 
     <string name="nav_device">Device</string>
     <string name="nav_instruments">Instruments</string>


### PR DESCRIPTION
Fixes #1587 

**Changes**: 

Adding toast message for guiding users to start or stop data recording in LuxMeter

**Screenshot/s for the changes**: 

<img width="162" alt="screenshot_2019-03-05-22-36-22-84 1" src="https://user-images.githubusercontent.com/43132209/53902738-df14c400-4067-11e9-99b8-bb7c2f0cd35b.png">

<img width="162" alt="screenshot_2019-03-05-22-46-21-27 1" src="https://user-images.githubusercontent.com/43132209/53902748-e76cff00-4067-11e9-998a-f53d8250ea15.png">


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 

[LuxMeterActivity.zip](https://github.com/fossasia/pslab-android/files/2937635/LuxMeterActivity.zip)

