### PR TITLE
Fix: #2005 Letters of the Spinner are corrupted

### DIFF
--- a/app/src/main/res/layout/activity_create_config.xml
+++ b/app/src/main/res/layout/activity_create_config.xml
@@ -53,17 +53,19 @@
 
                 <EditText
                     android:id="@+id/interval_edit_text"
-                    android:layout_width="wrap_content"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:hint="@string/time_interval_hint"
                     android:imeOptions="actionDone"
                     android:inputType="number"
-                    android:textAlignment="center" />
+                    android:textAlignment="center"
+                    android:layout_weight="1"/>
 
                 <android.support.v7.widget.AppCompatSpinner
                     android:id="@+id/interval_unit_spinner"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"/>
             </LinearLayout>
 
             <TextView


### PR DESCRIPTION
Fix: #2005 Letters of the Spinner are corrupted

**Changes**:  Letters of the Spinner won't disappear even if the screen size of mobile is small or the font size is made to maximum.

**Screenshot/s for the changes**: 
![screen_pslab](https://user-images.githubusercontent.com/44086235/68896237-0e301900-0751-11ea-8e85-eaa627c2403f.jpeg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members
