### PR TITLE
fix: Snackbar sensor view

### DIFF
--- a/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
+++ b/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
@@ -468,7 +468,9 @@ public class PowerSourceActivity extends AppCompatActivity {
                             , getString(R.string.open), new View.OnClickListener() {
                                 @Override
                                 public void onClick(View view) {
-                                    startActivity(new Intent(PowerSourceActivity.this, DataLoggerActivity.class));
+                                    Intent intent = new Intent(PowerSourceActivity.this, DataLoggerActivity.class);
+                                    intent.putExtra(DataLoggerActivity.CALLER_ACTIVITY, getResources().getString(R.string.power_source));
+                                    startActivity(intent);
                                 }
                             }, Snackbar.LENGTH_LONG);
 

--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -485,6 +485,7 @@ public abstract class PSLabSensor extends AppCompatActivity {
                     @Override
                     public void onClick(View view) {
                         Intent intent = new Intent(PSLabSensor.this, DataLoggerActivity.class);
+                        intent.putExtra(DataLoggerActivity.CALLER_ACTIVITY, getSensorName());
                         startActivity(intent);
                     }
                 }, Snackbar.LENGTH_INDEFINITE);


### PR DESCRIPTION
…fter recording, in some sensors, opens the datasets of all the sensors rather than that of the currently opened sensor.

Fixes #2027 

**Changes**:
Made change to `PSLabSensor` and `PowerSourceActivity` to fix issue #2027 

**Screenshot/s for the changes**:
<table>
<tr>
<td><img src="https://user-images.githubusercontent.com/13999905/70848992-0d4ced00-1e9f-11ea-90d3-2107cd2f9d50.gif" /></td>
<td><img src="https://user-images.githubusercontent.com/13999905/70848993-0d4ced00-1e9f-11ea-96f3-c9ea778478e6.gif" /></td>
<td><img src="https://user-images.githubusercontent.com/13999905/70848994-0de58380-1e9f-11ea-9c00-00027b1faf8f.gif" /></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/13999905/70849071-ad0a7b00-1e9f-11ea-9751-4a187befc29e.gif" /></td>
<td><img src="https://user-images.githubusercontent.com/13999905/70848996-0e7e1a00-1e9f-11ea-86ea-466d50d9a11b.gif" /></td>
<td><img src="https://user-images.githubusercontent.com/13999905/70848997-0e7e1a00-1e9f-11ea-993d-8e26170ec51c.gif" /></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/13999905/70848998-0f16b080-1e9f-11ea-9903-badfd0b91ea1.gif" /></td>
<td><img src="https://user-images.githubusercontent.com/13999905/70848999-0f16b080-1e9f-11ea-98bc-5f453f092442.gif" /></td>
</tr>
</table>

**Checklist**:
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**:
[issue2027fix.zip](https://github.com/fossasia/pslab-android/files/3963849/issue2027fix.zip)


