### PR TITLE
fix: updating "Delete All Data" operation

### DIFF
--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -178,7 +178,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                     CustomSnackBar.showSnackBar(findViewById(android.R.id.content), context.getString(R.string.nothing_to_delete),
                             null, null, Snackbar.LENGTH_SHORT);
                     new DeleteAllTask().execute();
-                } else{
+                } else {
                     new AlertDialog.Builder(context)
                             .setTitle(context.getString(R.string.delete))
                             .setMessage(context.getString(R.string.delete_all_message))

--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -174,20 +174,26 @@ public class DataLoggerActivity extends AppCompatActivity {
                 break;
             case R.id.delete_all:
                 Context context = DataLoggerActivity.this;
-                new AlertDialog.Builder(context)
-                        .setTitle(context.getString(R.string.delete))
-                        .setMessage(context.getString(R.string.delete_all_message))
-                        .setPositiveButton(context.getString(R.string.delete), new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                deleteAllProgressBar.setVisibility(View.VISIBLE);
-                                new DeleteAllTask().execute();
-                            }
-                        }).setNegativeButton(context.getString(R.string.cancel), new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                        dialog.dismiss();
-                    }
-                }).create().show();
+                if(LocalDataLog.with().getAllSensorBlocks().size() <= 0){
+                    CustomSnackBar.showSnackBar(findViewById(android.R.id.content), context.getString(R.string.nothing_to_delete),
+                            null, null, Snackbar.LENGTH_SHORT);
+                    new DeleteAllTask().execute();
+                } else{
+                    new AlertDialog.Builder(context)
+                            .setTitle(context.getString(R.string.delete))
+                            .setMessage(context.getString(R.string.delete_all_message))
+                            .setPositiveButton(context.getString(R.string.delete), new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    deleteAllProgressBar.setVisibility(View.VISIBLE);
+                                    new DeleteAllTask().execute();
+                                }
+                            }).setNegativeButton(context.getString(R.string.cancel), new DialogInterface.OnClickListener() {
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                        }
+                    }).create().show();
+                }
                 break;
         }
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
+++ b/app/src/main/java/io/pslab/activity/DataLoggerActivity.java
@@ -174,7 +174,7 @@ public class DataLoggerActivity extends AppCompatActivity {
                 break;
             case R.id.delete_all:
                 Context context = DataLoggerActivity.this;
-                if(LocalDataLog.with().getAllSensorBlocks().size() <= 0){
+                if (LocalDataLog.with().getAllSensorBlocks().size() == 0) {
                     CustomSnackBar.showSnackBar(findViewById(android.R.id.content), context.getString(R.string.nothing_to_delete),
                             null, null, Snackbar.LENGTH_SHORT);
                     new DeleteAllTask().execute();


### PR DESCRIPTION
The code has been modified to check whether any log is present while deleting and if no logs are present then the "Delete All Data" menu option shows a snackbar "Nothing To Delete".

Fixes #2184 

**Changes**: 
In the onOptionsItemSelected function under the category of R.id.delete_all an if condition is added to check whether the size of LocalDataLog is greater than 0 or not. If it is 0 then the "Delete All Data" displays a snackbar "Nothing to delete", otherwise functions normally as before.

**Screenshot/s for the changes**: 
Before: 

https://user-images.githubusercontent.com/65716045/105618271-6198ff00-5e0b-11eb-9801-90825859383b.mp4

After:
![Nothing to Delete](https://user-images.githubusercontent.com/65716045/105618278-707fb180-5e0b-11eb-887d-1e6f3f600b7b.png)


**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 

[app-fdroid-debug.zip](https://github.com/fossasia/pslab-android/files/5861389/app-fdroid-debug.zip)


