### PR TITLE
Fixes #1999 Replaced Toast Messages with Snackbar messages

### DIFF
--- a/app/src/main/java/io/pslab/activity/CreateConfigActivity.java
+++ b/app/src/main/java/io/pslab/activity/CreateConfigActivity.java
@@ -14,7 +14,6 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.Toast;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -99,7 +98,8 @@ public class CreateConfigActivity extends AppCompatActivity {
             public void onClick(View v) {
                 interval = intervalEditText.getText().toString();
                 if (interval.length() == 0) {
-                    Toast.makeText(CreateConfigActivity.this, getResources().getString(R.string.no_interval_message), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                            getString(R.string.no_interval_message),null,null, Snackbar.LENGTH_SHORT);
                 } else {
                     ArrayList<String> selectedParamsList = new ArrayList<>();
                     for (int i = 0; i < paramsListContainer.getChildCount(); i++) {

--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -8,6 +8,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.Environment;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DividerItemDecoration;
@@ -19,7 +20,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -45,6 +45,7 @@ import io.pslab.models.ServoData;
 import io.pslab.models.ThermometerData;
 import io.pslab.models.WaveGeneratorData;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.LocalDataLog;
 import io.realm.Realm;
 import io.realm.RealmObject;
@@ -209,7 +210,8 @@ public class DataLoggerActivity extends AppCompatActivity {
                 File file = new File(path);
                 getFileData(file);
             } else
-                Toast.makeText(this, this.getResources().getString(R.string.no_file_selected), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    getString(R.string.no_file_selected),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -230,11 +232,13 @@ public class DataLoggerActivity extends AppCompatActivity {
                         if (object != null) {
                             realm.copyToRealm(object);
                         } else {
-                            Toast.makeText(this, getResources().getString(R.string.incorrect_import_format), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                    getString(R.string.incorrect_import_format),null,null, Snackbar.LENGTH_SHORT);
                         }
                         realm.commitTransaction();
                     } catch (Exception e) {
-                        Toast.makeText(this, getResources().getString(R.string.incorrect_import_format), Toast.LENGTH_SHORT).show();
+                        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                getString(R.string.incorrect_import_format),null,null, Snackbar.LENGTH_SHORT);
                     }
                 } else if (i == 0) {
                     block = System.currentTimeMillis();

--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -14,6 +14,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.customtabs.CustomTabsServiceConnection;
 import android.support.design.widget.NavigationView;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.view.GravityCompat;
@@ -28,7 +29,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.io.IOException;
 
@@ -42,6 +42,7 @@ import io.pslab.fragment.FAQFragment;
 import io.pslab.fragment.HomeFragment;
 import io.pslab.fragment.InstrumentsFragment;
 import io.pslab.fragment.PSLabPinLayoutFragment;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.CustomTabService;
 import io.pslab.others.InitializationVariable;
 import io.pslab.others.ScienceLabCommon;
@@ -348,7 +349,8 @@ public class MainActivity extends AppCompatActivity {
                 super.onBackPressed();
                 return;
             } else {
-                Toast.makeText(getBaseContext(), getString(R.string.Toast_double_tap), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                        getString(R.string.Toast_double_tap),null,null, Snackbar.LENGTH_SHORT);
             }
             mBackPressed = System.currentTimeMillis();
         }
@@ -365,7 +367,8 @@ public class MainActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.menu_pslab_connected:
-                Toast.makeText(getApplicationContext(), getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                        getString(R.string.device_connected_successfully),null,null, Snackbar.LENGTH_SHORT);
                 break;
             case R.id.menu_pslab_disconnected:
                 attemptToConnectPSLab();
@@ -389,14 +392,16 @@ public class MainActivity extends AppCompatActivity {
         mScienceLabCommon = ScienceLabCommon.getInstance();
         if (communicationHandler.isConnected()) {
             initialisationDialog.dismiss();
-            Toast.makeText(this, getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    getString(R.string.device_connected_successfully),null,null, Snackbar.LENGTH_SHORT);
         } else {
             communicationHandler = new CommunicationHandler(usbManager);
             if (communicationHandler.isDeviceFound()) {
                 attemptToGetUSBPermission();
             } else {
                 initialisationDialog.dismiss();
-                Toast.makeText(this, getString(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                        getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                 navItemIndex = 2;
                 CURRENT_TAG = TAG_DEVICE;
                 loadHomeFragment();
@@ -478,19 +483,22 @@ public class MainActivity extends AppCompatActivity {
                             PSLabisConnected = mScienceLabCommon.openDevice(communicationHandler);
                             initialisationDialog.dismiss();
                             invalidateOptionsMenu();
-                            Toast.makeText(getApplicationContext(), getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                    getString(R.string.device_connected_successfully),null,null, Snackbar.LENGTH_SHORT);
                             if (navItemIndex == 0) {
                                 getSupportFragmentManager().beginTransaction().replace(R.id.frame, InstrumentsFragment.newInstance()).commit();
                             } else if (navItemIndex == 1) {
                                 getSupportFragmentManager().beginTransaction().replace(R.id.frame, HomeFragment.newInstance(true, true)).commitAllowingStateLoss();
                             } else {
-                                Toast.makeText(getApplicationContext(), getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
+                                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                        getString(R.string.device_connected_successfully),null,null, Snackbar.LENGTH_SHORT);
                             }
                         }
                     } else {
                         initialisationDialog.dismiss();
                         Log.d(TAG, "permission denied for device " + device);
-                        Toast.makeText(getApplicationContext(), getString(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                     }
                 }
             }
@@ -512,7 +520,8 @@ public class MainActivity extends AppCompatActivity {
                 } else if (navItemIndex == 1) {
                     getSupportFragmentManager().beginTransaction().replace(R.id.frame, HomeFragment.newInstance(true, true)).commitAllowingStateLoss();
                 }
-                Toast.makeText(getApplicationContext(), getString(R.string.device_connected_successfully), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                        getString(R.string.device_connected_successfully),null,null, Snackbar.LENGTH_SHORT);
             }
         }
     }

--- a/app/src/main/java/io/pslab/activity/RoboticArmActivity.java
+++ b/app/src/main/java/io/pslab/activity/RoboticArmActivity.java
@@ -33,7 +33,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.triggertrap.seekarc.SeekArc;
 
@@ -115,7 +114,8 @@ public class RoboticArmActivity extends AppCompatActivity {
 
         scienceLab = ScienceLabCommon.scienceLab;
         if (!scienceLab.isConnected()) {
-            Toast.makeText(this, getResources().getString(R.string.device_not_connected), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    getString(R.string.device_not_connected),null,null, Snackbar.LENGTH_SHORT);
         }
         Display display = getWindowManager().getDefaultDisplay();
         Point size = new Point();
@@ -565,7 +565,8 @@ public class RoboticArmActivity extends AppCompatActivity {
     }
 
     private void toastInvalidValueMessage() {
-        Toast.makeText(RoboticArmActivity.this, getResources().getString(R.string.invalid_servo_value), Toast.LENGTH_SHORT).show();
+        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                getString(R.string.invalid_servo_value),null,null, Snackbar.LENGTH_SHORT);
     }
 
     private void setReceivedData() {

--- a/app/src/main/java/io/pslab/activity/SensorActivity.java
+++ b/app/src/main/java/io/pslab/activity/SensorActivity.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.design.widget.BottomSheetBehavior;
 import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -20,11 +21,11 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import io.pslab.R;
 import io.pslab.communication.ScienceLab;
 import io.pslab.communication.peripherals.I2C;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.MathUtils;
 import io.pslab.others.ScienceLabCommon;
 import io.pslab.others.SwipeGestureDetector;
@@ -162,7 +163,8 @@ public class SensorActivity extends AppCompatActivity {
                         startActivity(intent);
                         break;
                     default:
-                        Toast.makeText(getApplication(), "Sensor Not Supported", Toast.LENGTH_SHORT).show();
+                        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                "Sensor Not Supported",null,null, Snackbar.LENGTH_SHORT);
                 }
             }
         });

--- a/app/src/main/java/io/pslab/activity/SensorDataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/SensorDataLoggerActivity.java
@@ -27,7 +27,6 @@ import android.widget.ArrayAdapter;
 import android.widget.FrameLayout;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -38,6 +37,7 @@ import io.pslab.communication.peripherals.I2C;
 import io.pslab.communication.sensors.MPU6050;
 import io.pslab.models.DataMPU6050;
 import io.pslab.models.SensorLogged;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import java.io.IOException;
@@ -157,7 +157,8 @@ public class SensorDataLoggerActivity extends AppCompatActivity {
 
     private void handleClick(int position) {
         String sensor = sensorList.get(position);
-        Toast.makeText(context, sensor, Toast.LENGTH_SHORT).show();
+        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                sensor,null,null,Snackbar.LENGTH_SHORT);
         switch (sensor) {
             case "MPU6050":
                 MaterialDialog dialog = new MaterialDialog.Builder(context)
@@ -235,7 +236,8 @@ public class SensorDataLoggerActivity extends AppCompatActivity {
                                     realm.copyToRealm(sensorLogged);
                                 }
                                 realm.commitTransaction();
-                                Toast.makeText(SensorDataLoggerActivity.this, "Data Logged Successfully", Toast.LENGTH_SHORT).show();
+                                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                        "Data Logged Successfully",null,null,Snackbar.LENGTH_SHORT);
                                 dialog.dismiss();
                             }
                         })
@@ -300,7 +302,8 @@ public class SensorDataLoggerActivity extends AppCompatActivity {
                 hasPermission = true;
             } else {
                 hasPermission = false;
-                Toast.makeText(this, "Can't log data", Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                        "Can't log data",null,null,Snackbar.LENGTH_SHORT);
             }
         }
     }

--- a/app/src/main/java/io/pslab/activity/ShowLoggedData.java
+++ b/app/src/main/java/io/pslab/activity/ShowLoggedData.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.LinearLayoutManager;
@@ -19,7 +20,6 @@ import android.widget.ArrayAdapter;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import io.pslab.others.CustomSnackBar;
 import io.realm.Realm;
 import io.realm.RealmResults;
 
@@ -174,7 +175,8 @@ public class ShowLoggedData extends AppCompatActivity {
                                 e.printStackTrace();
                             }
                         }
-                        Toast.makeText(context, "MPU6050 data exported successfully", Toast.LENGTH_SHORT).show();
+                        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                "MPU6050 data exported successfully",null,null, Snackbar.LENGTH_SHORT);
                         break;
                 }
             } else {
@@ -209,12 +211,14 @@ public class ShowLoggedData extends AppCompatActivity {
                         } catch (FileNotFoundException e) {
                             e.printStackTrace();
                         }
-                        Toast.makeText(context, "MPU6050 data exported successfully", Toast.LENGTH_SHORT).show();
+                        CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                                "MPU6050 data exported successfully",null,null,Snackbar.LENGTH_SHORT);
                         break;
                 }
             }
         } else {
-            Toast.makeText(context, "Can't write to storage", Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    "Can't write to storage",null,null,Snackbar.LENGTH_SHORT);
         }
     }
 

--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -39,7 +39,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.Legend;
@@ -554,7 +553,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                     }, Snackbar.LENGTH_SHORT);
 
         } else {
-            Toast.makeText(WaveGeneratorActivity.this, R.string.device_not_connected, Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    getString(R.string.device_not_connected),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -668,7 +668,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 if (scienceLab.isConnected()) {
                     viewWaveDialog();
                 } else {
-                    Toast.makeText(WaveGeneratorActivity.this, R.string.device_not_connected, Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                            getString(R.string.device_not_connected),null,null,Snackbar.LENGTH_SHORT);
                 }
                 break;
             case R.id.show_guide:

--- a/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
@@ -5,6 +5,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Environment;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.RecyclerView;
@@ -13,7 +14,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -53,6 +53,7 @@ import io.pslab.models.ServoData;
 import io.pslab.models.ThermometerData;
 import io.pslab.models.WaveGeneratorData;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.LocalDataLog;
 import io.realm.RealmRecyclerViewAdapter;
 import io.realm.RealmResults;
@@ -242,10 +243,9 @@ public class SensorLoggerListAdapter extends RealmRecyclerViewAdapter<SensorData
                                         File.separator + CSVLogger.CSV_DIRECTORY +
                                         File.separator + block.getSensorType() +
                                         File.separator + CSVLogger.FILE_NAME_FORMAT.format(block.getBlock()) + ".csv");
-                        Toast.makeText(context, logDirectory.delete()
-                                        ? context.getString(R.string.log_deleted)
-                                        : context.getString(R.string.nothing_to_delete),
-                                Toast.LENGTH_LONG).show();
+                        CustomSnackBar.showSnackBar(context.findViewById(android.R.id.content),
+                                logDirectory.delete()?context.getString(R.string.log_deleted)
+                                :context.getString(R.string.nothing_to_delete),null,null, Snackbar.LENGTH_LONG);
                         if (block.getSensorType().equalsIgnoreCase(PSLabSensor.LUXMETER)) {
                             LocalDataLog.with().clearBlockOfLuxRecords(block.getBlock());
                         } else if (block.getSensorType().equalsIgnoreCase(PSLabSensor.BAROMETER)) {
@@ -534,7 +534,8 @@ public class SensorLoggerListAdapter extends RealmRecyclerViewAdapter<SensorData
             context.startActivity(map);
         } else {
             map.putExtra("hasMarkers", false);
-            Toast.makeText(context, context.getResources().getString(R.string.no_location_data), Toast.LENGTH_LONG).show();
+            CustomSnackBar.showSnackBar(context.findViewById(android.R.id.content),
+                    context.getString(R.string.no_location_data),null,null,Snackbar.LENGTH_LONG);
         }
     }
 

--- a/app/src/main/java/io/pslab/fragment/AccelerometerDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/AccelerometerDataFragment.java
@@ -11,13 +11,13 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.text.Html;
 import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Toast;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
@@ -35,6 +35,7 @@ import io.pslab.activity.AccelerometerActivity;
 import io.pslab.models.AccelerometerData;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 
 import static android.content.Context.SENSOR_SERVICE;
 import static io.pslab.others.CSVLogger.CSV_DIRECTORY;
@@ -177,8 +178,8 @@ public class AccelerometerDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -267,8 +268,8 @@ public class AccelerometerDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getActivity().getResources().getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -451,7 +452,8 @@ public class AccelerometerDataFragment extends Fragment {
         sensorManager = (SensorManager) getContext().getSystemService(SENSOR_SERVICE);
         sensor = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
         if (sensor == null) {
-            Toast.makeText(getContext(), getResources().getString(R.string.no_accelerometer_sensor), Toast.LENGTH_LONG).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getResources().getString(R.string.no_accelerometer_sensor),null,null,Snackbar.LENGTH_LONG);
         } else {
             sensorManager.registerListener(accelerometerSensorEventListener,
                     sensor, SensorManager.SENSOR_DELAY_FASTEST);

--- a/app/src/main/java/io/pslab/fragment/BaroMeterDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BaroMeterDataFragment.java
@@ -11,13 +11,13 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import io.pslab.DataFormatter;
 
@@ -54,6 +54,7 @@ import io.pslab.models.BaroData;
 import io.pslab.models.PSLabSensor;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import static android.content.Context.SENSOR_SERVICE;
@@ -241,8 +242,8 @@ public class BaroMeterDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getActivity().getResources().getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -335,8 +336,8 @@ public class BaroMeterDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getActivity().getResources().getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -585,7 +586,8 @@ public class BaroMeterDataFragment extends Fragment {
                 sensorManager = (SensorManager) getContext().getSystemService(SENSOR_SERVICE);
                 sensor = sensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE);
                 if (sensor == null) {
-                    Toast.makeText(getContext(), getResources().getString(R.string.no_baro_sensor), Toast.LENGTH_LONG).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getResources().getString(R.string.no_baro_sensor),null,null, Snackbar.LENGTH_LONG);
                 } else {
                     float max = sensor.getMaximumRange() / 1000;
                     PreferenceManager.getDefaultSharedPreferences(getActivity()).edit().putFloat(baroSensor.BAROMETER_LIMIT, max).apply();
@@ -607,14 +609,16 @@ public class BaroMeterDataFragment extends Fragment {
                             sensorBMP180.setOversampling(10);
                             sensorType = 0;
                         } else {
-                            Toast.makeText(getContext(), getResources().getText(R.string.sensor_not_connected_tls), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                    getString(R.string.sensor_not_connected_tls),null,null, Snackbar.LENGTH_SHORT);
                             sensorType = 0;
                         }
                     } catch (IOException | InterruptedException e) {
                         e.printStackTrace();
                     }
                 } else {
-                    Toast.makeText(getContext(), getResources().getText(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                     sensorType = 0;
                 }
                 break;

--- a/app/src/main/java/io/pslab/fragment/BaroMeterSettingsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BaroMeterSettingsFragment.java
@@ -3,15 +3,16 @@ package io.pslab.fragment;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.widget.Toast;
 
 import io.pslab.DataFormatter;
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.PSLabPermission;
 
 /**
@@ -85,7 +86,8 @@ public class BaroMeterSettingsFragment extends PreferenceFragmentCompat implemen
                         updatePeriodPref.setSummary(String.valueOf(updatePeriod) + " ms");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.update_period_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.update_period_msg),null,null, Snackbar.LENGTH_SHORT);
                     updatePeriodPref.setSummary("1000 ms");
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();
@@ -102,7 +104,8 @@ public class BaroMeterSettingsFragment extends PreferenceFragmentCompat implemen
                         highLimitPref.setSummary(DataFormatter.formatDouble(highLimit, DataFormatter.LOW_PRECISION_FORMAT) + " atm");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.high_limit_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.high_limit_msg),null,null,Snackbar.LENGTH_SHORT);
                     highLimitPref.setSummary("1.10 atm");
                     highLimitPref.setText("1.10");
                     SharedPreferences.Editor editor = sharedPref.edit();

--- a/app/src/main/java/io/pslab/fragment/BluetoothScanFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BluetoothScanFragment.java
@@ -11,6 +11,7 @@ import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +21,6 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 
 public class BluetoothScanFragment extends DialogFragment {
     private Button bluetoothScanStopButton;
@@ -101,7 +102,8 @@ public class BluetoothScanFragment extends DialogFragment {
         scannedDevicesListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                Toast.makeText(getContext(), bluetoothDevices.get(position).getAddress(), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        bluetoothDevices.get(position).getAddress(),null,null, Snackbar.LENGTH_SHORT);
                 bluetoothDevice = bluetoothDevices.get(position);
                 getDialog().cancel();
                 connectBluetooth();
@@ -120,7 +122,8 @@ public class BluetoothScanFragment extends DialogFragment {
         bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         if (bluetoothAdapter == null) {
             isScanning = false;
-            Toast.makeText(getContext(), getResources().getString(R.string.bluetooth_not_supported), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.bluetooth_not_supported),null,null,Snackbar.LENGTH_SHORT);
         } else {
             if (!bluetoothAdapter.isEnabled()) {
                 Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.view.LayoutInflater;
@@ -16,11 +17,11 @@ import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.Spinner;
-import android.widget.Toast;
 
 import io.pslab.DataFormatter;
 import io.pslab.R;
 import io.pslab.activity.OscilloscopeActivity;
+import io.pslab.others.CustomSnackBar;
 
 public class ChannelParametersFragment extends Fragment {
 
@@ -274,7 +275,8 @@ public class ChannelParametersFragment extends Fragment {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = true;
             } else {
-                Toast.makeText(getActivity(), "This feature won't work.", Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        "This feature won't work.",null,null, Snackbar.LENGTH_SHORT);
                 if (builtInMicCheckBox.isChecked())
                     builtInMicCheckBox.toggle();
             }

--- a/app/src/main/java/io/pslab/fragment/CompassDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/CompassDataFragment.java
@@ -11,6 +11,7 @@ import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -20,7 +21,6 @@ import android.view.animation.RotateAnimation;
 import android.widget.ImageView;
 import android.widget.RadioButton;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -41,6 +41,7 @@ import io.pslab.communication.peripherals.I2C;
 import io.pslab.models.CompassData;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import static android.content.Context.SENSOR_SERVICE;
@@ -380,8 +381,8 @@ public class CompassDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -489,8 +490,8 @@ public class CompassDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -601,7 +602,8 @@ public class CompassDataFragment extends Fragment {
                 sensorManager = (SensorManager) getContext().getSystemService(SENSOR_SERVICE);
                 sensor = sensorManager.getDefaultSensor(Sensor.TYPE_ORIENTATION);
                 if (sensor == null) {
-                    Toast.makeText(getContext(), getResources().getString(R.string.no_compass_sensor), Toast.LENGTH_LONG).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.no_compass_sensor),null,null, Snackbar.LENGTH_LONG);
                 } else {
                     sensorManager.registerListener(compassEventListner, sensor, SensorManager.SENSOR_DELAY_GAME);
                 }
@@ -617,14 +619,16 @@ public class CompassDataFragment extends Fragment {
                         if (data.contains(0x39)) {
                             sensorType = 1;
                         } else {
-                            Toast.makeText(getContext(), getResources().getText(R.string.sensor_not_connected_tls), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                    getString(R.string.sensor_not_connected_tls),null,null, Snackbar.LENGTH_SHORT);
                             sensorType = 0;
                         }
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
                 } else {
-                    Toast.makeText(getContext(), getResources().getText(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                     sensorType = 0;
                 }
                 break;

--- a/app/src/main/java/io/pslab/fragment/ControlFragmentAdvanced.java
+++ b/app/src/main/java/io/pslab/fragment/ControlFragmentAdvanced.java
@@ -3,6 +3,7 @@ package io.pslab.fragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AlertDialog;
 import android.text.InputType;
@@ -14,11 +15,11 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.Spinner;
-import android.widget.Toast;
 
 import io.pslab.DataFormatter;
 import io.pslab.R;
 import io.pslab.communication.ScienceLab;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.EditTextWidget;
 import io.pslab.others.ScienceLabCommon;
 
@@ -424,14 +425,14 @@ public class ControlFragmentAdvanced extends Fragment {
 
                                 if (Double.parseDouble(input) > maxima) {
                                     input = DataFormatter.formatDouble(maxima, DataFormatter.LOW_PRECISION_FORMAT);
-                                    Toast.makeText(getContext(), "The Maximum value for this field is " + maxima, Toast.LENGTH_SHORT).show();
+                                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                            "The Maximum value for this field is " + maxima,null,null, Snackbar.LENGTH_SHORT);
                                 }
                                 if (Double.parseDouble(input) < minima) {
                                     input = DataFormatter.formatDouble(minima, DataFormatter.MEDIUM_PRECISION_FORMAT);
-                                    Toast.makeText(getContext(), "The Minimum value for this field is " + minima, Toast.LENGTH_SHORT).show();
+                                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                            "The Minimum value for this field is " + minima,null,null, Snackbar.LENGTH_SHORT);
                                 }
-
-
                                 et.setText(input);
                             }
                         })

--- a/app/src/main/java/io/pslab/fragment/DustSensorDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DustSensorDataFragment.java
@@ -8,12 +8,13 @@ import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.anastr.speedviewlib.PointerSpeedometer;
 import com.github.mikephil.charting.charts.LineChart;
@@ -44,6 +45,7 @@ import io.pslab.models.DustSensorData;
 import io.pslab.models.GasSensorData;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import static io.pslab.others.CSVLogger.CSV_DIRECTORY;
@@ -108,7 +110,7 @@ public class DustSensorDataFragment extends Fragment {
         entries = new ArrayList<>();
         setupInstruments();
         if(!scienceLab.isConnected())
-            Toast.makeText(getContext(), R.string.not_connected, Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),getString(R.string.not_connected),null,null,Snackbar.LENGTH_SHORT);
         return rootView;
     }
 
@@ -187,8 +189,8 @@ public class DustSensorDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -262,8 +264,8 @@ public class DustSensorDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 

--- a/app/src/main/java/io/pslab/fragment/DustSensorSettingsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DustSensorSettingsFragment.java
@@ -3,14 +3,15 @@ package io.pslab.fragment;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.widget.Toast;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.PSLabPermission;
 
 public class DustSensorSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -80,7 +81,8 @@ public class DustSensorSettingsFragment extends PreferenceFragmentCompat impleme
                         updatePeriodPref.setSummary(updatePeriod + " ms");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.update_period_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.update_period_msg),null,null, Snackbar.LENGTH_SHORT);
                     updatePeriodPref.setSummary("1000 ms");
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();
@@ -97,7 +99,8 @@ public class DustSensorSettingsFragment extends PreferenceFragmentCompat impleme
                         highLimitPref.setSummary(String.valueOf(highLimit) + " PPM");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.high_limit_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.high_limit_msg),null,null,Snackbar.LENGTH_SHORT);
                     highLimitPref.setSummary("4.0 V");
                     highLimitPref.setText("4.0");
                     SharedPreferences.Editor editor = sharedPref.edit();

--- a/app/src/main/java/io/pslab/fragment/ESPFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ESPFragment.java
@@ -4,6 +4,7 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -12,11 +13,11 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ProgressBar;
-import android.widget.Toast;
 
 import java.io.IOException;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -44,7 +45,8 @@ public class ESPFragment extends DialogFragment {
             public void onClick(View v) {
                 espIPAddress = espIPEditText.getText().toString();
                 if (espIPAddress.length() == 0) {
-                    Toast.makeText(getContext(), getResources().getString(R.string.incorrect_IP_address_message), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.incorrect_IP_address_message),null,null, Snackbar.LENGTH_SHORT);
                 } else {
                     new ESPTask().execute();
                 }
@@ -95,7 +97,8 @@ public class ESPFragment extends DialogFragment {
             espConnectProgressBar.setVisibility(View.GONE);
             espConnectBtn.setVisibility(View.VISIBLE);
             if (result.length() == 0) {
-                Toast.makeText(getContext(), getResources().getString(R.string.incorrect_IP_address_message), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        getString(R.string.incorrect_IP_address_message),null,null,Snackbar.LENGTH_SHORT);
             } else {
                 Log.v("Response", result);
             }

--- a/app/src/main/java/io/pslab/fragment/GasSensorDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GasSensorDataFragment.java
@@ -8,12 +8,12 @@ import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.anastr.speedviewlib.PointerSpeedometer;
 import com.github.mikephil.charting.charts.LineChart;
@@ -42,6 +42,7 @@ import io.pslab.communication.ScienceLab;
 import io.pslab.models.GasSensorData;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import static io.pslab.others.CSVLogger.CSV_DIRECTORY;
@@ -92,7 +93,8 @@ public class GasSensorDataFragment extends Fragment {
         unbinder = ButterKnife.bind(this, rootView);
         scienceLab = ScienceLabCommon.scienceLab;
         if (!scienceLab.isConnected()) {
-            Toast.makeText(getContext(), R.string.not_connected, Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.not_connected),null,null, Snackbar.LENGTH_SHORT);
         }
         entries = new ArrayList<>();
         setupInstruments();
@@ -170,8 +172,8 @@ public class GasSensorDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -240,8 +242,8 @@ public class GasSensorDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 

--- a/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.text.Html;
 import android.util.Pair;
@@ -19,7 +20,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
@@ -39,6 +39,7 @@ import io.pslab.activity.GyroscopeActivity;
 import io.pslab.models.GyroData;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 
 import static android.content.Context.SENSOR_SERVICE;
 import static io.pslab.others.CSVLogger.CSV_DIRECTORY;
@@ -184,8 +185,8 @@ public class GyroscopeDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -274,8 +275,8 @@ public class GyroscopeDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -461,7 +462,8 @@ public class GyroscopeDataFragment extends Fragment {
         } else {
             sensor = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
             if (sensor == null) {
-                Toast.makeText(getContext(), getResources().getString(R.string.no_gyroscope_sensor), Toast.LENGTH_LONG).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        getString(R.string.no_gyroscope_sensor),null,null,Snackbar.LENGTH_LONG);
             } else {
                 sensorManager.registerListener(gyroScopeSensorEventListener,
                         sensor, SensorManager.SENSOR_DELAY_FASTEST);

--- a/app/src/main/java/io/pslab/fragment/GyroscopeSettingsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GyroscopeSettingsFragment.java
@@ -3,13 +3,14 @@ package io.pslab.fragment;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.widget.Toast;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.PSLabPermission;
 
 public class GyroscopeSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -79,7 +80,8 @@ public class GyroscopeSettingsFragment extends PreferenceFragmentCompat implemen
                         updatePeriodPref.setSummary(updatePeriod + " ms");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.update_period_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.update_period_msg),null,null, Snackbar.LENGTH_SHORT);
                     updatePeriodPref.setSummary("1000 ms");
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();
@@ -108,7 +110,8 @@ public class GyroscopeSettingsFragment extends PreferenceFragmentCompat implemen
                         higLimitPref.setSummary(String.valueOf(highLimit) + " rad/s");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.high_limit_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.high_limit_msg),null,null, Snackbar.LENGTH_SHORT);
                     higLimitPref.setSummary("20 " + "rad/s");
                     higLimitPref.setText("20");
                     SharedPreferences.Editor editor = sharedPref.edit();

--- a/app/src/main/java/io/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LALogicLinesFragment.java
@@ -25,7 +25,6 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.components.Legend;
@@ -479,7 +478,8 @@ public class LALogicLinesFragment extends Fragment {
                                 monitor.start();
                                 break;
                             default:
-                                Toast.makeText(getContext(), getResources().getString(R.string.needs_implementation), Toast.LENGTH_SHORT).show();
+                                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                        getString(R.string.needs_implementation),null,null, Snackbar.LENGTH_SHORT);
                                 break;
                         }
 
@@ -498,7 +498,8 @@ public class LALogicLinesFragment extends Fragment {
                         };
                         logicLinesChart.setOnChartValueSelectedListener(listener);
                     } else
-                        Toast.makeText(getContext(), getResources().getString(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                        CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                 }
             }
         });
@@ -1016,7 +1017,8 @@ public class LALogicLinesFragment extends Fragment {
             } else {
                 progressBar.setVisibility(View.GONE);
                 ((LogicalAnalyzerActivity) getActivity()).setStatus(false);
-                Toast.makeText(getContext(), getResources().getString(R.string.no_data_generated), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        getString(R.string.no_data_generated),null,null, Snackbar.LENGTH_SHORT);
                 analyze_button.setClickable(true);
             }
 
@@ -1147,7 +1149,8 @@ public class LALogicLinesFragment extends Fragment {
             } else {
                 progressBar.setVisibility(View.GONE);
                 ((LogicalAnalyzerActivity) getActivity()).setStatus(false);
-                Toast.makeText(getContext(), getResources().getString(R.string.no_data_generated), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        getString(R.string.no_data_generated),null,null, Snackbar.LENGTH_SHORT);
             }
 
             analyze_button.setClickable(true);
@@ -1285,7 +1288,8 @@ public class LALogicLinesFragment extends Fragment {
             } else {
                 progressBar.setVisibility(View.GONE);
                 ((LogicalAnalyzerActivity) getActivity()).setStatus(false);
-                Toast.makeText(getContext(), getResources().getString(R.string.no_data_generated), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        getString(R.string.no_data_generated),null,null, Snackbar.LENGTH_SHORT);
             }
 
             analyze_button.setClickable(true);
@@ -1434,7 +1438,8 @@ public class LALogicLinesFragment extends Fragment {
             } else {
                 progressBar.setVisibility(View.GONE);
                 ((LogicalAnalyzerActivity) getActivity()).setStatus(false);
-                Toast.makeText(getContext(), getResources().getString(R.string.no_data_generated), Toast.LENGTH_SHORT).show();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                        getString(R.string.no_data_generated),null,null, Snackbar.LENGTH_SHORT);
             }
 
             analyze_button.setClickable(true);

--- a/app/src/main/java/io/pslab/fragment/LuxMeterDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LuxMeterDataFragment.java
@@ -11,13 +11,13 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.anastr.speedviewlib.PointerSpeedometer;
 import com.github.mikephil.charting.charts.LineChart;
@@ -52,6 +52,7 @@ import io.pslab.models.LuxData;
 import io.pslab.models.PSLabSensor;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import static android.content.Context.SENSOR_SERVICE;
@@ -220,8 +221,8 @@ public class LuxMeterDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -314,8 +315,8 @@ public class LuxMeterDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -533,7 +534,8 @@ public class LuxMeterDataFragment extends Fragment {
                 sensorManager = (SensorManager) getContext().getSystemService(SENSOR_SERVICE);
                 sensor = sensorManager.getDefaultSensor(Sensor.TYPE_LIGHT);
                 if (sensor == null) {
-                    Toast.makeText(getContext(), getResources().getString(R.string.no_lux_sensor), Toast.LENGTH_LONG).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.no_lux_sensor),null,null, Snackbar.LENGTH_LONG);
                 } else {
                     float max = sensor.getMaximumRange() * 10000;
                     PreferenceManager.getDefaultSharedPreferences(getActivity()).edit().putFloat(luxSensor.LUXMETER_LIMIT, max).apply();
@@ -555,14 +557,16 @@ public class LuxMeterDataFragment extends Fragment {
                             sensorBH1750.setRange(String.valueOf(gain));
                             sensorType = 0;
                         } else {
-                            Toast.makeText(getContext(), getResources().getText(R.string.sensor_not_connected_tls), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                    getString(R.string.sensor_not_connected_tls),null,null, Snackbar.LENGTH_SHORT);
                             sensorType = 0;
                         }
                     } catch (IOException | InterruptedException e) {
                         e.printStackTrace();
                     }
                 } else {
-                    Toast.makeText(getContext(), getResources().getText(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                     sensorType = 0;
                 }
 
@@ -580,14 +584,16 @@ public class LuxMeterDataFragment extends Fragment {
                             sensorTSL2561.setGain(String.valueOf(gain));
                             sensorType = 2;
                         } else {
-                            Toast.makeText(getContext(), getResources().getText(R.string.sensor_not_connected_tls), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                    getString(R.string.sensor_not_connected_tls),null,null, Snackbar.LENGTH_SHORT);
                             sensorType = 0;
                         }
                     } catch (IOException | InterruptedException e) {
                         e.printStackTrace();
                     }
                 } else {
-                    Toast.makeText(getContext(), getResources().getText(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                     sensorType = 0;
                 }
                 break;

--- a/app/src/main/java/io/pslab/fragment/LuxMeterSettingFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LuxMeterSettingFragment.java
@@ -3,14 +3,15 @@ package io.pslab.fragment;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.widget.Toast;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.PSLabPermission;
 
 /**
@@ -87,7 +88,8 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
                         updatePeriodPref.setSummary(updatePeriod + " ms");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.update_period_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.update_period_msg),null,null, Snackbar.LENGTH_SHORT);
                     updatePeriodPref.setSummary("1000 ms");
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();
@@ -116,7 +118,8 @@ public class LuxMeterSettingFragment extends PreferenceFragmentCompat implements
                         higLimitPref.setSummary(String.valueOf(highLimit) + " Lx");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.high_limit_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.high_limit_msg),null,null, Snackbar.LENGTH_SHORT);
                     higLimitPref.setSummary("2000 Lx");
                     higLimitPref.setText("2000");
                     SharedPreferences.Editor editor = sharedPref.edit();

--- a/app/src/main/java/io/pslab/fragment/MultimeterSettingsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/MultimeterSettingsFragment.java
@@ -3,13 +3,14 @@ package io.pslab.fragment;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.widget.Toast;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.PSLabPermission;
 
 public class MultimeterSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -71,7 +72,8 @@ public class MultimeterSettingsFragment extends PreferenceFragmentCompat impleme
                         updatePeriodPref.setSummary(String.valueOf(updatePeriod) + " ms");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.update_period_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.update_period_msg),null,null, Snackbar.LENGTH_SHORT);
                     updatePeriodPref.setSummary("1000 ms");
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();

--- a/app/src/main/java/io/pslab/fragment/ThermometerDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ThermometerDataFragment.java
@@ -11,13 +11,13 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.github.anastr.speedviewlib.PointerSpeedometer;
 import com.github.mikephil.charting.charts.LineChart;
@@ -51,6 +51,7 @@ import io.pslab.models.PSLabSensor;
 import io.pslab.models.SensorDataBlock;
 import io.pslab.models.ThermometerData;
 import io.pslab.others.CSVLogger;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 import static android.content.Context.SENSOR_SERVICE;
@@ -221,8 +222,8 @@ public class ThermometerDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -315,8 +316,8 @@ public class ThermometerDataFragment extends Fragment {
                 processRecordedData(0);
             }
         } catch (IllegalArgumentException e) {
-            Toast.makeText(getActivity(),
-                    getActivity().getResources().getString(R.string.no_data_fetched), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 
@@ -531,7 +532,8 @@ public class ThermometerDataFragment extends Fragment {
                 sensorManager = (SensorManager) getContext().getSystemService(SENSOR_SERVICE);
                 sensor = sensorManager.getDefaultSensor(Sensor.TYPE_AMBIENT_TEMPERATURE);
                 if (sensor == null) {
-                    Toast.makeText(getContext(), getResources().getString(R.string.no_thermometer_sensor), Toast.LENGTH_LONG).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.no_thermometer_sensor),null,null, Snackbar.LENGTH_LONG);
                 } else {
                     float max = sensor.getMaximumRange();
                     PreferenceManager.getDefaultSharedPreferences(getActivity()).edit().putFloat(thermoSensor.THERMOMETER_MAX_LIMIT, max).apply();
@@ -553,14 +555,16 @@ public class ThermometerDataFragment extends Fragment {
                             sensorSHT21.selectParameter(TEMPERATURE);
                             sensorType = 1;
                         } else {
-                            Toast.makeText(getContext(), getResources().getText(R.string.sensor_not_connected_tls), Toast.LENGTH_SHORT).show();
+                            CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                                    getString(R.string.sensor_not_connected_tls),null,null, Snackbar.LENGTH_SHORT);
                             sensorType = 0;
                         }
                     } catch (IOException | InterruptedException e) {
                         e.printStackTrace();
                     }
                 } else {
-                    Toast.makeText(getContext(), getResources().getText(R.string.device_not_found), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.device_not_found),null,null, Snackbar.LENGTH_SHORT);
                     sensorType = 0;
                 }
                 break;

--- a/app/src/main/java/io/pslab/fragment/ThermometerSettingsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ThermometerSettingsFragment.java
@@ -3,14 +3,15 @@ package io.pslab.fragment;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v7.preference.CheckBoxPreference;
 import android.support.v7.preference.EditTextPreference;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.support.v7.preference.PreferenceManager;
-import android.widget.Toast;
 
 import io.pslab.R;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.PSLabPermission;
 
 public class ThermometerSettingsFragment extends PreferenceFragmentCompat implements SharedPreferences.OnSharedPreferenceChangeListener {
@@ -80,7 +81,8 @@ public class ThermometerSettingsFragment extends PreferenceFragmentCompat implem
                         updatePeriodPref.setSummary(updatePeriod + " ms");
                     }
                 } catch (NumberFormatException e) {
-                    Toast.makeText(getActivity(), getActivity().getResources().getString(R.string.update_period_msg), Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
+                            getString(R.string.update_period_msg),null,null, Snackbar.LENGTH_SHORT);
                     updatePeriodPref.setSummary("1000 ms");
                     updatePeriodPref.setText("1000");
                     SharedPreferences.Editor editor = sharedPref.edit();

--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -27,7 +27,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.json.JSONArray;
 
@@ -508,9 +507,8 @@ public abstract class PSLabSensor extends AppCompatActivity {
                     Intent map = new Intent(getApplicationContext(), MapsActivity.class);
                     startActivity(map);
                 } else {
-                    Toast.makeText(getApplicationContext(),
-                            getResources().getString(R.string.no_permission_for_maps),
-                            Toast.LENGTH_LONG).show();
+                    CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                            getString(R.string.no_permission_for_maps),null,null,Snackbar.LENGTH_LONG);
                 }
                 break;
             case PSLabPermission.LOG_PERMISSION:
@@ -662,7 +660,8 @@ public abstract class PSLabSensor extends AppCompatActivity {
         try {
             getDataFromDataLogger();
         } catch (ArrayIndexOutOfBoundsException e) {
-            Toast.makeText(getApplicationContext(), getString(R.string.no_data_fetched), Toast.LENGTH_LONG).show();
+            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    getString(R.string.no_data_fetched),null,null,Snackbar.LENGTH_LONG);
         }
         if (checkGPSOnResume) {
             isRecording = true;

--- a/app/src/main/java/io/pslab/others/CustomTabService.java
+++ b/app/src/main/java/io/pslab/others/CustomTabService.java
@@ -7,8 +7,8 @@ import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.customtabs.CustomTabsServiceConnection;
 import android.support.customtabs.CustomTabsSession;
+import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
-import android.widget.Toast;
 
 import io.pslab.R;
 
@@ -59,7 +59,8 @@ public class CustomTabService {
         try{
             mCustomTabsIntent.launchUrl(activity, Uri.parse(Url));
         }catch (Exception e){
-            Toast.makeText(activity.getApplication(), "Error: "+e.toString(), Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(activity.findViewById(android.R.id.content),
+                    "Error: "+e.toString(),null,null, Snackbar.LENGTH_SHORT);
         }
     }
 }

--- a/app/src/main/java/io/pslab/others/GPSLogger.java
+++ b/app/src/main/java/io/pslab/others/GPSLogger.java
@@ -12,7 +12,6 @@ import android.location.LocationManager;
 import android.os.Bundle;
 import android.provider.Settings;
 import android.support.design.widget.Snackbar;
-import android.widget.Toast;
 
 import io.pslab.R;
 import io.pslab.models.PSLabSensor;
@@ -141,9 +140,8 @@ public class GPSLogger {
             locationManager.requestLocationUpdates(provider, UPDATE_INTERVAL_IN_MILLISECONDS, MIN_DISTANCE_CHANGE_FOR_UPDATES,
                     locationListener);
         } else {
-            Toast.makeText(context.getApplicationContext(),
-                    context.getResources().getString(R.string.no_permission_for_maps),
-                    Toast.LENGTH_LONG).show();
+            CustomSnackBar.showSnackBar(((Activity) context).findViewById(android.R.id.content),
+                    context.getString(R.string.no_permission_for_maps),null,null,Snackbar.LENGTH_LONG);
         }
     }
 }

--- a/app/src/main/java/io/pslab/receivers/USBDetachReceiver.java
+++ b/app/src/main/java/io/pslab/receivers/USBDetachReceiver.java
@@ -1,19 +1,21 @@
 package io.pslab.receivers;
 
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.util.Log;
-import android.widget.Toast;
 
 import io.pslab.R;
 import io.pslab.activity.MainActivity;
 import io.pslab.activity.PowerSourceActivity;
 import io.pslab.communication.PacketHandler;
 import io.pslab.fragment.HomeFragment;
+import io.pslab.others.CustomSnackBar;
 import io.pslab.others.ScienceLabCommon;
 
 /**
@@ -39,7 +41,8 @@ public class USBDetachReceiver extends BroadcastReceiver {
                     ScienceLabCommon.scienceLab.close();
                     // Clear saved values in Power Source Instrument
                     context.getSharedPreferences(PowerSourceActivity.POWER_PREFERENCES, Context.MODE_PRIVATE).edit().clear().apply();
-                    Toast.makeText(context, "USB Device Disconnected", Toast.LENGTH_SHORT).show();
+                    CustomSnackBar.showSnackBar(((Activity)context).findViewById(android.R.id.content),
+                            "USB Device Disconnected",null,null, Snackbar.LENGTH_SHORT);
 
                     PacketHandler.version = "";
 

--- a/app/src/playstore/java/io/pslab/activity/MapsActivity.java
+++ b/app/src/playstore/java/io/pslab/activity/MapsActivity.java
@@ -2,7 +2,6 @@ package io.pslab.activity;
 
 import android.support.v4.app.FragmentActivity;
 import android.os.Bundle;
-import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
@@ -42,7 +41,8 @@ public class MapsActivity extends FragmentActivity implements OnMapReadyCallback
                 e.printStackTrace();
             }
         } else {
-            Toast.makeText(this, R.string.no_location_specified, Toast.LENGTH_SHORT).show();
+            CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
+                    getString(R.string.no_location_specified),null,null,Snackbar.LENGTH_SHORT);
         }
     }
 


### PR DESCRIPTION
Fixes #1999 

**Changes**:
Replaced all the occurrence of `Toast` with `Snackbar`. The class `io.pslab.others.CustomSnackbar` was used to make Snackbars.

**Screenshot/s for the changes**: 
![issue1999_ss1](https://user-images.githubusercontent.com/13999905/69265953-3ce63d80-0bf0-11ea-893f-8d342ef06277.jpeg)
![issue1999_ss2](https://user-images.githubusercontent.com/13999905/69265956-3ce63d80-0bf0-11ea-976f-552d2967b12c.jpeg)
![issue1999_ss3](https://user-images.githubusercontent.com/13999905/69265959-3d7ed400-0bf0-11ea-83e1-bb688ec84105.jpeg)
![issue1999_ss4](https://user-images.githubusercontent.com/13999905/69265960-3d7ed400-0bf0-11ea-966e-b3757cc05e0e.jpeg)
![issue1999_ss5](https://user-images.githubusercontent.com/13999905/69265961-3e176a80-0bf0-11ea-9f81-6acce24dd74c.jpeg)
![issue1999_ss6](https://user-images.githubusercontent.com/13999905/69265962-3e176a80-0bf0-11ea-9de6-576d9c281b08.jpeg)
![issue1999_ss7](https://user-images.githubusercontent.com/13999905/69265963-3eb00100-0bf0-11ea-8e25-cfc8d6236d3f.jpeg)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**:
[issue1999fix.zip](https://github.com/fossasia/pslab-android/files/3870980/issue1999fix.zip)


