### PR TITLE
Changing Delete Log SnackBar

### DIFF
--- a/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
@@ -254,9 +254,7 @@ public class SensorLoggerListAdapter extends RealmRecyclerViewAdapter<SensorData
                                         File.separator + CSVLogger.CSV_DIRECTORY +
                                         File.separator + block.getSensorType() +
                                         File.separator + CSVLogger.FILE_NAME_FORMAT.format(block.getBlock()) + ".csv");
-                        CustomSnackBar.showSnackBar(context.findViewById(android.R.id.content),
-                                logDirectory.delete() ? context.getString(R.string.log_deleted)
-                                        : context.getString(R.string.nothing_to_delete), null, null, Snackbar.LENGTH_LONG);
+                        CustomSnackBar.showSnackBar(context.findViewById(android.R.id.content), context.getString(R.string.log_deleted), null, null, Snackbar.LENGTH_LONG);
                         if (block.getSensorType().equalsIgnoreCase(PSLabSensor.LUXMETER)) {
                             LocalDataLog.with().clearBlockOfLuxRecords(block.getBlock());
                         } else if (block.getSensorType().equalsIgnoreCase(PSLabSensor.BAROMETER)) {


### PR DESCRIPTION
Upon deletion of a logged data, the toast message should show "Log Deleted" but for some devices like Oscilloscope, it is showing "Nothing to delete" upon deletion of a log.

Fixes #2168 

**Changes**: The condition statement written to decide whether the snackbar should show "Log Deleted" or "Nothing to Delete" is not required and directly "Log Deleted" message can be shown as when there is nothing in the log then there is no option for the user to delete a log as the items menu sets "Delete All" menu option visibility to false.

**Screenshot/s for the changes**: 
Before Changes:
![image](https://user-images.githubusercontent.com/65716045/104831447-17fe6080-58af-11eb-8e16-6d85242a3ba8.png)

After changes:
![image](https://user-images.githubusercontent.com/65716045/104831438-fbfabf00-58ae-11eb-9724-87f0ba13c735.png)


**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[delete-log-toast.zip](https://github.com/fossasia/pslab-android/files/5825582/delete-log-toast.zip)
