### PR TITLE
Fixes #2000 Fixed the repeated display of 'Not Connected' Toast messa…

### DIFF
--- a/app/src/main/java/io/pslab/fragment/DustSensorDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DustSensorDataFragment.java
@@ -107,6 +107,8 @@ public class DustSensorDataFragment extends Fragment {
         scienceLab = ScienceLabCommon.scienceLab;
         entries = new ArrayList<>();
         setupInstruments();
+        if(!scienceLab.isConnected())
+            Toast.makeText(getContext(), R.string.not_connected, Toast.LENGTH_SHORT).show();
         return rootView;
     }
 
@@ -388,8 +390,6 @@ public class DustSensorDataFragment extends Fragment {
                 mChart.moveViewToX(data.getEntryCount());
                 mChart.invalidate();
             }
-        } else {
-            Toast.makeText(getContext(), R.string.not_connected, Toast.LENGTH_SHORT).show();
         }
     }
 


### PR DESCRIPTION
…ge in DustSensor

Fixes #2000

**Changes**: 
Fixed the repeated display of 'Not Connected' Toast message in DustSensor.
Made Changes to  `onCreateView()` and `visualizeData()` in `DustSensorDataFragment` 

**Screenshot/s for the changes**: 
![fix2000](https://user-images.githubusercontent.com/13999905/68681424-66b4ba00-0589-11ea-8b59-fa6eb9391e1d.gif)

**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[issue2000fix.zip](https://github.com/fossasia/pslab-android/files/3836572/issue2000fix.zip)
