### PR TITLE
Fix #1605 expand/collapse option added to FAQ fragment

### DIFF
--- a/app/src/main/java/io/pslab/fragment/FAQFragment.java
+++ b/app/src/main/java/io/pslab/fragment/FAQFragment.java
@@ -45,11 +45,28 @@ public class FAQFragment extends Fragment {
     public void onViewCreated(View view, Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         ExpandableListView listView;
-
+        TextView expandAllLabel;
+        expandAllLabel = view.findViewById(R.id.faq_expand_label);
         listView = (ExpandableListView) view.findViewById(R.id.expListView);
         listView.setAdapter(new ExpandableListAdapter(questions, answers));
         listView.setGroupIndicator(null);
-
+        expandAllLabel.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (expandAllLabel.getText().equals(getString(R.string.expand_all_label))) {
+                    for (int i = 0; i < questions.length; i++) {
+                        listView.expandGroup(i);
+                    }
+                    expandAllLabel.setText(getString(R.string.collapse_all_label));
+                }
+                else {
+                    for (int i = 0; i < questions.length; i++) {
+                        listView.collapseGroup(i);
+                    }
+                    expandAllLabel.setText(getString(R.string.expand_all_label));
+                }
+            }
+        });
     }
 
     public class ExpandableListAdapter extends BaseExpandableListAdapter {

--- a/app/src/main/res/layout/fragment_faq.xml
+++ b/app/src/main/res/layout/fragment_faq.xml
@@ -5,7 +5,17 @@
     android:layout_height="match_parent"
     android:background="@color/white"
     android:orientation="vertical">
-
+    <TextView
+        android:id="@+id/faq_expand_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/expand_all_label"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="end"
+        android:textColor="@color/colorPrimaryDark"
+        android:layout_marginRight="@dimen/faq_answer_margin"
+        />
     <ExpandableListView
         android:id="@+id/expListView"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1093,5 +1093,6 @@
     <string name="no_data_fetched">No Data Fetched</string>
     <string name="recorder">Recorder</string>
     <string name="save_graph">Save Graph</string>
-
+    <string name="expand_all_label">Expand All</string>
+    <string name="collapse_all_label">Collapse All</string>
 </resources>


### PR DESCRIPTION
Fixes #1605 
**Changes**: Added a clickable label on top of FAQ to expand/ collapse all questions.

**Screenshot/s for the changes**: 

![20190308_161242](https://user-images.githubusercontent.com/32041242/54024443-d0402580-41bd-11e9-8834-73727d8a62fb.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

