### PR TITLE
Added Toast message when sensor not present in Compass

### DIFF
--- a/app/src/main/java/io/pslab/activity/CompassActivity.java
+++ b/app/src/main/java/io/pslab/activity/CompassActivity.java
@@ -28,6 +28,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.util.Date;
 
@@ -109,11 +110,15 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
         setSupportActionBar(mToolbar);
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
+        mSensorManager = (SensorManager) getSystemService(SENSOR_SERVICE);
+        if((mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD))==null){
+            Toast.makeText(this, R.string.Toast_magnetic_not_present, Toast.LENGTH_SHORT).show();
+        }
 
         compassPreference = getSharedPreferences(PREFS_NAME, MODE_PRIVATE);
         setUpBottomSheet();
 
-        mSensorManager = (SensorManager) getSystemService(SENSOR_SERVICE);
+
         xAxisRadioButton.setChecked(true);
         direction = 0;
 
@@ -161,14 +166,21 @@ public class CompassActivity extends AppCompatActivity implements SensorEventLis
     protected void onResume() {
         super.onResume();
 
-        mSensorManager.registerListener(this, mSensorManager.getDefaultSensor(Sensor.TYPE_ORIENTATION), SensorManager.SENSOR_DELAY_GAME);
+        if((mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD))==null){
+            Toast.makeText(this, R.string.Toast_magnetic_not_present, Toast.LENGTH_SHORT).show();
+        }else {
+            mSensorManager.registerListener(this, mSensorManager.getDefaultSensor(Sensor.TYPE_ORIENTATION), SensorManager.SENSOR_DELAY_GAME);
+        }
     }
 
     @Override
     protected void onPause() {
         super.onPause();
-
-        mSensorManager.unregisterListener(this);
+        if((mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD))==null){
+            Toast.makeText(this, R.string.Toast_magnetic_not_present, Toast.LENGTH_SHORT).show();
+        }else {
+            mSensorManager.unregisterListener(this);
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="closeDrawer">close_drawer</string>
 
     <string name="Toast_double_tap">Press again to close PSLab</string>
+    <string name="Toast_magnetic_not_present">"The sensor required for this instrument is not present in your device"</string>
 
     <string name="nav_device">Device</string>
     <string name="nav_instruments">Instruments</string>
@@ -792,7 +793,7 @@
     <string name="text_parallel_axes">Select axes parallel to ground</string>
     <string name="unit_degree">°</string>
     <string name="compass_test_value">360°</string>
-    <string name="show_axis_help">Show Guide</string>
+    <string name="show_axis_help">Get current axis</string>
 
     <string name="compass_bottom_sheet_heading">Compass</string>
     <string name="compass_bottom_sheet_text">Compass instrument is used to navigate and to find magnetic field along axis. Compass instrument in PSLab app can be used with built-in mobile sensors or with sensor HMC5883L.</string>


### PR DESCRIPTION
Fixes #1634 

**Changes**: A toast message appears if the device dos not contain magnetic sensor

**Screenshot/s for the changes**: 
![toast](https://user-images.githubusercontent.com/37077735/54948224-21903900-4f62-11e9-8190-9feaa2dfc3d6.jpg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug (3).zip](https://github.com/fossasia/pslab-android/files/3005130/app-debug.3.zip)


