### PR TITLE
Compass slide up guide fixed

### DIFF
--- a/app/src/main/res/layout/activity_compass.xml
+++ b/app/src/main/res/layout/activity_compass.xml
@@ -167,7 +167,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/card_compass_raw_values"
-                android:layout_marginBottom="@dimen/card_margin"
+                android:layout_marginBottom="@dimen/header_padding_top"
                 android:layout_marginEnd="@dimen/card_margin"
                 android:layout_marginLeft="@dimen/card_margin"
                 android:layout_marginRight="@dimen/card_margin"


### PR DESCRIPTION
Fixes #1639 

**Changes**: Increased margin bottom of layout to slide up the guide.

**Screenshot/s for the changes**: 
![còmpass gif](https://user-images.githubusercontent.com/37077735/55287416-63075680-535d-11e9-8cf9-f0ff5042cb3b.gif)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[app-debug (2).zip](https://github.com/fossasia/pslab-android/files/3026444/app-debug.2.zip)
