### PR TITLE
Fixed NullPointerException in HomeFragment by initializing wvProgressBar

### DIFF
--- a/app/src/main/java/io/pslab/fragment/HomeFragment.java
+++ b/app/src/main/java/io/pslab/fragment/HomeFragment.java
@@ -91,6 +91,8 @@ public class HomeFragment extends Fragment {
         unbinder = ButterKnife.bind(this, view);
         stepsHeader.setPaintFlags(Paint.UNDERLINE_TEXT_FLAG);
         deviceDescription.setPaintFlags(Paint.UNDERLINE_TEXT_FLAG);
+        wvProgressBar = (ProgressBar) view.findViewById(R.id.web_view_progress);
+
         if (deviceFound & deviceConnected) {
             tvConnectMsg.setVisibility(View.GONE);
             try {


### PR DESCRIPTION
Fixes #[NullPointerException in HomeFragment because of wvProgressBar]

**Changes**: [HomeFragment.java

Log:

```
2021-01-04 17:00:02.758 12294-12294/io.pslab E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.pslab, PID: 12294
    java.lang.NullPointerException: Attempt to invoke virtual method 'void android.widget.ProgressBar.setVisibility(int)' on a null object reference
        at io.pslab.fragment.HomeFragment$1$1.onPageFinished(HomeFragment.java:123)
        at fp.b(chromium-Monochrome.aab-stable-424019823:2)
        at Vs0.handleMessage(chromium-Monochrome.aab-stable-424019823:66)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:201)
        at android.app.ActivityThread.main(ActivityThread.java:6823)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:873)

```
