### PR TITLE
Toast message in gas sensor made consistent with all instruments

### DIFF
--- a/app/src/main/java/io/pslab/fragment/GasSensorDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GasSensorDataFragment.java
@@ -91,6 +91,9 @@ public class GasSensorDataFragment extends Fragment {
         rootView = inflater.inflate(R.layout.fragment_gas_sensor, container, false);
         unbinder = ButterKnife.bind(this, rootView);
         scienceLab = ScienceLabCommon.scienceLab;
+        if (!scienceLab.isConnected()) {
+            Toast.makeText(getContext(), R.string.not_connected, Toast.LENGTH_SHORT).show();
+        }
         entries = new ArrayList<>();
         setupInstruments();
         return rootView;
@@ -366,8 +369,6 @@ public class GasSensorDataFragment extends Fragment {
                 mChart.moveViewToX(data.getEntryCount());
                 mChart.invalidate();
             }
-        } else {
-            Toast.makeText(getContext(), R.string.not_connected, Toast.LENGTH_SHORT).show();
         }
     }
 


### PR DESCRIPTION
Fixes #1979 

**Changes**: Toast message made consistent with all other instruments.

**Screenshot/s for the changes**: 
![20191002_023447](https://user-images.githubusercontent.com/37077735/66001106-76d37700-e4be-11e9-8a83-a50bc5c9393a.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[toast.zip](https://github.com/fossasia/pslab-android/files/3678516/toast.zip)

