### PR TITLE
Fix #1600 show logged data option added to multimeter menu

### DIFF
--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -58,6 +58,10 @@ public class DataLoggerActivity extends AppCompatActivity {
                 getSupportActionBar().setTitle(caller);
                 categoryData = LocalDataLog.with().getTypeOfSensorBlocks(getString(R.string.baro_meter));
                 break;
+            case "Multimeter":
+                getSupportActionBar().setTitle(caller);
+                categoryData = LocalDataLog.with().getTypeOfSensorBlocks(getString(R.string.multimeter));
+                break;
             default:
                 categoryData = LocalDataLog.with().getAllSensorBlocks();
                 getSupportActionBar().setTitle(getString(R.string.logged_data));

--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -474,6 +474,11 @@ public class MultimeterActivity extends AppCompatActivity {
             case android.R.id.home:
                 this.finish();
                 break;
+            case R.id.multimeter_show_data:
+                Intent intent = new Intent(this, DataLoggerActivity.class);
+                intent.putExtra(DataLoggerActivity.CALLER_ACTIVITY, getResources().getString(R.string.multimeter));
+                startActivity(intent);
+                break;
             default:
                 break;
         }

--- a/app/src/main/res/menu/multimeter_log_menu.xml
+++ b/app/src/main/res/menu/multimeter_log_menu.xml
@@ -17,6 +17,11 @@
         android:title="@string/save_csv_data"
         app:showAsAction="never" />
     <item
+        android:id="@+id/multimeter_show_data"
+        android:icon="@drawable/menu_icon_save"
+        android:title="@string/show_logged_data"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/settings"
         android:title="@string/multimeter_configurations"
         app:showAsAction="never" />


### PR DESCRIPTION
Fixes #1600

**Changes**: show logged data option added to multimeter menu

**Screenshot/s for the changes**: 
![20190309_010320](https://user-images.githubusercontent.com/32041242/54051209-43ba5500-4207-11e9-8115-3fa8e6ca75c2.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

