### PR TITLE
Fixes #2032 Fixes crash which occurred in the oscilloscope

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -45,6 +45,7 @@ import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.math3.complex.Complex;
 
 import java.util.ArrayList;
@@ -978,7 +979,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
                 String[] xDataString = null;
                 maxAmp = 0;
                 scienceLab.captureTraces(4, samples, timeGap, channel, isTriggerSelected, null);
-                Thread.sleep((long)(samples*timeGap*1e-3));
+                Thread.sleep((long) (samples * timeGap * 1e-3));
                 for (int i = 0; i < noOfChannels; i++) {
                     entries.add(new ArrayList<>());
                     channel = channels[i];
@@ -1052,12 +1053,12 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
                         double max = xData[xData.length - 1];
                         for (int j = 0; j < 500; j++) {
                             double x = j * max / 500;
-                            double t = 2*Math.PI*freq*(x - phase);
+                            double t = 2 * Math.PI * freq * (x - phase);
                             double y;
-                            if (t%(2*Math.PI) < 2*Math.PI*dc) {
+                            if (t % (2 * Math.PI) < 2 * Math.PI * dc) {
                                 y = offset + amp;
                             } else {
-                                y = offset - 2*amp;
+                                y = offset - 2 * amp;
                             }
                             curveFitEntries.get(curveFitEntries.size() - 1).add(new Entry((float) x, (float) y));
                         }
@@ -1097,7 +1098,7 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
                         float audioValue = (float) map(buffer[i], -32768, 32767, -3, 3);
                         if (!isFourierTransformSelected) {
                             if (noOfChannels == 1) {
-                                xDataString[i] = String.valueOf(2.0*i);
+                                xDataString[i] = String.valueOf(2.0 * i);
                             }
                             entries.get(entries.size() - 1).add(new Entry(i, audioValue));
                         } else {
@@ -1117,9 +1118,9 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
 
                 }
                 if (isRecording) {
-                    loggingXdata = String.join(" ", xDataString);
+                    loggingXdata = StringUtils.join(" ", xDataString);
                     for (int i = 0; i < yDataString.size(); i++) {
-                        loggingYdata[i] = String.join(" ", yDataString.get(i));
+                        loggingYdata[i] = StringUtils.join(" ", yDataString.get(i));
                     }
                     runOnUiThread(new Runnable() {
                         @Override


### PR DESCRIPTION
Fixes #2032

**Changes**: Use join method of Apache StringUtils instead of the join method of the Android String class. The join method was added to the String class of Android in API level 26, but the minimum API level of the app is 23.

**Checklist**:
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [app-fdroid-debug.zip](https://github.com/fossasia/pslab-android/files/4155262/app-fdroid-debug.zip)
