### PR TITLE
Updating guide of multimeter

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -637,7 +637,7 @@
         <b>Different Sections</b>\n\n
         <b>Resistance:</b> Measures the resistance of the element connected between the RES and GND pin of the PSLab device.\n\n
         <b>Capacitance:</b> Measures the capacitance of the element connected between the CAP and GND pin of the PSLab device.\n\n
-        <b>Voltage:</b> Measures the voltage of any elements connect connected between any of the channel and GND pins and other pins such as VOL.\n\n
+        <b>Voltage:</b> Measures the voltage of any element connected between any of the channel and GND pins and other pins such as VOL.\n\n
         <b>Frequency:</b> Measures the frequency across any element connected between any of ID and GND pins.\n\n
         <b>Count Pulse:</b> Measures the pulse of any wave through an element connected between any of ID and GND pins.\n\n
     </string>


### PR DESCRIPTION
In the "different sections" section of the guide of multimeter for "voltage" there was grammatical error in the description. The strings.xml file has been modified to correct the error for better readability for the user.

**Changes**: 
The description for "Voltage" in "Different sections" section of Multimeter's guide is changed from "Mesures the voltage of any elements connect connected between any of the channel and GND pins and other pins such as AN8" to "Mesures the voltage of any element connected between any of the channel and GND pins and other pins such as AN8"
There is an extra "connect" written which is causing the grammatical error. 
