### PR TITLE
Fix #1809 fourier transform can be seen while playing back saved log

### DIFF
--- a/app/src/main/java/io/pslab/fragment/OscilloscopePlaybackFragment.java
+++ b/app/src/main/java/io/pslab/fragment/OscilloscopePlaybackFragment.java
@@ -7,6 +7,8 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -30,6 +32,8 @@ public class OscilloscopePlaybackFragment extends Fragment {
         View rootView = inflater.inflate(R.layout.fragment_oscilloscope_playback, container, false);
         timebaseTextView = rootView.findViewById(R.id.timebase_data);
         playButton = rootView.findViewById(R.id.play_button);
+        CheckBox fourierCheckBox = rootView.findViewById(R.id.fourier_checkbox);
+
         playButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -42,6 +46,13 @@ public class OscilloscopePlaybackFragment extends Fragment {
                     playButton.setImageResource(R.drawable.pause_icon);
                     oscilloscopeActivity.playRecordedData();
                 }
+            }
+        });
+
+        fourierCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                oscilloscopeActivity.isPlaybackFourierChecked = isChecked;
             }
         });
         return rootView;


### PR DESCRIPTION
Fixes #1809 

**Changes**: User can now see Fourier transform of the saved log while playing it back

**Screenshot/s for the changes**: 
![20190620_171149](https://user-images.githubusercontent.com/32041242/59847019-0bd2ba00-937f-11e9-844e-b3b84393e0cd.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[playback_fft.zip](https://github.com/fossasia/pslab-android/files/3310233/playback_fft.zip)

@mariobehling  @CloudyPadmal  @cweitat  have a look :)
