### PR TITLE
Fix #1614 shared preference editor.commit replaced with better option editor.apply

### DIFF
--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -154,13 +154,13 @@ public class MultimeterActivity extends AppCompatActivity {
                 switchIsChecked = isChecked;
                 SharedPreferences.Editor editor = multimeter_data.edit();
                 editor.putBoolean("SwitchState", switchIsChecked);
-                editor.commit();
+                editor.apply();
             }
         });
         reset.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                multimeter_data.edit().clear().commit();
+                multimeter_data.edit().clear().apply();
                 switchIsChecked = false;
                 aSwitch.setChecked(false);
                 knobState = 2;
@@ -367,7 +367,7 @@ public class MultimeterActivity extends AppCompatActivity {
         SharedPreferences.Editor editor = multimeter_data.edit();
         editor.putString("TextBox", Quantity);
         editor.putString("TextBoxUnit", Unit);
-        editor.commit();
+        editor.apply();
         quantity.setText(Quantity);
         unit.setText(Unit);
     }
@@ -380,7 +380,7 @@ public class MultimeterActivity extends AppCompatActivity {
     private void saveKnobState(int state) {
         SharedPreferences.Editor editor = multimeter_data.edit();
         editor.putInt("KnobState", state);
-        editor.commit();
+        editor.apply();
     }
 
     @Override

--- a/app/src/main/java/io/pslab/fragment/BaroMeterSettingsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BaroMeterSettingsFragment.java
@@ -88,7 +88,7 @@ public class BaroMeterSettingsFragment extends PreferenceFragmentCompat implemen
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();
                     editor.putString(s, "1000");
-                    editor.commit();
+                    editor.apply();
                 }
                 break;
             case KEY_HIGH_LIMIT:
@@ -104,7 +104,7 @@ public class BaroMeterSettingsFragment extends PreferenceFragmentCompat implemen
                     highLimitPref.setText("1.1");
                     SharedPreferences.Editor editor = sharedPref.edit();
                     editor.putString(KEY_HIGH_LIMIT, "1.1");
-                    editor.commit();
+                    editor.apply();
                 }
                 break;
             case KEY_BARO_SENSOR_TYPE:

--- a/app/src/main/java/io/pslab/fragment/LuxMeterSettingFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LuxMeterSettingFragment.java
@@ -86,7 +86,7 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();
                     editor.putString(s, "1000");
-                    editor.commit();
+                    editor.apply();
                 }
                 break;
             case KEY_LUX_SENSOR_GAIN:
@@ -98,7 +98,7 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
                     sensorGainPref.setText("1");
                     SharedPreferences.Editor editor = sharedPref.edit();
                     editor.putString(KEY_LUX_SENSOR_GAIN, "1");
-                    editor.commit();
+                    editor.apply();
                 }
                 break;
             case KEY_HIGH_LIMIT:
@@ -110,7 +110,7 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
                     higLimitPref.setText("2000");
                     SharedPreferences.Editor editor = sharedPref.edit();
                     editor.putString(KEY_HIGH_LIMIT, "2000");
-                    editor.commit();
+                    editor.apply();
                 }
                 break;
             case KEY_LUX_SENSOR_TYPE:


### PR DESCRIPTION
Fixes #1614

**Changes**: Replaced editor.commit with editor.apply

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

