### PR TITLE
fix: #2088 Effect on click event for logged data item

### DIFF
--- a/app/src/main/res/layout/logger_data_item.xml
+++ b/app/src/main/res/layout/logger_data_item.xml
@@ -5,6 +5,8 @@
     android:id="@+id/data_item_card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clickable="true"
+    android:foreground="?android:attr/selectableItemBackground"
     android:layout_margin="@dimen/logger_card_margin"
     app:cardCornerRadius="@dimen/logger_card_corner_rad">
 
@@ -57,6 +59,8 @@
             android:layout_marginRight="5dp"
             android:layout_weight="0.1"
             android:padding="5dp"
+            android:clickable="true"
+            android:foreground="?android:attr/selectableItemBackground"
             android:src="@drawable/ic_map_red_24dp"
             tools:ignore="ContentDescription" />
 
@@ -67,6 +71,8 @@
             android:layout_gravity="center_vertical"
             android:layout_weight="0.1"
             android:padding="5dp"
+            android:clickable="true"
+            android:foreground="?android:attr/selectableItemBackground"
             android:src="@drawable/ic_delete_red_24dp"
             tools:ignore="ContentDescription" />
 


### PR DESCRIPTION
Fixes #2088 Effect on click event on logged data item 

**Changes**:
Added Ripple effect on click for logged data item.
Also added ripple effect on click for map and delete icon on logged data item.

**Screenshot/s for the changes**: 
![fix list ripple](https://user-images.githubusercontent.com/44086235/72876087-b5b26480-3d1b-11ea-8ebf-e245a6542ceb.gif)


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members