### PR TITLE
Fixed About page crash issue

### DIFF
--- a/app/src/main/java/io/pslab/fragment/AboutUsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/AboutUsFragment.java
@@ -39,7 +39,6 @@ public class AboutUsFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_about_us, container, false);
-        simulateDayNight(0);
         ButterKnife.bind(this, view);
         View aboutPage = new AboutPage(getActivity())
                 .isRTL(false)
@@ -65,24 +64,4 @@ public class AboutUsFragment extends Fragment {
     public boolean onOptionsItemSelected(MenuItem item) {
         return super.onOptionsItemSelected(item);
     }
-
-    private void simulateDayNight(int currentSetting) {
-        final int DAY = 0;
-        final int NIGHT = 1;
-        final int FOLLOW_SYSTEM = 3;
-
-        int currentNightMode = getResources().getConfiguration().uiMode
-                & Configuration.UI_MODE_NIGHT_MASK;
-        if (currentSetting == DAY && currentNightMode != Configuration.UI_MODE_NIGHT_NO) {
-            AppCompatDelegate.setDefaultNightMode(
-                    AppCompatDelegate.MODE_NIGHT_NO);
-        } else if (currentSetting == NIGHT && currentNightMode != Configuration.UI_MODE_NIGHT_YES) {
-            AppCompatDelegate.setDefaultNightMode(
-                    AppCompatDelegate.MODE_NIGHT_YES);
-        } else if (currentSetting == FOLLOW_SYSTEM) {
-            AppCompatDelegate.setDefaultNightMode(
-                    AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
-        }
-    }
-
 }


### PR DESCRIPTION
Fixes #2083 

**Changes**: 
- **Removed the simulate Day Night Function** : The About section is powered by  https://github.com/medyo/android-about-page this package which unfortunately uses` App Compat Day Night` as a parent style which directly takes the information from system variable to change the theme **actively**. The function `simulateDayNight` counters that by forcing the app theme to change back to light. This creates a loop you can see in bottom gif, in android 10 of my testing in avd even shows more frequent crashes.

![ezgif com-optimize](https://user-images.githubusercontent.com/27860105/72689235-5d217280-3b35-11ea-969b-462112b94adb.gif)


**Screenshot/s for the changes**:
Before : 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27860105/72689139-61995b80-3b34-11ea-84e9-fc5164a75a78.gif)

Now: 
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/27860105/72689161-92799080-3b34-11ea-9605-234429d2d03d.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [Compress the `app-debug.apk` file into a `<feature>.rar` or `<feature>.zip` file and upload it here]

[aboutPageCrash.zip](https://github.com/fossasia/pslab-android/files/4083747/aboutPageCrash.zip)
