### PR TITLE
App Bar titles fixed using string resources

### DIFF
--- a/app/src/main/res/layout/activity_compass.xml
+++ b/app/src/main/res/layout/activity_compass.xml
@@ -167,7 +167,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/card_compass_raw_values"
-                android:layout_marginBottom="@dimen/card_margin"
+                android:layout_marginBottom="@dimen/header_padding_top"
                 android:layout_marginEnd="@dimen/card_margin"
                 android:layout_marginLeft="@dimen/card_margin"
                 android:layout_marginRight="@dimen/card_margin"

--- a/app/src/main/res/layout/activity_logic_analyzer.xml
+++ b/app/src/main/res/layout/activity_logic_analyzer.xml
@@ -11,7 +11,7 @@
         android:layout_height="wrap_content"
         android:background="@color/colorPrimary"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
-        app:title="Logical Analyzer" />
+        app:title="@string/logical_analyzer" />
 
     <LinearLayout
         android:id="@+id/la_frame_layout"


### PR DESCRIPTION
Fixes #1620
**Changes**: Using string resources for multimeter and Logic Analyzer appbar title

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[Uploading app-debug.zip…]()

