### PR TITLE
Fix: 2186 Fix crash when searching for bluetooth devices

### DIFF
--- a/app/src/main/java/io/pslab/fragment/BluetoothScanFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BluetoothScanFragment.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import io.pslab.R;
@@ -35,8 +36,8 @@ public class BluetoothScanFragment extends DialogFragment {
     private ProgressBar scanProgressBar;
     private ListView scannedDevicesListView;
     private ArrayAdapter<String> deviceListAdapter;
-    private ArrayList<String> deviceList;
-    private ArrayList<BluetoothDevice> bluetoothDevices;
+    private List<String> deviceList;
+    private List<BluetoothDevice> bluetoothDevices;
     private final BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
         public void onReceive(Context context, Intent intent) {
             String action = intent.getAction();
@@ -44,7 +45,7 @@ public class BluetoothScanFragment extends DialogFragment {
                 BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
                 if (device != null) {
                     String deviceName = device.getName();
-                    deviceList.add(deviceName);
+                    deviceList.add(deviceName == null ? device.getAddress() : deviceName);
                     bluetoothDevices.add(device);
                     deviceListAdapter.notifyDataSetChanged();
                 }


### PR DESCRIPTION
Fixes #2186

**Changes**: Provide fallback if a discovered Bluetooth device has no name.

**Checklist**:
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding them
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`
- [x] I have reformatted code in every file included in this PR [<kbd>CTRL</kbd>+<kbd>ALT</kbd>+<kbd>L</kbd>]
- [x] My code does not contain any extra lines or extra spaces
- [ ] I have requested reviews from other members

**APK for testing**:
[fix_bluetooth_crash.zip](https://github.com/fossasia/pslab-android/files/7198365/fix_bluetooth_crash.zip)
