### PR TITLE
Fixes #2008 Fixes crash which occurred in Create Config File

### DIFF
--- a/app/src/main/java/io/pslab/activity/CreateConfigActivity.java
+++ b/app/src/main/java/io/pslab/activity/CreateConfigActivity.java
@@ -15,6 +15,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Spinner;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -99,7 +101,7 @@ public class CreateConfigActivity extends AppCompatActivity {
                 interval = intervalEditText.getText().toString();
                 if (interval.length() == 0) {
                     CustomSnackBar.showSnackBar(findViewById(android.R.id.content),
-                            getString(R.string.no_interval_message),null,null, Snackbar.LENGTH_SHORT);
+                            getString(R.string.no_interval_message), null, null, Snackbar.LENGTH_SHORT);
                 } else {
                     ArrayList<String> selectedParamsList = new ArrayList<>();
                     for (int i = 0; i < paramsListContainer.getChildCount(); i++) {
@@ -184,7 +186,7 @@ public class CreateConfigActivity extends AppCompatActivity {
             FileWriter writer = new FileWriter(configFile);
             writer.write("instrument: " + instrumentName + "\n");
             writer.write("interval: " + interval + " " + intervalUnit + "\n");
-            String param = String.join(",", params);
+            String param = StringUtils.join(",", params);
             writer.write("params: " + param);
             writer.flush();
             writer.close();


### PR DESCRIPTION
Fixes #2008

**Changes**: Use join method of Apache StringUtils instead of the join method of the Android String class. The join method was added to the String class of Android in API level 26, but the minimum API level of the app is 23.

**Checklist**:
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: [app-fdroid-debug.zip](https://github.com/fossasia/pslab-android/files/4155409/app-fdroid-debug.zip)
