### PR TITLE
Fix #1647 Show guide option added to Accelerometer

### DIFF
--- a/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
+++ b/app/src/main/java/io/pslab/activity/AccelerometerActivity.java
@@ -244,6 +244,8 @@ public class AccelerometerActivity extends AppCompatActivity {
             case android.R.id.home:
                 this.finish();
                 break;
+            case R.id.show_guide:
+                bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
             default:
                 break;
         }

--- a/app/src/main/res/menu/data_log_menu.xml
+++ b/app/src/main/res/menu/data_log_menu.xml
@@ -12,6 +12,11 @@
         android:title="@string/delete_csv_data"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/show_guide"
+        android:icon="@drawable/menu_icon_guide"
+        android:title="@string/show_guide"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/record_csv_data"
         android:icon="@drawable/menu_icon_save"
         android:title="@string/save_csv_data"


### PR DESCRIPTION
Fixes #1647 

**Changes**: Added Show guide option to accelerometer

**Screenshot/s for the changes**: 
![20190327_110502](https://user-images.githubusercontent.com/32041242/55052990-c99c2400-5080-11e9-93b2-26a4b5b13e5e.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

