### PR TITLE
fix: degree and second symbols added to robotic arm timeline

### DIFF
--- a/app/src/main/java/io/pslab/activity/RoboticArmActivity.java
+++ b/app/src/main/java/io/pslab/activity/RoboticArmActivity.java
@@ -150,6 +150,11 @@ public class RoboticArmActivity extends AppCompatActivity {
         scrollView = findViewById(R.id.horizontal_scroll_view);
         servoCSVLogger = new CSVLogger(getResources().getString(R.string.robotic_arm));
 
+        degreeText1.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
+        degreeText2.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
+        degreeText3.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
+        degreeText4.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
+
         LinearLayout.LayoutParams servoControllerParams = new LinearLayout.LayoutParams(screen_width / 4 - 4, screen_height / 2 - 4);
         servoControllerParams.setMargins(2, 5, 2, 0);
         servo1Layout.setLayoutParams(servoControllerParams);
@@ -173,7 +178,7 @@ public class RoboticArmActivity extends AppCompatActivity {
             timeLineBox.setLayoutParams(servoTimeLineBoxParams);
             timeLineBox.setPadding(5, 5, 5, 5);
             TextView timeText = timeLineBox.findViewById(R.id.timeline_box_time_text);
-            timeText.setText(String.valueOf(i + 1));
+            timeText.setText(String.valueOf(i + 1) + getResources().getString(R.string.robotic_arm_second_unit));
             timeLineBox.setOnDragListener(servo1DragListener);
             servo1TimeLine.addView(timeLineBox, i);
         }
@@ -183,7 +188,7 @@ public class RoboticArmActivity extends AppCompatActivity {
             timeLineBox.setLayoutParams(servoTimeLineBoxParams);
             timeLineBox.setPadding(5, 5, 5, 5);
             TextView timeText = timeLineBox.findViewById(R.id.timeline_box_time_text);
-            timeText.setText(String.valueOf(i + 1));
+            timeText.setText(String.valueOf(i + 1) + getResources().getString(R.string.robotic_arm_second_unit));
             timeLineBox.setOnDragListener(servo2DragListener);
             servo2TimeLine.addView(timeLineBox, i);
         }
@@ -193,7 +198,7 @@ public class RoboticArmActivity extends AppCompatActivity {
             timeLineBox.setLayoutParams(servoTimeLineBoxParams);
             timeLineBox.setPadding(5, 5, 5, 5);
             TextView timeText = timeLineBox.findViewById(R.id.timeline_box_time_text);
-            timeText.setText(String.valueOf(i + 1));
+            timeText.setText(String.valueOf(i + 1) + getResources().getString(R.string.robotic_arm_second_unit));
             timeLineBox.setOnDragListener(servo3DragListener);
             servo3TimeLine.addView(timeLineBox, i);
         }
@@ -203,7 +208,7 @@ public class RoboticArmActivity extends AppCompatActivity {
             timeLineBox.setLayoutParams(servoTimeLineBoxParams);
             timeLineBox.setPadding(5, 5, 5, 5);
             TextView timeText = timeLineBox.findViewById(R.id.timeline_box_time_text);
-            timeText.setText(String.valueOf(i + 1));
+            timeText.setText(String.valueOf(i + 1) + getResources().getString(R.string.robotic_arm_second_unit));
             timeLineBox.setOnDragListener(servo4DragListener);
             servo4TimeLine.addView(timeLineBox, i);
         }
@@ -226,10 +231,10 @@ public class RoboticArmActivity extends AppCompatActivity {
             @Override
             public void onProgressChanged(SeekArc seekArc, int i, boolean b) {
                 if (editEnter) {
-                    degreeText1.setText(String.valueOf(degree));
+                    degreeText1.setText(String.valueOf(degree) + getResources().getString(R.string.robotic_arm_degree_symbol));
                     editEnter = false;
                 } else {
-                    degreeText1.setText(String.valueOf((int) (i * 3.6)));
+                    degreeText1.setText(String.valueOf((int) (i * 3.6)) + getResources().getString(R.string.robotic_arm_degree_symbol));
                 }
                 degreeText1.setCursorVisible(false);
             }
@@ -249,10 +254,10 @@ public class RoboticArmActivity extends AppCompatActivity {
             @Override
             public void onProgressChanged(SeekArc seekArc, int i, boolean b) {
                 if (editEnter) {
-                    degreeText2.setText(String.valueOf(degree));
+                    degreeText2.setText(String.valueOf(degree) + getResources().getString(R.string.robotic_arm_degree_symbol));
                     editEnter = false;
                 } else {
-                    degreeText2.setText(String.valueOf((int) (i * 3.6)));
+                    degreeText2.setText(String.valueOf((int) (i * 3.6)) + getResources().getString(R.string.robotic_arm_degree_symbol));
                 }
                 degreeText2.setCursorVisible(false);
             }
@@ -272,10 +277,10 @@ public class RoboticArmActivity extends AppCompatActivity {
             @Override
             public void onProgressChanged(SeekArc seekArc, int i, boolean b) {
                 if (editEnter) {
-                    degreeText3.setText(String.valueOf(degree));
+                    degreeText3.setText(String.valueOf(degree) + getResources().getString(R.string.robotic_arm_degree_symbol));
                     editEnter = false;
                 } else {
-                    degreeText3.setText(String.valueOf((int) (i * 3.6)));
+                    degreeText3.setText(String.valueOf((int) (i * 3.6)) + getResources().getString(R.string.robotic_arm_degree_symbol));
                 }
                 degreeText3.setCursorVisible(false);
             }
@@ -295,10 +300,10 @@ public class RoboticArmActivity extends AppCompatActivity {
             @Override
             public void onProgressChanged(SeekArc seekArc, int i, boolean b) {
                 if (editEnter) {
-                    degreeText4.setText(String.valueOf(degree));
+                    degreeText4.setText(String.valueOf(degree) + getResources().getString(R.string.robotic_arm_degree_symbol));
                     editEnter = false;
                 } else {
-                    degreeText4.setText(String.valueOf((int) (i * 3.6)));
+                    degreeText4.setText(String.valueOf((int) (i * 3.6)) + getResources().getString(R.string.robotic_arm_degree_symbol));
                 }
                 degreeText4.setCursorVisible(false);
             }
@@ -357,7 +362,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     degree = Integer.valueOf(degreeText1.getText().toString());
                     if (degree > 360 || degree < 0) {
-                        degreeText1.setText(getResources().getString(R.string.zero));
+                        degreeText1.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
                         seekArc1.setProgress(0);
                         toastInvalidValueMessage();
                     } else {
@@ -383,7 +388,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     degree = Integer.valueOf(degreeText2.getText().toString());
                     if (degree > 360 || degree < 0) {
-                        degreeText2.setText(getResources().getString(R.string.zero));
+                        degreeText2.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
                         seekArc2.setProgress(0);
                         toastInvalidValueMessage();
                     } else {
@@ -409,7 +414,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     degree = Integer.valueOf(degreeText3.getText().toString());
                     if (degree > 360 || degree < 0) {
-                        degreeText3.setText(getResources().getString(R.string.zero));
+                        degreeText3.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
                         seekArc3.setProgress(0);
                         toastInvalidValueMessage();
                     } else {
@@ -435,7 +440,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     degree = Integer.valueOf(degreeText4.getText().toString());
                     if (degree > 360 || degree < 0) {
-                        degreeText4.setText(getResources().getString(R.string.zero));
+                        degreeText4.setText(getResources().getString(R.string.zero) + getResources().getString(R.string.robotic_arm_degree_symbol));
                         seekArc4.setProgress(0);
                         toastInvalidValueMessage();
                     } else {
@@ -467,13 +472,13 @@ public class RoboticArmActivity extends AppCompatActivity {
                 timeIndicatorLayout.setLayoutParams(timeIndicatorParams);
                 scrollView.smoothScrollBy(screen_width / 6, 0);
                 String deg1 = ((TextView) servo1TimeLine.getChildAt(timelinePosition).findViewById(R.id.timeline_box_degree_text)).getText().toString();
-                deg1 = (deg1.length() > 0) ? deg1 : "0";
+                deg1 = (deg1.length() > 0) ? deg1.substring(0, deg1.length() - 1) : getResources().getString(R.string.zero);
                 String deg2 = ((TextView) servo2TimeLine.getChildAt(timelinePosition).findViewById(R.id.timeline_box_degree_text)).getText().toString();
-                deg2 = (deg2.length() > 0) ? deg2 : "0";
+                deg2 = (deg2.length() > 0) ? deg2.substring(0, deg2.length() - 1) : getResources().getString(R.string.zero);
                 String deg3 = ((TextView) servo3TimeLine.getChildAt(timelinePosition).findViewById(R.id.timeline_box_degree_text)).getText().toString();
-                deg3 = (deg3.length() > 0) ? deg3 : "0";
+                deg3 = (deg3.length() > 0) ? deg3.substring(0, deg3.length() - 1) : getResources().getString(R.string.zero);
                 String deg4 = ((TextView) servo4TimeLine.getChildAt(timelinePosition).findViewById(R.id.timeline_box_degree_text)).getText().toString();
-                deg4 = (deg4.length() > 0) ? deg4 : "0";
+                deg4 = (deg4.length() > 0) ? deg4.substring(0, deg4.length() - 1) : getResources().getString(R.string.zero);
                 if (scienceLab.isConnected()) {
                     scienceLab.servo4(Double.valueOf(deg1), Double.valueOf(deg2), Double.valueOf(deg3), Double.valueOf(deg4));
                 }
@@ -567,10 +572,10 @@ public class RoboticArmActivity extends AppCompatActivity {
         ArrayList servoDataList = new ArrayList(recordedServoData);
         for (int i = 0; i < servoDataList.size(); i++) {
             ServoData servoData = (ServoData) servoDataList.get(i);
-            ((TextView) servo1TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree1());
-            ((TextView) servo2TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree2());
-            ((TextView) servo3TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree3());
-            ((TextView) servo4TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree4());
+            ((TextView) servo1TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree1() + getResources().getString(R.string.robotic_arm_degree_symbol));
+            ((TextView) servo2TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree2() + getResources().getString(R.string.robotic_arm_degree_symbol));
+            ((TextView) servo3TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree3() + getResources().getString(R.string.robotic_arm_degree_symbol));
+            ((TextView) servo4TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).setText(servoData.getDegree4() + getResources().getString(R.string.robotic_arm_degree_symbol));
         }
     }
 
@@ -585,18 +590,22 @@ public class RoboticArmActivity extends AppCompatActivity {
         double lat, lon;
         for (int i = 0; i < 60; i++) {
             timestamp = System.currentTimeMillis();
-            degree1 = degree2 = degree3 = degree4 = "0";
+            degree1 = degree2 = degree3 = degree4 = getResources().getString(R.string.zero);
             if (((TextView) servo1TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().length() > 0) {
                 degree1 = ((TextView) servo1TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().toString();
+                degree1 = degree1.substring(0, degree1.length() - 1);
             }
             if (((TextView) servo2TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().length() > 0) {
                 degree2 = ((TextView) servo2TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().toString();
+                degree2 = degree2.substring(0, degree2.length() - 1);
             }
             if (((TextView) servo3TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().length() > 0) {
                 degree3 = ((TextView) servo3TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().toString();
+                degree3 = degree3.substring(0, degree3.length() - 1);
             }
             if (((TextView) servo4TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().length() > 0) {
                 degree4 = ((TextView) servo4TimeLine.getChildAt(i).findViewById(R.id.timeline_box_degree_text)).getText().toString();
+                degree4 = degree4.substring(0, degree4.length() - 1);
             }
             if (gpsLogger.isGPSEnabled()) {
                 Location location = gpsLogger.getDeviceLocation();
@@ -638,7 +647,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 View view = (View) event.getLocalState();
                 TextView text = view.findViewById(R.id.degreeText);
                 if (view.getId() == R.id.servo_1) {
-                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText());
+                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText().toString());
                 }
             }
             return true;
@@ -651,7 +660,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 View view = (View) event.getLocalState();
                 TextView text = view.findViewById(R.id.degreeText);
                 if (view.getId() == R.id.servo_2) {
-                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText());
+                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText().toString());
                 }
             }
             return true;
@@ -664,7 +673,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 View view = (View) event.getLocalState();
                 TextView text = view.findViewById(R.id.degreeText);
                 if (view.getId() == R.id.servo_3) {
-                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText());
+                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText().toString());
                 }
             }
             return true;
@@ -677,7 +686,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 View view = (View) event.getLocalState();
                 TextView text = view.findViewById(R.id.degreeText);
                 if (view.getId() == R.id.servo_4) {
-                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText());
+                    ((TextView) v.findViewById(R.id.timeline_box_degree_text)).setText(text.getText().toString());
                 }
             }
             return true;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -704,6 +704,9 @@
     <string name="ir_thermometer_desc">\u2022 The above pin configuration has to be same except for the pin
     GND. You can use any of the PSLab device GND pins.\n</string>
 
+    <string name="robotic_arm_second_unit">s</string>
+    <string name="robotic_arm_degree_symbol">\u00B0</string>
+
     <string name="high_limit">High Limit</string>
     <string name="update_period">Update Period</string>
     <string name="max_lx">Max (Lx)</string>


### PR DESCRIPTION
Fixes #1966 

**Changes**: degree and second symbols added to robotic arm timeline

**Screenshot/s for the changes**: 
<img src="https://user-images.githubusercontent.com/32041242/63933816-99194580-ca77-11e9-9eab-5c1dfff7e723.png" width="500"/>


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[robotic.zip](https://github.com/fossasia/pslab-android/files/3555144/robotic.zip)

