### PR TITLE
updated setupGuideLayout in abstract class PSLabSensor to hide image if not available in a sensor's bottomsheet guide

### DIFF
--- a/app/src/main/java/io/pslab/fragment/HomeFragment.java
+++ b/app/src/main/java/io/pslab/fragment/HomeFragment.java
@@ -91,6 +91,8 @@ public class HomeFragment extends Fragment {
         unbinder = ButterKnife.bind(this, view);
         stepsHeader.setPaintFlags(Paint.UNDERLINE_TEXT_FLAG);
         deviceDescription.setPaintFlags(Paint.UNDERLINE_TEXT_FLAG);
+        wvProgressBar = (ProgressBar) view.findViewById(R.id.web_view_progress);
+
         if (deviceFound & deviceConnected) {
             tvConnectMsg.setVisibility(View.GONE);
             try {

--- a/app/src/main/java/io/pslab/models/PSLabSensor.java
+++ b/app/src/main/java/io/pslab/models/PSLabSensor.java
@@ -588,6 +588,12 @@ public abstract class PSLabSensor extends AppCompatActivity {
         bottomSheetText.setText(getGuideAbstract());
         bottomSheetSchematic.setImageResource(getGuideSchematics());
         bottomSheetDesc.setText(getGuideDescription());
+        // if sensor doesn't image in it's guide and hence returns 0 for getGuideSchematics(), hide the visibility of bottomSheetSchematic
+        if (getGuideSchematics() != 0) {
+            bottomSheetSchematic.setImageResource(getGuideSchematics());
+        }else{
+            bottomSheetSchematic.setVisibility(View.GONE);
+        }
         // If a sensor has extra content than provided in the standard layout, create a new layout
         // and attach the layout id with getGuideExtraContent()
         if (getGuideExtraContent() != 0) {


### PR DESCRIPTION
Fixes: [empty imageview is sensors bottomsheet guide]

**Changes**: [updated setupGuideLayout in abstract class PSLabSensor to hide image if not available in a sensor's bottomsheet guide]

**Screenshot/s for the changes**: 
`Before-------------------------------------------------------------------------------------------------------------After`

<p float="left">
  <img src="https://i.imgur.com/d2Jy8Zu.jpg" width="400" />
  <img src="https://i.imgur.com/wSZe9fy.jpg" width="400" /> 
</p>

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members