### PR TITLE
Fix #1610 additional gray view removed from the bottom of accelerometer layout

### DIFF
--- a/app/src/main/res/layout/activity_accelerometer.xml
+++ b/app/src/main/res/layout/activity_accelerometer.xml
@@ -29,7 +29,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@+id/top_app_bar_layout"
-        android:layout_marginBottom="50dp"
         android:layout_marginTop="?attr/actionBarSize"
         android:scrollbars="vertical" />
 


### PR DESCRIPTION
Fixes #1610 

**Changes**: removed bottom margin

**Screenshot/s for the changes**: 

**before:**
![Screenshot_20190308-180211](https://user-images.githubusercontent.com/32041242/55280569-727ea380-534d-11e9-919a-2d30a070b652.png)

**after**:
![Screenshot_20190331-003509](https://user-images.githubusercontent.com/32041242/55280552-3a776080-534d-11e9-9801-5caedcd44ad5.png)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

