### PR TITLE
Fix # button to open guide added to Oscilloscope, logic analyzer and wave generator

### DIFF
--- a/app/src/main/java/io/pslab/activity/LogicalAnalyzerActivity.java
+++ b/app/src/main/java/io/pslab/activity/LogicalAnalyzerActivity.java
@@ -91,6 +91,15 @@ public class LogicalAnalyzerActivity extends AppCompatActivity {
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
+
+        ImageView guideImageView = findViewById(R.id.logic_analyzer_guide_button);
+        guideImageView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                bottomSheetBehavior.setState(bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN ?
+                        BottomSheetBehavior.STATE_EXPANDED : BottomSheetBehavior.STATE_HIDDEN);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -380,6 +380,15 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
         };
         monitorThread = new Thread(runnable);
         monitorThread.start();
+
+        ImageView guideImageView = findViewById(R.id.oscilloscope_guide_button);
+        guideImageView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                bottomSheetBehavior.setState(bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN ?
+                        BottomSheetBehavior.STATE_EXPANDED : BottomSheetBehavior.STATE_HIDDEN);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -442,6 +442,15 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 //do nothing
             }
         });
+
+        ImageView guideImageView = findViewById(R.id.wave_generator_guide_button);
+        guideImageView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                bottomSheetBehavior.setState(bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN ?
+                        BottomSheetBehavior.STATE_EXPANDED : BottomSheetBehavior.STATE_HIDDEN);
+            }
+        });
     }
 
     @Override

--- a/app/src/main/res/layout/activity_logic_analyzer.xml
+++ b/app/src/main/res/layout/activity_logic_analyzer.xml
@@ -28,6 +28,12 @@
         android:alpha="0"
         android:background="@color/black" />
 
+    <ImageView
+        android:id="@+id/logic_analyzer_guide_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/menu_icon_guide"
+        />
     <include layout="@layout/bottom_sheet_custom" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_oscilloscope.xml
+++ b/app/src/main/res/layout/activity_oscilloscope.xml
@@ -175,6 +175,12 @@
                     app:srcCompat="@drawable/red_led" />
             </android.support.constraint.ConstraintLayout>
 
+            <ImageView
+                android:id="@+id/oscilloscope_guide_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/menu_icon_guide"
+                />
         </RelativeLayout>
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_wave_generator.xml
+++ b/app/src/main/res/layout/activity_wave_generator.xml
@@ -535,7 +535,6 @@
                 app:layout_constraintVertical_bias="0.70" />
 
         </android.support.constraint.ConstraintLayout>
-
     </android.support.constraint.ConstraintLayout>
 
     <RelativeLayout

--- a/app/src/main/res/layout/activity_wave_generator_main.xml
+++ b/app/src/main/res/layout/activity_wave_generator_main.xml
@@ -11,7 +11,13 @@
         android:layout_height="match_parent"
         android:background="@color/black"
         android:alpha="0"/>
-
+    <ImageView
+        android:id="@+id/wave_generator_guide_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/menu_icon_guide"
+        android:layout_margin="@dimen/body_resistance_margin"
+        />
     <include layout="@layout/btm_sheet_wavegen_custom" />
 
 </android.support.design.widget.CoordinatorLayout>


### PR DESCRIPTION
Fixes #1599

**Changes**: button to open guide added to Oscilloscope, logic analyzer and wave generator

**Screenshot/s for the changes**: 

![screenshot_20190308-173819](https://user-images.githubusercontent.com/32041242/54028520-4434fa80-41cb-11e9-9930-fe9b05d52f35.png)
![screenshot_20190308-173806](https://user-images.githubusercontent.com/32041242/54028521-44cd9100-41cb-11e9-87cf-8fa40cc3946f.png)
![screenshot_20190308-173753](https://user-images.githubusercontent.com/32041242/54028522-44cd9100-41cb-11e9-8a4a-ff83dee1562b.png)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members


