### PR TITLE
Decimals in Barometer made consistent

### DIFF
--- a/app/src/main/java/io/pslab/fragment/BaroMeterDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BaroMeterDataFragment.java
@@ -180,8 +180,8 @@ public class BaroMeterDataFragment extends Fragment {
             y.setAxisMaximum(currentMax);
             y.setAxisMinimum(currentMin);
             y.setLabelCount(10);
-            statMax.setText(String.valueOf(currentMax));
-            statMin.setText(String.valueOf(currentMin));
+            statMax.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, currentMax));
+            statMin.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, currentMin));
             statMean.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, (sum / recordedBaroArray.size())));
 
             LineDataSet dataSet = new LineDataSet(entries, getString(R.string.baro_unit));
@@ -233,11 +233,11 @@ public class BaroMeterDataFragment extends Fragment {
                                 turns++;
                                 if (currentMax < d.getBaro()) {
                                     currentMax = d.getBaro();
-                                    statMax.setText(String.valueOf(d.getBaro()));
+                                    statMax.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, d.getBaro()));
                                 }
                                 if (currentMin > d.getBaro()) {
                                     currentMin = d.getBaro();
-                                    statMin.setText(String.valueOf(d.getBaro()));
+                                    statMin.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, d.getBaro()));
                                 }
                                 y.setAxisMaximum(currentMax);
                                 y.setAxisMinimum(currentMin);
@@ -415,11 +415,11 @@ public class BaroMeterDataFragment extends Fragment {
     private void visualizeData() {
         if (currentMax < baroValue) {
             currentMax = baroValue;
-            statMax.setText(String.valueOf(baroValue));
+            statMax.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, baroValue));
         }
         if (currentMin > baroValue) {
             currentMin = baroValue;
-            statMin.setText(String.valueOf(baroValue));
+            statMin.setText(String.format(Locale.getDefault(), PSLabSensor.BAROMETER_DATA_FORMAT, baroValue));
         }
         y.setAxisMaximum(currentMax);
         y.setAxisMinimum(currentMin);

--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -92,7 +92,7 @@ public abstract class PSLabSensor extends AppCompatActivity {
     public static final String LUXMETER_DATA_FORMAT = "%.2f";
     public static final String BAROMETER = "Barometer";
     public static final String BAROMETER_CONFIGURATIONS = "Barometer Configurations";
-    public static final String BAROMETER_DATA_FORMAT = "%.5f";
+    public static final String BAROMETER_DATA_FORMAT = "%.2f";
 
     @BindView(R.id.sensor_toolbar)
     Toolbar sensorToolBar;


### PR DESCRIPTION
Fixes #1633 
**Changes**: All the readings have been to rounded off to 2 decimal place.

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/34190580/55750847-df86ed00-5a61-11e9-8e22-7d60b15b104a.jpeg" width="300px"/>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [app-debug.zip](https://github.com/fossasia/pslab-android/files/3055944/app-debug.zip)

