### PR TITLE
Auto collapse other questions when new question expanded

### DIFF
--- a/app/src/main/java/io/pslab/fragment/FAQFragment.java
+++ b/app/src/main/java/io/pslab/fragment/FAQFragment.java
@@ -15,6 +15,7 @@ public class FAQFragment extends Fragment {
 
     private String[] questions;
     private String[][] answers;
+    private int lastExpandedPosition = -1;
 
     public static FAQFragment newInstance() {
         return new FAQFragment();
@@ -49,7 +50,15 @@ public class FAQFragment extends Fragment {
         listView = (ExpandableListView) view.findViewById(R.id.expListView);
         listView.setAdapter(new ExpandableListAdapter(questions, answers));
         listView.setGroupIndicator(null);
-
+        listView.setOnGroupExpandListener(new ExpandableListView.OnGroupExpandListener() {
+            @Override
+            public void onGroupExpand(int groupPosition) {
+                if(lastExpandedPosition != -1 && groupPosition != lastExpandedPosition){
+                    listView.collapseGroup(lastExpandedPosition);
+                }
+                lastExpandedPosition = groupPosition;
+            }
+        });
     }
 
     public class ExpandableListAdapter extends BaseExpandableListAdapter {


### PR DESCRIPTION
Fixes #1630 

**Changes**:Changes made to collapse other questions when new question is expanded.
**Screenshot/s for the changes**:

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/37077735/55236946-4567af00-51ee-11e9-87e9-71e7743871bc.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug (1).zip](https://github.com/fossasia/pslab-android/files/3022998/app-debug.1.zip)

