### PR TITLE
Fix #1657 show guide option added

### DIFF
--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -479,6 +479,9 @@ public class MultimeterActivity extends AppCompatActivity {
                 intent.putExtra(DataLoggerActivity.CALLER_ACTIVITY, getResources().getString(R.string.multimeter));
                 startActivity(intent);
                 break;
+            case R.id.show_guide:
+                bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
+                break;
             default:
                 break;
         }

--- a/app/src/main/res/menu/multimeter_log_menu.xml
+++ b/app/src/main/res/menu/multimeter_log_menu.xml
@@ -12,6 +12,11 @@
         android:title="@string/delete_csv_data"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/show_guide"
+        android:icon="@drawable/menu_icon_save"
+        android:title="@string/show_guide"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/record_csv_data"
         android:icon="@drawable/menu_icon_save"
         android:title="@string/save_csv_data"


### PR DESCRIPTION
Fixes #1657 
**Changes**: Every instrument except multimeter had show guide option, so i have added that option to multimeter menu

**Screenshot/s for the changes**: 
![20190409_131452](https://user-images.githubusercontent.com/32041242/55782528-1db7f700-5aca-11e9-9800-36d2d1d5f040.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

