### PR TITLE
feat: Wave generator active even without pressing view button

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -587,7 +587,7 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         }
     }
 
-    private void viewWave() {
+    private void setWave() {
         double freq1 = (double) (WaveGeneratorCommon.wave.get(WaveConst.WAVE1).get(WaveConst.FREQUENCY));
         double freq2 = (double) WaveGeneratorCommon.wave.get(WaveConst.WAVE2).get(WaveConst.FREQUENCY);
         double phase = (double) WaveGeneratorCommon.wave.get(WaveConst.WAVE2).get(WaveConst.PHASE);
@@ -616,15 +616,15 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 scienceLab.sqrPWM(freqSqr1, dutySqr1, phaseSqr2, dutySqr2, phaseSqr3, dutySqr3, phaseSqr4, dutySqr4, false);
             }
 
-            waveDialog.show();
-            Window window = waveDialog.getWindow();
-            window.setLayout(dpToPx(350), dpToPx(300));
-            waveDialog.getButton(DialogInterface.BUTTON_NEGATIVE)
-                    .setTextColor(ContextCompat.getColor(WaveGeneratorActivity.this, R.color.colorPrimary));
-
-        } else {
-            Toast.makeText(WaveGeneratorActivity.this, R.string.device_not_connected, Toast.LENGTH_SHORT).show();
         }
+    }
+
+    private void viewWaveDialog() {
+        waveDialog.show();
+        Window window = waveDialog.getWindow();
+        window.setLayout(dpToPx(350), dpToPx(300));
+        waveDialog.getButton(DialogInterface.BUTTON_NEGATIVE)
+                .setTextColor(ContextCompat.getColor(WaveGeneratorActivity.this, R.color.colorPrimary));
     }
 
     @Override
@@ -643,7 +643,12 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 saveWaveConfig();
                 break;
             case R.id.play_data:
-                viewWave();
+                setWave();
+                if (scienceLab.isConnected()) {
+                    viewWaveDialog();
+                } else {
+                    Toast.makeText(WaveGeneratorActivity.this, R.string.device_not_connected, Toast.LENGTH_SHORT).show();
+                }
                 break;
             case R.id.show_guide:
                 bottomSheetBehavior.setState(bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN ?
@@ -925,7 +930,7 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         } else {
             WaveGeneratorCommon.wave.get(waveBtnActive).put(prop_active, value);
         }
-
+        setWave();
         Double dValue = (double) value;
         String valueText = DataFormatter.formatDouble(dValue, DataFormatter.MEDIUM_PRECISION_FORMAT) + " " + unit;
         activePropTv.setText(valueText);


### PR DESCRIPTION
Fixes #1928

**Changes**: Wave generator active even without pressing view button

**Screenshot/s for the changes**:
![20190818_234846](https://user-images.githubusercontent.com/32041242/63229026-48088680-c219-11e9-8f67-c5916ceaa650.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[wave.tar.gz](https://github.com/fossasia/pslab-android/files/3513445/wave.tar.gz)

