### PR TITLE
fix: wrong information displayed in Compass instrument

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -792,7 +792,7 @@
     <string name="text_parallel_axes">Select axes parallel to ground</string>
     <string name="unit_degree">°</string>
     <string name="compass_test_value">360°</string>
-    <string name="show_axis_help">Get current axis</string>
+    <string name="show_axis_help">Show Guide</string>
 
     <string name="compass_bottom_sheet_heading">Compass</string>
     <string name="compass_bottom_sheet_text">Compass instrument is used to navigate and to find magnetic field along axis. Compass instrument in PSLab app can be used with built-in mobile sensors or with sensor HMC5883L.</string>


### PR DESCRIPTION
Fixes #1656 

**Changes**: Changed wrong message displayed on long press of menu in compass instrument

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/34190580/55155147-a6569f00-517c-11e9-9b2a-cf3dd7ca2814.gif" width = "300px"/>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: [app-debug.zip](https://github.com/fossasia/pslab-android/files/3017797/app-debug.zip)
