### PR TITLE
Visual message when no data fetched in gyroscope

### DIFF
--- a/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
@@ -17,6 +17,8 @@ import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.github.mikephil.charting.data.Entry;
@@ -65,6 +67,8 @@ public class GyroscopeDataFragment extends Fragment {
     private int[] colors = {Color.YELLOW, Color.MAGENTA, Color.GREEN};
     private DecimalFormat df = new DecimalFormat("+#0.0;-#0.0");
     private View rootView;
+    private TextView noSensorText;
+    private LinearLayout gyroLinearLayout;
 
     public static GyroscopeDataFragment newInstance() {
         return new GyroscopeDataFragment();
@@ -101,6 +105,8 @@ public class GyroscopeDataFragment extends Fragment {
 
         gyroscopeViewFragments.get(1).getGyroAxisImage().setImageResource(R.drawable.phone_y_axis);
         gyroscopeViewFragments.get(2).getGyroAxisImage().setImageResource(R.drawable.phone_z_axis);
+        gyroLinearLayout = rootView.findViewById(R.id.gyro_linearlayout);
+        noSensorText = new TextView(getContext());
 
         setupInstruments();
         return rootView;
@@ -114,9 +120,20 @@ public class GyroscopeDataFragment extends Fragment {
             resetInstrumentData();
             playRecordedData();
         } else if (gyroSensor.viewingData) {
-            recordedGyroArray = new ArrayList<>();
-            resetInstrumentData();
-            plotAllRecordedData();
+            if (sensorManager != null) {
+                recordedGyroArray = new ArrayList<>();
+                resetInstrumentData();
+                plotAllRecordedData();
+            }
+            else {
+                gyroscopeViewFragments.clear();
+                rootView.findViewById(R.id.gyroscope_x_axis_fragment).setVisibility(View.INVISIBLE);
+                rootView.findViewById(R.id.gyroscope_y_axis_fragment).setVisibility(View.INVISIBLE);
+                rootView.findViewById(R.id.gyroscope_z_axis_fragment).setVisibility(View.INVISIBLE);
+                noSensorText.setText(getResources().getString(R.string.no_data_recorded_gyro));
+                noSensorText.setAllCaps(true);
+                gyroLinearLayout.addView(noSensorText);
+            }
         } else if (!gyroSensor.isRecording) {
             updateGraphs();
             initiateGyroSensor();
@@ -133,6 +150,9 @@ public class GyroscopeDataFragment extends Fragment {
         }
         if (sensorManager != null) {
             sensorManager.unregisterListener(gyroScopeSensorEventListener);
+        }
+        else {
+            gyroLinearLayout.removeView(noSensorText);
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -787,6 +787,7 @@
     <string name="gyroscope_description_text">Orientation of the positive X, Y, and Z axes. For any positive axis on the device, clockwise rotation outputs negative values, and counterclockwise rotation outputs positive values.</string>
     <string name="gyroscope_config">Gyroscope Configuration</string>
     <string name="no_gyroscope_sensor">Your device does not have sensor required for this functionality</string>
+    <string name="no_data_recorded_gyro">No data recorded as the sensor is not present in the device. Try with an external sensor.</string>
     <string name="lux_meter">Lux Meter</string>
     <string name="lux_default_1000">1000</string>
     <string name="lux_default_2000">2000</string>


### PR DESCRIPTION
Fixes #1723

**Changes**: Graphs removed and a visual message to user when no data fetched

**Screenshot/s for the changes**: 
![Screenshot_20190610-231434_PSLab](https://user-images.githubusercontent.com/37077735/59215373-b6f0b000-8bd6-11e9-85c8-74d03050cc47.jpg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [ ] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[gyro.zip](https://github.com/fossasia/pslab-android/files/3273178/gyro.zip)
