### PR TITLE
feat: Use phone speaker to produce sound

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -9,6 +9,10 @@ import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
 import android.location.LocationManager;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioTrack;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
@@ -182,6 +186,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
     private RelativeLayout pwmModeControls;
     private RelativeLayout squareModeControls;
     private LineChart previewChart;
+    private boolean isPlayingSound = false;
+    private ProduceSoundTask produceSoundTask;
 
     @SuppressLint("ClickableViewAccessibility")
     @Override
@@ -451,6 +457,23 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             setReceivedData();
         }
         chartInit();
+
+        btnProduceSound.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (isPlayingSound) {
+                    btnProduceSound.setText(getResources().getString(R.string.produce_sound_text));
+                    produceSoundTask.cancel(true);
+                    produceSoundTask = null;
+                    isPlayingSound = false;
+                } else {
+                    btnProduceSound.setText(getResources().getString(R.string.stop_sound_text));
+                    produceSoundTask = new ProduceSoundTask();
+                    produceSoundTask.execute();
+                    isPlayingSound = true;
+                }
+            }
+        });
     }
 
     public void saveWaveConfig() {
@@ -1250,6 +1273,52 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
         public final int getValue() {
             return value;
+        }
+    }
+
+    private class ProduceSoundTask extends AsyncTask<Void, Void, Void> {
+
+        private AudioTrack track;
+
+        @Override
+        protected Void doInBackground(Void... voids) {
+            short[] buffer = new short[1024];
+            track = new AudioTrack(AudioManager.STREAM_MUSIC, 44100, AudioFormat.CHANNEL_CONFIGURATION_MONO, AudioFormat.ENCODING_PCM_16BIT, buffer.length, AudioTrack.MODE_STREAM);
+            float angle = 0;
+            float samples[] = new float[1024];
+
+            track.play();
+            double frequency;
+            while (isPlayingSound) {
+                if (WaveGeneratorCommon.mode_selected == WaveConst.SQUARE) {
+                    frequency = WaveGeneratorCommon.wave.get(waveBtnActive).get(WaveConst.FREQUENCY);
+                } else {
+                    frequency = WaveGeneratorCommon.wave.get(WaveConst.SQR1).get(WaveConst.FREQUENCY);
+                }
+                float increment = (float) ((2 * Math.PI) * frequency / 44100);
+                for (int i = 0; i < samples.length; i++) {
+                    samples[i] = (float) Math.sin(angle);
+                    if (WaveGeneratorCommon.mode_selected == WaveConst.PWM) {
+                        samples[i] = (samples[i] >= 0.0) ? 1 : -1;
+                    } else {
+                        if (WaveGeneratorCommon.wave.get(waveBtnActive).get(WaveConst.WAVETYPE) == 2) {
+                            samples[i] = (float) ((2 / Math.PI) * Math.asin(samples[i]));
+                        }
+                    }
+                    buffer[i] = (short) (samples[i] * Short.MAX_VALUE);
+                    angle += increment;
+                }
+                track.write(buffer, 0, buffer.length);
+            }
+            return null;
+        }
+
+        @Override
+        protected void onCancelled() {
+            super.onCancelled();
+            track.flush();
+            track.stop();
+            track.release();
         }
     }
 }

--- a/app/src/main/res/layout/wave_generator_main_controls.xml
+++ b/app/src/main/res/layout/wave_generator_main_controls.xml
@@ -13,6 +13,7 @@
         android:layout_marginBottom="@dimen/margin_btn"
         android:layout_weight="1"
         android:background="@drawable/btn_back_rounded"
+        android:stateListAnimator="@animator/selector_animator"
         android:minWidth="@dimen/btn_min_width"
         android:text="@string/produce_sound_text"
         android:textAllCaps="false"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -677,6 +677,7 @@
     <string name="text_pwm">PWM</string>
     <string name="view_text">View</string>
     <string name="produce_sound_text">Produce Sound</string>
+    <string name="stop_sound_text">Stop Sound</string>
     <string name="save_text">Save</string>
     <string name="phase_holder_text">45 deg</string>
     <string name="duty_holder_text">50 %</string>


### PR DESCRIPTION
Fixes #1937 #1165 

**Changes**: Added feature to produce sound using phone speaker


**Screenshot/s for the changes**: 

https://drive.google.com/file/d/1MRU9cBSepwstXNkJvfHau9L7rGFDxriv/view?usp=sharing


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[wave_gen_sound.zip](https://github.com/fossasia/pslab-android/files/3563479/wave_gen_sound.zip)

@CloudyPadmal  @mariobehling this feature is complete for now. As @mariobehling mentioned in last meet we can build it up from here to allow user to play/view multiple waves simultaneously. Please review.