### PR TITLE
Decimals in Luxmeter made consistent

### DIFF
--- a/app/src/main/java/io/pslab/fragment/LuxMeterDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LuxMeterDataFragment.java
@@ -183,8 +183,8 @@ public class LuxMeterDataFragment extends Fragment {
             y.setAxisMaximum(currentMax);
             y.setAxisMinimum(currentMin);
             y.setLabelCount(10);
-            statMax.setText(String.valueOf(currentMax));
-            statMin.setText(String.valueOf(currentMin));
+            statMax.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, currentMax));
+            statMin.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, currentMin));
             statMean.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, (sum / recordedLuxArray.size())));
 
             LineDataSet dataSet = new LineDataSet(entries, getString(R.string.lux));
@@ -236,11 +236,11 @@ public class LuxMeterDataFragment extends Fragment {
                                 turns++;
                                 if (currentMax < d.getLux()) {
                                     currentMax = d.getLux();
-                                    statMax.setText(String.valueOf(d.getLux()));
+                                    statMax.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, d.getLux()));
                                 }
                                 if (currentMin > d.getLux()) {
                                     currentMin = d.getLux();
-                                    statMin.setText(String.valueOf(d.getLux()));
+                                    statMin.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, d.getLux()));
                                 }
                                 y.setAxisMaximum(currentMax);
                                 y.setAxisMinimum(currentMin);
@@ -418,11 +418,11 @@ public class LuxMeterDataFragment extends Fragment {
     private void visualizeData() {
         if (currentMax < luxValue) {
             currentMax = luxValue;
-            statMax.setText(String.valueOf(luxValue));
+            statMax.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, luxValue));
         }
         if (currentMin > luxValue) {
             currentMin = luxValue;
-            statMin.setText(String.valueOf(luxValue));
+            statMin.setText(String.format(Locale.getDefault(), PSLabSensor.LUXMETER_DATA_FORMAT, luxValue));
         }
         y.setAxisMaximum(currentMax);
         y.setAxisMinimum(currentMin);


### PR DESCRIPTION
Fixes #1638 

**Changes**:All the readings have been to rounded off to 2 decimal place.

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/34190580/55749803-7bfbc000-5a5f-11e9-9e67-fb5fd99c086a.jpeg" width=300px>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [app-debug.zip](https://github.com/fossasia/pslab-android/files/3055666/app-debug.zip)
