### PR TITLE
Bump gradle from 3.3.2 to 3.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "io.realm:realm-gradle-plugin:5.8.0"
         classpath "gradle.plugin.com.github.b3er.local.properties:local-properties-plugin:1.1"
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Fixed #1995 

**Changes**: [Updated gradle version from 3.3.2 to 3.5.2]
**Screenshot/s for the changes**: [Add screenshot/s of the layout where you made changes or a `*.gif` containing a demonstration]

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [ ] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**: [Compress the `app-debug.apk` file into a `<feature>.rar` or `<feature>.zip` file and upload it here]
