### PR TITLE
WIP: Playback data from SD card feature added

### DIFF
--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -138,12 +138,12 @@ public class DataLoggerActivity extends AppCompatActivity {
         LayoutInflater inflater = this.getLayoutInflater();
         final View dialogView = inflater.inflate(R.layout.import_log_device_type_alert_layout, null);
         dialogBuilder.setView(dialogView);
-        dialogBuilder.setPositiveButton("Select", new DialogInterface.OnClickListener() {
+        dialogBuilder.setPositiveButton(getResources().getString(R.string.import_log_positive_button), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                RadioGroup votingAlgoRadioGroup = dialogView.findViewById(R.id.import_log_device_radio_group);
+                RadioGroup importLogRadioGroup = dialogView.findViewById(R.id.import_log_device_radio_group);
                 try {
-                    RadioButton selectedRadioButton = dialogView.findViewById(votingAlgoRadioGroup.getCheckedRadioButtonId());
+                    RadioButton selectedRadioButton = dialogView.findViewById(importLogRadioGroup.getCheckedRadioButtonId());
                     selectedDevice = selectedRadioButton.getText().toString();
                     selectFile();
                 } catch (Exception e) {
@@ -190,7 +190,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                             realm.copyToRealm(baroData);
                             realm.commitTransaction();
                         } catch (Exception e) {
-                            Toast.makeText(this, "File format does not match device log format", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(this, getResources().getString(R.string.incorrect_import_format), Toast.LENGTH_SHORT).show();
                         }
                     } else {
                         block = System.currentTimeMillis();
@@ -223,7 +223,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                             realm.copyToRealm(luxData);
                             realm.commitTransaction();
                         } catch (Exception e) {
-                            Toast.makeText(this, "File format does not match device log format", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(this, getResources().getString(R.string.incorrect_import_format), Toast.LENGTH_SHORT).show();
                         }
                     } else {
                         block = System.currentTimeMillis();

--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -20,7 +20,6 @@ import android.widget.RadioGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -57,6 +56,7 @@ public class DataLoggerActivity extends AppCompatActivity {
     private String selectedDevice = null;
     private Realm realm;
     private RealmResults<SensorDataBlock> categoryData;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -91,6 +91,7 @@ public class DataLoggerActivity extends AppCompatActivity {
         }
         fillData();
     }
+
     private void fillData() {
         if (categoryData.size() > 0) {
             blankView.setVisibility(View.GONE);
@@ -107,6 +108,7 @@ public class DataLoggerActivity extends AppCompatActivity {
             blankView.setVisibility(View.VISIBLE);
         }
     }
+
     @Override
     public void onBackPressed() {
         finish();
@@ -140,11 +142,11 @@ public class DataLoggerActivity extends AppCompatActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 RadioGroup votingAlgoRadioGroup = dialogView.findViewById(R.id.import_log_device_radio_group);
-                try{
+                try {
                     RadioButton selectedRadioButton = dialogView.findViewById(votingAlgoRadioGroup.getCheckedRadioButtonId());
                     selectedDevice = selectedRadioButton.getText().toString();
                     selectFile();
-                }catch (Exception e){
+                } catch (Exception e) {
                     Toast.makeText(DataLoggerActivity.this, getResources().getString(R.string.import_data_log_no_selection_error), Toast.LENGTH_SHORT).show();
                 }
             }
@@ -178,7 +180,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                 String line = reader.readLine();
                 int i = 0;
                 long block = 0, time = 0;
-                while(line != null){
+                while (line != null) {
                     if (i != 0) {
                         String[] data = line.split(",");
                         try {
@@ -187,18 +189,17 @@ public class DataLoggerActivity extends AppCompatActivity {
                             realm.beginTransaction();
                             realm.copyToRealm(baroData);
                             realm.commitTransaction();
-                        }catch (Exception e) {
+                        } catch (Exception e) {
                             Toast.makeText(this, "File format does not match device log format", Toast.LENGTH_SHORT).show();
                         }
-                    }
-                    else {
+                    } else {
                         block = System.currentTimeMillis();
                         time = block;
                         realm.beginTransaction();
                         realm.copyToRealm(new SensorDataBlock(block, getResources().getString(R.string.baro_meter)));
                         realm.commitTransaction();
                     }
-                    i ++;
+                    i++;
                     line = reader.readLine();
                 }
                 fillData();
@@ -212,7 +213,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                 String line = reader.readLine();
                 int i = 0;
                 long block = 0, time = 0;
-                while(line != null){
+                while (line != null) {
                     if (i != 0) {
                         String[] data = line.split(",");
                         try {
@@ -221,18 +222,17 @@ public class DataLoggerActivity extends AppCompatActivity {
                             realm.beginTransaction();
                             realm.copyToRealm(luxData);
                             realm.commitTransaction();
-                        }catch (Exception e) {
+                        } catch (Exception e) {
                             Toast.makeText(this, "File format does not match device log format", Toast.LENGTH_SHORT).show();
                         }
-                    }
-                    else {
+                    } else {
                         block = System.currentTimeMillis();
                         time = block;
                         realm.beginTransaction();
                         realm.copyToRealm(new SensorDataBlock(block, getResources().getString(R.string.lux_meter)));
                         realm.commitTransaction();
                     }
-                    i ++;
+                    i++;
                     line = reader.readLine();
                 }
                 fillData();

--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -1,21 +1,41 @@
 package io.pslab.activity;
 
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextView;
+import android.widget.Toast;
+
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import io.pslab.R;
 import io.pslab.adapters.SensorLoggerListAdapter;
+import io.pslab.models.BaroData;
+import io.pslab.models.LuxData;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.LocalDataLog;
+import io.realm.Realm;
 import io.realm.RealmResults;
 
 /**
@@ -34,12 +54,16 @@ public class DataLoggerActivity extends AppCompatActivity {
     @BindView(R.id.toolbar)
     Toolbar toolbar;
 
+    private String selectedDevice = null;
+    private Realm realm;
+    private RealmResults<SensorDataBlock> categoryData;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_data_logger);
         ButterKnife.bind(this);
         setSupportActionBar(toolbar);
+        realm = LocalDataLog.with().getRealm();
         String caller = getIntent().getStringExtra(CALLER_ACTIVITY);
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -47,7 +71,6 @@ public class DataLoggerActivity extends AppCompatActivity {
         }
         if (caller == null) caller = "";
 
-        RealmResults<SensorDataBlock> categoryData;
 
         switch (caller) {
             case "Lux Meter":
@@ -66,7 +89,9 @@ public class DataLoggerActivity extends AppCompatActivity {
                 categoryData = LocalDataLog.with().getAllSensorBlocks();
                 getSupportActionBar().setTitle(getString(R.string.logged_data));
         }
-
+        fillData();
+    }
+    private void fillData() {
         if (categoryData.size() > 0) {
             blankView.setVisibility(View.GONE);
             SensorLoggerListAdapter adapter = new SensorLoggerListAdapter(categoryData, this);
@@ -82,7 +107,6 @@ public class DataLoggerActivity extends AppCompatActivity {
             blankView.setVisibility(View.VISIBLE);
         }
     }
-
     @Override
     public void onBackPressed() {
         finish();
@@ -94,7 +118,127 @@ public class DataLoggerActivity extends AppCompatActivity {
             case android.R.id.home:
                 finish();
                 return true;
+            case R.id.action_import_log:
+                importLog();
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.activity_data_logger_menu, menu);
+        return true;
+    }
+
+    private void importLog() {
+        AlertDialog alertDialog;
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
+        LayoutInflater inflater = this.getLayoutInflater();
+        final View dialogView = inflater.inflate(R.layout.import_log_device_type_alert_layout, null);
+        dialogBuilder.setView(dialogView);
+        dialogBuilder.setPositiveButton("Select", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                RadioGroup votingAlgoRadioGroup = dialogView.findViewById(R.id.import_log_device_radio_group);
+                try{
+                    RadioButton selectedRadioButton = dialogView.findViewById(votingAlgoRadioGroup.getCheckedRadioButtonId());
+                    selectedDevice = selectedRadioButton.getText().toString();
+                    selectFile();
+                }catch (Exception e){
+                    Toast.makeText(DataLoggerActivity.this, getResources().getString(R.string.import_data_log_no_selection_error), Toast.LENGTH_SHORT).show();
+                }
+            }
+        });
+        alertDialog = dialogBuilder.create();
+        alertDialog.show();
+    }
+
+    private void selectFile() {
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType("*/*");
+        startActivityForResult(intent, 100);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
+        if (requestCode == 100) {
+            Uri uri = data.getData();
+            String path = uri.getPath();
+            path = path.replace("/root_path/", "/");
+            File file = new File(path);
+            getFileData(file);
+        }
+    }
+
+    private void getFileData(File file) {
+        if (selectedDevice != null && selectedDevice.equals(getResources().getString(R.string.baro_meter))) {
+            try {
+                FileInputStream is = new FileInputStream(file);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                String line = reader.readLine();
+                int i = 0;
+                long block = 0, time = 0;
+                while(line != null){
+                    if (i != 0) {
+                        String[] data = line.split(",");
+                        try {
+                            time += 1000;
+                            BaroData baroData = new BaroData(time, block, Float.valueOf(data[2]), Double.valueOf(data[3]), Double.valueOf(data[4]));
+                            realm.beginTransaction();
+                            realm.copyToRealm(baroData);
+                            realm.commitTransaction();
+                        }catch (Exception e) {
+                            Toast.makeText(this, "File format does not match device log format", Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                    else {
+                        block = System.currentTimeMillis();
+                        time = block;
+                        realm.beginTransaction();
+                        realm.copyToRealm(new SensorDataBlock(block, getResources().getString(R.string.baro_meter)));
+                        realm.commitTransaction();
+                    }
+                    i ++;
+                    line = reader.readLine();
+                }
+                fillData();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else if (selectedDevice != null && selectedDevice.equals(getResources().getString(R.string.lux_meter))) {
+            try {
+                FileInputStream is = new FileInputStream(file);
+                BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+                String line = reader.readLine();
+                int i = 0;
+                long block = 0, time = 0;
+                while(line != null){
+                    if (i != 0) {
+                        String[] data = line.split(",");
+                        try {
+                            time += 1000;
+                            LuxData luxData = new LuxData(time, block, Float.valueOf(data[2]), Double.valueOf(data[3]), Double.valueOf(data[4]));
+                            realm.beginTransaction();
+                            realm.copyToRealm(luxData);
+                            realm.commitTransaction();
+                        }catch (Exception e) {
+                            Toast.makeText(this, "File format does not match device log format", Toast.LENGTH_SHORT).show();
+                        }
+                    }
+                    else {
+                        block = System.currentTimeMillis();
+                        time = block;
+                        realm.beginTransaction();
+                        realm.copyToRealm(new SensorDataBlock(block, getResources().getString(R.string.lux_meter)));
+                        realm.commitTransaction();
+                    }
+                    i ++;
+                    line = reader.readLine();
+                }
+                fillData();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/import_log_device_type_alert_layout.xml
+++ b/app/src/main/res/layout/import_log_device_type_alert_layout.xml
@@ -8,32 +8,26 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerInParent="true"
-        android:padding="50dp"
-        >
+        android:padding="50dp">
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/baro_meter"
-            />
+            android:text="@string/baro_meter" />
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/lux_meter"
-            />
+            android:text="@string/lux_meter" />
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/multimeter"
-            />
+            android:text="@string/multimeter" />
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/accelerometer"
-            />
+            android:text="@string/accelerometer" />
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="@string/compass"
-            />
+            android:text="@string/compass" />
     </RadioGroup>
 </RelativeLayout>

--- a/app/src/main/res/layout/import_log_device_type_alert_layout.xml
+++ b/app/src/main/res/layout/import_log_device_type_alert_layout.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <RadioGroup
+        android:id="@+id/import_log_device_radio_group"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:padding="50dp"
+        >
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/baro_meter"
+            />
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/lux_meter"
+            />
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/multimeter"
+            />
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/accelerometer"
+            />
+        <RadioButton
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/compass"
+            />
+    </RadioGroup>
+</RelativeLayout>

--- a/app/src/main/res/menu/activity_data_logger_menu.xml
+++ b/app/src/main/res/menu/activity_data_logger_menu.xml
@@ -4,6 +4,5 @@
     <item
         android:title="@string/import_log_action"
         android:id="@+id/action_import_log"
-        app:showAsAction="never"
         />
 </menu>

--- a/app/src/main/res/menu/activity_data_logger_menu.xml
+++ b/app/src/main/res/menu/activity_data_logger_menu.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:title="@string/import_log_action"
+        android:id="@+id/action_import_log"
+        app:showAsAction="never"
+        />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1116,5 +1116,6 @@
     <string name="no_data_fetched">No Data Fetched</string>
     <string name="recorder">Recorder</string>
     <string name="save_graph">Save Graph</string>
-
+    <string name="import_log_action">Import Log</string>
+    <string name="import_data_log_no_selection_error">Kindly select one of the devices</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -975,6 +975,11 @@
     <string name="pause_recording_data">Pause Recording</string>
     <string name="view_map">View Map</string>
 
+    <string name="incorrect_import_format">File format does not match device log format</string>
+    <string name="import_log_action">Import Log</string>
+    <string name="import_data_log_no_selection_error">Kindly select one of the devices</string>
+    <string name="import_log_positive_button">Select</string>
+
     <string name="data_recording_with_location">Data recording started with location</string>
     <string name="data_recording_with_nogps">Data recording started but GPS is off</string>
     <string name="data_recording_with_gps_off">Recorded data will not contain location</string>
@@ -1116,6 +1121,4 @@
     <string name="no_data_fetched">No Data Fetched</string>
     <string name="recorder">Recorder</string>
     <string name="save_graph">Save Graph</string>
-    <string name="import_log_action">Import Log</string>
-    <string name="import_data_log_no_selection_error">Kindly select one of the devices</string>
 </resources>


### PR DESCRIPTION
Fixes #1690 

**Changes**: 

I have added an option in data logger activity where user can import the log stored as CSV on the SD card for the instrument selected by the user. 

**Currently I have implemented this feature for Barometer and Lux meter. Once the mentors approves these changes I will add the other instruments as well**

**Screenshot/s for the changes**: 

Following are the steps to import log in the application

**step 1**

Create a CSV file on the SD card or local storage with proper headers and required fields as per selected instrument. (Following is a CSV for Luxmeter)
![Screenshot_20190416-025340](https://user-images.githubusercontent.com/32041242/56166797-20e44300-5ff4-11e9-8c8e-91d8121c0e05.png)

**step 2**

Open DataLogger Activity, go to import log menu and in the alert dialogg select appropriate device, once a device is selected user can browse through the phone storage and select a file to be imported.

![Screenshot_20190416-025351](https://user-images.githubusercontent.com/32041242/56166907-58eb8600-5ff4-11e9-99e3-f6c140ea610b.png)

![Screenshot_20190416-025355](https://user-images.githubusercontent.com/32041242/56166924-64d74800-5ff4-11e9-931e-8ea8f8af653e.png)

**step 3**

Once the file is selected, if the format of CSV is as per the selected instrument, the log entry of that file can be seen in the lit, clicking on it will play the logged data as usual.

![Screenshot_20190416-025409](https://user-images.githubusercontent.com/32041242/56166983-98b26d80-5ff4-11e9-9548-e5afcf075a69.png)

**GIFs**

![20190416_025441](https://user-images.githubusercontent.com/32041242/56167010-a831b680-5ff4-11e9-9fd4-fd2a280e97b3.gif)

![20190416_025459](https://user-images.githubusercontent.com/32041242/56167021-aec02e00-5ff4-11e9-80d4-6ba06f0be765.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[SD_card_playback.zip](https://github.com/fossasia/pslab-android/files/3082166/SD_card_playback.zip)

@CloudyPadmal  I have implemented this feature according to my understanding of the issue you filed. Kindly suggest any change you think must be required to successfully implement this feature