### PR TITLE
fix:thermometer crash fixed

### DIFF
--- a/app/src/main/res/layout/activity_thermometer.xml
+++ b/app/src/main/res/layout/activity_thermometer.xml
@@ -1,36 +1,137 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/thermometer_coordinator_layout"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/thermometer_linearlayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:orientation="vertical">
 
-    <android.support.design.widget.AppBarLayout
+    <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_margin="@dimen/card_margin">
 
-    </android.support.design.widget.AppBarLayout>
-
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:context=".activity.ThermometerActivity"
-        android:orientation="vertical">
-
-        <com.biansemao.widget.ThermometerView
-            android:id="@+id/tv_thermometer"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="60dp"
-            android:paddingBottom="30dp"
-            android:paddingTop="30dp" />
+            android:baselineAligned="false">
 
-    </LinearLayout>
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="3"
+                android:gravity="center_horizontal|center_vertical"
+                android:orientation="vertical">
 
-    <include layout="@layout/bottomsheet_compass" />
+                <TextView
+                    android:id="@+id/label_thermo_sensor"
+                    style="@style/lux_meter_stat_heading"
+                    android:paddingBottom="5dp"
+                    android:textSize="@dimen/lux_sensor_label_title_size" />
 
-</android.support.design.widget.CoordinatorLayout>
+                <TextView
+                    android:id="@+id/label_thermo_stat_max"
+                    style="@style/lux_meter_stat_heading"
+                    android:text="@string/max_thermo" />
+
+                <TextView
+                    android:id="@+id/thermo_max"
+                    style="@style/lux_meter_stat_display" />
+
+                <TextView
+                    android:id="@+id/label_thermo_stat_min"
+                    style="@style/lux_meter_stat_heading"
+                    android:text="@string/min_lx" />
+
+                <TextView
+                    android:id="@+id/thermo_min"
+                    style="@style/lux_meter_stat_display" />
+
+                <TextView
+                    android:id="@+id/label_thermo_stat_avg"
+                    style="@style/lux_meter_stat_heading"
+                    android:text="@string/avg_thermo" />
+
+                <TextView
+                    android:id="@+id/thermo_avg"
+                    style="@style/lux_meter_stat_display" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="match_parent"
+                android:layout_weight="5"
+                android:orientation="vertical">
+
+                <com.github.anastr.speedviewlib.PointerSpeedometer
+                    android:id="@+id/thermo_meter"
+                    android:layout_width="match_parent"
+                    android:layout_height="@dimen/speedometer_height"
+                    android:padding="15dp"
+                    app:sv_speedTextColor="@color/black"
+                    app:sv_speedTextPosition="BOTTOM_CENTER"
+                    app:sv_speedTextSize="@dimen/lux_display_font_size"
+                    app:sv_speedometerMode="NORMAL"
+                    app:sv_textSize="@dimen/lux_guage_font_size"
+                    app:sv_unit="@string/thermo_unit"
+                    app:sv_unitTextColor="@color/black" />
+
+            </LinearLayout>
+
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="@dimen/card_margin">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="4">
+
+            <RelativeLayout
+                android:id="@+id/chart_xaxis_layout_thermo"
+                style="@style/graph_x_axis_title_block">
+
+                <TextView
+                    android:id="@+id/tv_graph_label_xaxis_hmc_thermo"
+                    style="@style/graph_x_axis_title_text"
+                    android:text="@string/time"
+                    tools:layout_editor_absoluteX="288dp"
+                    tools:layout_editor_absoluteY="0dp" />
+
+            </RelativeLayout>
+
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/chart_yaxis_layout_hmc_thermo"
+                style="@style/graph_y_axis_title_block">
+
+                <TextView
+                    android:id="@+id/tv_label_left_yaxis_hmc_thermo"
+                    style="@style/graph_y_axis_title_text"
+                    android:text="@string/thermo_unit"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+            </android.support.constraint.ConstraintLayout>
+
+            <com.github.mikephil.charting.charts.LineChart
+                android:id="@+id/chart_thermo_meter"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@+id/chart_xaxis_layout_thermo"
+                android:layout_toEndOf="@+id/chart_yaxis_layout_hmc_thermo"
+                android:layout_toRightOf="@+id/chart_yaxis_layout_hmc_thermo"
+                android:background="@color/black" />
+        </RelativeLayout>
+
+    </android.support.v7.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,4 +787,7 @@
     <string name="thermometer_bottom_sheet_text">Thermometer instrument is used to measure ambient temprature. It can be measured using inbuilt ambient temprature sensor or through SHT21.</string>
     <string name="thermometer_bottom_sheet_desc">Thermometer instrument is used to measure ambient temprature. It can be measured using inbuilt ambient temprature sensor or through SHT21.</string>
     <string name="no_thermometer_sensor">Device does not have Thermometer Sensor</string>
+    <string name="max_thermo">Max (F)</string>
+    <string name="avg_thermo">Avg (F)</string>
+    <string name="thermo_unit">F</string>
 </resources>


### PR DESCRIPTION
Fixes #1752 

**Changes**: No crash on opening thermometer.

**Screenshot/s for the changes**: 
![Screenshot_20190528-003046_PSLab](https://user-images.githubusercontent.com/37077735/58498126-0082d900-819b-11e9-9985-30f1e40fd9a9.jpg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[app-debug.zip](https://github.com/fossasia/pslab-android/files/3228887/app-debug.zip)

