### PR TITLE
config menu separated

### DIFF
--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -272,7 +272,7 @@ public abstract class PSLabSensor extends AppCompatActivity {
         }
         menu.findItem(R.id.save_graph).setVisible(viewingData || playingData);
         menu.findItem(R.id.play_data).setVisible(viewingData || playingData);
-        menu.findItem(R.id.settings).setTitle(getSensorName() + "Configurations");
+        menu.findItem(R.id.settings).setTitle(getSensorName() + " Configurations");
         menu.findItem(R.id.stop_data).setVisible(viewingData).setEnabled(startedPlay);
     }
 


### PR DESCRIPTION
Fixes #1879

**Changes**: Space added between instrument name and "Configurations"

**Screenshot/s for the changes**:
<img src = "https://user-images.githubusercontent.com/32041242/62003312-12e5a880-b133-11e9-80ad-b252cc3dee81.png" width = "300"/>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[config_menu.zip](https://github.com/fossasia/pslab-android/files/3438904/config_menu.zip)

