### PR TITLE
show logged data in barometer activty shows only barometer data

### DIFF
--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -54,7 +54,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                 getSupportActionBar().setTitle(caller);
                 categoryData = LocalDataLog.with().getTypeOfSensorBlocks(getString(R.string.lux_meter));
                 break;
-            case "Baro Meter":
+            case "Barometer":
                 getSupportActionBar().setTitle(caller);
                 categoryData = LocalDataLog.with().getTypeOfSensorBlocks(getString(R.string.baro_meter));
                 break;


### PR DESCRIPTION
Fixes #1645 

**Changes**: Now opening log activity from barometer activity will only show barometer logs.

**Screenshot/s for the changes**:
![20190509_200527](https://user-images.githubusercontent.com/32041242/57462357-521ffe00-7296-11e9-88b5-e02de4fb66e0.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

@abhinavraj23  @cweitat  @CloudyPadmal  Kindly review
