### PR TITLE
Correcting spelling in guide of Oscilloscope

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -529,7 +529,7 @@
         value, plot will halt.</string>
     <string name="data_analysis_desc">\u2022 Using this Setting, the mathematical function of the analysed signal
         can be found. Can choose the Wave type from Sine or Square and the Channel that needs to be analyzed.\n\n
-        \u2022 Furthermore, analyzed signal\'s Fourier transform can be observed by checking Fourier Transfroms check box.</string>
+        \u2022 Furthermore, analyzed signal\'s Fourier transform can be observed by checking Fourier Transforms check box.</string>
     <string name="xy_plot_desc">\u2022 This is used to plot the Channel to Channel voltage in a X-Y plot having
         voltage as the unit for the both axes relevant for the corresponding Channels.</string>
 


### PR DESCRIPTION
The edit corrects the spelling of "Transforms" in the data analysis section of the guide of Oscilloscope. Initially, it was written as "Transfroms" which is now changed to "Transforms".

Fixes #2164 

**Changes**: 
Changed spelling of "Tranfroms" to "Transforms" in app/src/main/res/values/strings.xml line 532