### PR TITLE
Visibility of PSLab-MIC button changes when PSLab device is not found

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -320,9 +320,11 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
                     if (isInBuiltMicSelected && audioJack == null) {
                         audioJack = new AudioJack("input");
                     }
-                    if(!scienceLab.isDeviceFound()&& findViewById(R.id.pslab_mic_cb)!= null){
-                            findViewById(R.id.pslab_mic_cb).setVisibility(View.GONE);
-                        }
+                    
+                    if (!scienceLab.isDeviceFound() && findViewById(R.id.pslab_mic_cb) != null) {
+                        findViewById(R.id.pslab_mic_cb).setVisibility(View.GONE);
+                    }
+                    
                     if (scienceLab.isConnected() && isCH1Selected && !isCH2Selected && !isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
                         captureTask = new CaptureTask();
                         captureTask.execute(CHANNEL.CH1.toString());

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -320,7 +320,9 @@ public class OscilloscopeActivity extends AppCompatActivity implements View.OnCl
                     if (isInBuiltMicSelected && audioJack == null) {
                         audioJack = new AudioJack("input");
                     }
-
+                    if(!scienceLab.isDeviceFound()&& findViewById(R.id.pslab_mic_cb)!= null){
+                            findViewById(R.id.pslab_mic_cb).setVisibility(View.GONE);
+                        }
                     if (scienceLab.isConnected() && isCH1Selected && !isCH2Selected && !isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
                         captureTask = new CaptureTask();
                         captureTask.execute(CHANNEL.CH1.toString());


### PR DESCRIPTION
Fixes #2173 

**Changes**: 
 * The visibility of PSLab-MIC button is set to ``` View.Gone ``` when PSLab device is not found.
 
**Screenshot/s for the changes**: 
![Screenshot_20210122-225917_PSLab](https://user-images.githubusercontent.com/60058139/105575620-f3185a80-5d92-11eb-8d4a-9932f853ba1a.jpg)

**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [ ] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [ ] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 

[app-fdroid-debug.zip](https://github.com/fossasia/pslab-android/files/5860037/app-fdroid-debug.zip)

