### PR TITLE
Fix #1603 pin layout option removed from faq/about fragment

### DIFF
--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -428,6 +428,8 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
+        menu.findItem(R.id.menu_pslab_layout_back).setVisible(!(navItemIndex == 3 || navItemIndex == 4));
+        menu.findItem(R.id.menu_pslab_layout_front).setVisible(!(navItemIndex == 3 || navItemIndex == 4));
         menu.getItem(0).setVisible(PSLabisConnected);
         menu.getItem(1).setVisible(!PSLabisConnected);
         setPSLabVersionIDs();


### PR DESCRIPTION
Fixes #1603 
**Changes**:Removed unnecessary menu items from FAQ / about fragment. 
**Screenshot/s for the changes**:
![screenshot_20190308-122601](https://user-images.githubusercontent.com/32041242/54013054-ee962900-419d-11e9-833a-bb672d4b3677.png)
![screenshot_20190308-122555](https://user-images.githubusercontent.com/32041242/54013056-ef2ebf80-419d-11e9-9560-338708d3d9ca.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members


