### PR TITLE
Minor improvement in faq fragment

### DIFF
--- a/app/src/main/res/layout/list_group.xml
+++ b/app/src/main/res/layout/list_group.xml
@@ -36,6 +36,7 @@
             android:paddingBottom="@dimen/text_padding_top"
             android:paddingLeft="@dimen/text_padding_top"
             android:paddingTop="@dimen/text_padding_top"
+            android:paddingRight="@dimen/text_padding_top"
             android:textColor="@color/colorPrimaryDark"
             android:textSize="@dimen/text_size"
             tools:ignore="SpUsage" />


### PR DESCRIPTION
Fixes #2200 

**Changes**: 
Added padding right to list_group.xml (displays question in faq fragment)

**Screenshot/s for the changes**: 

https://user-images.githubusercontent.com/52701183/111592618-06720000-87ef-11eb-94ca-d88b92177659.mp4


**Checklist**: [Please tick following check boxes with `[x]` if the respective task is completed]
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [x] I have requested reviews from other members

**APK for testing**: 
[minor_ui_improvement_faq.zip](https://github.com/fossasia/pslab-android/files/6164038/minor_ui_improvement_faq.zip)

