### PR TITLE
Fixes #2206 getDrawable() replaced with ResourcesCompat.getDrawable()

### DIFF
--- a/app/src/fdroid/java/io/pslab/activity/MapsActivity.java
+++ b/app/src/fdroid/java/io/pslab/activity/MapsActivity.java
@@ -2,6 +2,7 @@ package io.pslab.activity;
 
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.res.ResourcesCompat;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -58,7 +59,7 @@ public class MapsActivity extends AppCompatActivity {
             JSONObject marker = markers.getJSONObject(i);
             m.setPosition(new GeoPoint(marker.getDouble("lat"), marker.getDouble("lon")));
             m.setTitle(marker.getString("data") + " @ " + marker.getString("date"));
-            m.setIcon(getResources().getDrawable(R.drawable.action_item_read));
+            m.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.action_item_read, null));
             m.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_TOP);
             map.getOverlays().add(m);
         }

--- a/app/src/main/java/io/pslab/activity/MultimeterActivity.java
+++ b/app/src/main/java/io/pslab/activity/MultimeterActivity.java
@@ -21,6 +21,8 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.core.content.res.ResourcesCompat;
+
 import android.view.GestureDetector;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -565,13 +567,13 @@ public class MultimeterActivity extends AppCompatActivity {
                 if (playClicked) {
                     playClicked = false;
                     stopMenu.setVisible(true);
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                     if (playBackTimer != null) {
                         playBackTimer.cancel();
                     }
                 } else {
                     playClicked = true;
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_pause_white_24dp));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_pause_white_24dp, null));
                     stopMenu.setVisible(true);
                     if (playBackTimer != null) {
                         playBackTimer.cancel();
@@ -590,7 +592,7 @@ public class MultimeterActivity extends AppCompatActivity {
                                         playBackTimer.cancel();
                                         currentPosition = 0;
                                         stopMenu.setVisible(false);
-                                        item.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                                        item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                                     }
                                 }
                             });
@@ -606,7 +608,7 @@ public class MultimeterActivity extends AppCompatActivity {
                 }
                 currentPosition = 0;
                 playClicked = false;
-                playMenu.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                playMenu.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
             default:
                 break;
         }

--- a/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
+++ b/app/src/main/java/io/pslab/activity/PowerSourceActivity.java
@@ -15,6 +15,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.core.widget.TextViewCompat;
 import android.view.GestureDetector;
 import android.view.KeyEvent;
@@ -451,7 +452,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                 break;
             case R.id.power_source_record_data:
                 if (!isRecording) {
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_record_stop_white));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_record_stop_white, null));
                     isRecording = true;
                     if (recordTimer == null) {
                         recordTimer = new Timer();
@@ -474,7 +475,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                         }
                     }, 0, recordPeriod);
                 } else {
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_record_white));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_record_white, null));
                     recordTimer.cancel();
                     recordTimer = null;
                     isRecording = false;
@@ -496,7 +497,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                 if (!playClicked) {
                     playClicked = true;
                     stopMenu.setVisible(true);
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_pause_white_24dp));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_pause_white_24dp, null));
                     if (playbackTimer == null) {
                         playbackTimer = new Timer();
                     } else {
@@ -517,7 +518,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                                         currentPosition = 0;
                                         playClicked = false;
                                         stopMenu.setVisible(false);
-                                        item.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                                        item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                                     }
                                 }
                             });
@@ -527,7 +528,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                 } else {
                     playClicked = false;
                     stopMenu.setVisible(false);
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                     if (playbackTimer != null) {
                         playbackTimer.cancel();
                         playbackTimer = null;
@@ -539,7 +540,7 @@ public class PowerSourceActivity extends AppCompatActivity {
                     playbackTimer.cancel();
                     currentPosition = 0;
                     playClicked = false;
-                    playMenu.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                    playMenu.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                     stopMenu.setVisible(false);
                 }
                 break;

--- a/app/src/main/java/io/pslab/activity/RoboticArmActivity.java
+++ b/app/src/main/java/io/pslab/activity/RoboticArmActivity.java
@@ -33,6 +33,7 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
+import androidx.core.content.res.ResourcesCompat;
 
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.snackbar.Snackbar;
@@ -728,11 +729,11 @@ public class RoboticArmActivity extends AppCompatActivity {
             case R.id.play_data:
                 if (isPlaying) {
                     isPlaying = false;
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                     timeLine.onFinish();
                 } else {
                     isPlaying = true;
-                    item.setIcon(getResources().getDrawable(R.drawable.ic_pause_white_24dp));
+                    item.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_pause_white_24dp, null));
                     timeLine.start();
                 }
                 break;
@@ -742,7 +743,7 @@ public class RoboticArmActivity extends AppCompatActivity {
                 timeIndicatorLayout.setLayoutParams(timeIndicatorParams);
                 scrollView.fullScroll(HorizontalScrollView.FOCUS_LEFT);
                 isPlaying = false;
-                playMenu.setIcon(getResources().getDrawable(R.drawable.ic_play_arrow_white_24dp));
+                playMenu.setIcon(ResourcesCompat.getDrawable(getResources(), R.drawable.ic_play_arrow_white_24dp, null));
                 timelinePosition = 0;
                 break;
             case R.id.show_guide:

--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -24,6 +24,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.content.ContextCompat;
+import androidx.core.content.res.ResourcesCompat;
 
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -275,8 +276,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         imgBtnSin.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                imgBtnSin.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                imgBtnTri.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                imgBtnSin.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                imgBtnTri.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 WaveGeneratorCommon.wave.get(waveBtnActive).put(WaveConst.WAVETYPE, SIN);
                 selectWaveform(SIN);
             }
@@ -285,8 +286,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         imgBtnTri.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                imgBtnSin.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                imgBtnTri.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
+                imgBtnSin.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                imgBtnTri.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
                 WaveGeneratorCommon.wave.get(waveBtnActive).put(WaveConst.WAVETYPE, TRIANGULAR);
                 selectWaveform(TRIANGULAR);
             }
@@ -301,8 +302,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 activePropTv = waveFreqValue;
                 waveMonPropSelect.setText(getString(R.string.wave_frequency));
                 setSeekBar(seekBar);
-                btnCtrlFreq.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnCtrlPhase.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnCtrlFreq.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnCtrlPhase.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
             }
         });
 
@@ -315,8 +316,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 activePropTv = wavePhaseValue;
                 waveMonPropSelect.setText(getString(R.string.phase_offset));
                 setSeekBar(seekBar);
-                btnCtrlFreq.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnCtrlPhase.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
+                btnCtrlFreq.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnCtrlPhase.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
             }
         });
 
@@ -330,8 +331,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 imgBtnSin.setEnabled(true);
                 imgBtnTri.setEnabled(true);
                 toggleDigitalMode(WaveConst.SQUARE);
-                btnDigitalMode.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnAnalogMode.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
+                btnDigitalMode.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnAnalogMode.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
             }
         });
 
@@ -347,8 +348,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 imgBtnTri.setEnabled(false);
                 pwmBtnActive = WaveConst.SQR1;
                 selectBtn(WaveConst.SQR1);
-                btnDigitalMode.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnAnalogMode.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnDigitalMode.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnAnalogMode.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
             }
         });
 
@@ -401,9 +402,9 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 activePropTv = pwmFreqValue;
                 pwmMonPropSelect.setText(getString(R.string.frequecy_colon));
                 setSeekBar(seekBar);
-                pwmBtnFreq.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                pwmBtnPhase.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                pwmBtnDuty.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                pwmBtnFreq.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                pwmBtnPhase.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                pwmBtnDuty.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
             }
         });
 
@@ -416,9 +417,9 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 activePropTv = pwmPhaseValue;
                 pwmMonPropSelect.setText(getString(R.string.pwm_phase));
                 setSeekBar(seekBar);
-                pwmBtnFreq.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                pwmBtnPhase.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                pwmBtnDuty.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                pwmBtnFreq.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                pwmBtnPhase.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                pwmBtnDuty.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
             }
         });
 
@@ -431,9 +432,9 @@ public class WaveGeneratorActivity extends AppCompatActivity {
                 activePropTv = pwmDutyValue;
                 pwmMonPropSelect.setText(getString(R.string.duty_cycle));
                 setSeekBar(seekBar);
-                pwmBtnFreq.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                pwmBtnPhase.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                pwmBtnDuty.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
+                pwmBtnFreq.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                pwmBtnPhase.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                pwmBtnDuty.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
             }
         });
 
@@ -718,8 +719,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
                 waveBtnActive = WaveConst.WAVE1;
 
-                btnCtrlWave1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnCtrlWave2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnCtrlWave1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnCtrlWave2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
 
                 btnCtrlPhase.setEnabled(false);  //disable phase for wave
                 wavePhaseValue.setText("--");
@@ -734,8 +735,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
                 waveBtnActive = WaveConst.WAVE2;
 
-                btnCtrlWave2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnCtrlWave1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnCtrlWave2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnCtrlWave1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
 
                 btnCtrlPhase.setEnabled(true); // enable phase for wave2
 
@@ -748,10 +749,10 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
             case SQR1:
                 pwmBtnActive = WaveConst.SQR1;
-                btnPwmSq1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnPwmSq2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq3.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq4.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnPwmSq1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnPwmSq2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setEnabled(false);  //phase disabled for sq1
                 pwmPhaseValue.setText("--");
                 fetchPropertyValue(pwmBtnActive, WaveConst.FREQUENCY, getString(R.string.unit_hz), pwmFreqValue);
@@ -761,10 +762,10 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             case SQR2:
 
                 pwmBtnActive = WaveConst.SQR2;
-                btnPwmSq1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnPwmSq3.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq4.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnPwmSq1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setEnabled(true);
                 fetchPropertyValue(pwmBtnActive, WaveConst.PHASE, getString(R.string.deg_text), pwmPhaseValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
@@ -773,10 +774,10 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             case SQR3:
 
                 pwmBtnActive = WaveConst.SQR3;
-                btnPwmSq1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq3.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnPwmSq4.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnPwmSq1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setEnabled(true);
                 fetchPropertyValue(pwmBtnActive, WaveConst.PHASE, getString(R.string.deg_text), pwmPhaseValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
@@ -785,10 +786,10 @@ public class WaveGeneratorActivity extends AppCompatActivity {
             case SQR4:
 
                 pwmBtnActive = WaveConst.SQR4;
-                btnPwmSq1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq3.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
-                btnPwmSq4.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
+                btnPwmSq1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
+                btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
                 pwmBtnPhase.setEnabled(true);
                 fetchPropertyValue(pwmBtnActive, WaveConst.PHASE, getString(R.string.deg_text), pwmPhaseValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
@@ -796,8 +797,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
 
             default:
                 waveBtnActive = WaveConst.WAVE1;
-                btnCtrlWave1.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded));
-                btnCtrlWave2.setBackground(getResources().getDrawable(R.drawable.btn_back_rounded_light));
+                btnCtrlWave1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                btnCtrlWave2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 btnCtrlPhase.setEnabled(false);  //disable phase for wave
                 wavePhaseValue.setText("--");
                 selectWaveform(WaveGeneratorCommon.wave.get(waveBtnActive).get(WaveConst.WAVETYPE));
@@ -817,21 +818,21 @@ public class WaveGeneratorActivity extends AppCompatActivity {
         switch (waveType) {
             case SIN:
                 waveFormText = getString(R.string.sine);
-                image = getResources().getDrawable(R.drawable.ic_sin);
+                image = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_sin, null);
                 break;
 
             case TRIANGULAR:
                 waveFormText = getString(R.string.triangular);
-                image = getResources().getDrawable(R.drawable.ic_triangular);
+                image = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_triangular, null);
                 break;
             case PWM:
                 waveFormText = getResources().getString(R.string.text_pwm);
-                image = getResources().getDrawable(R.drawable.ic_pwm_pic);
+                image = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_pwm_pic, null);
                 break;
 
             default:
                 waveFormText = getString(R.string.sine);
-                image = getResources().getDrawable(R.drawable.ic_sin);
+                image = ResourcesCompat.getDrawable(getResources(), R.drawable.ic_sin, null);
         }
         selectedWaveText.setText(waveFormText);
         selectedWaveImg.setImageDrawable(image);

--- a/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/SensorLoggerListAdapter.java
@@ -10,6 +10,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.cardview.widget.CardView;
+import androidx.core.content.res.ResourcesCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -92,59 +93,59 @@ public class SensorLoggerListAdapter extends RealmRecyclerViewAdapter<SensorData
         switch (block.getSensorType()) {
             case PSLabSensor.LUXMETER:
                 holder.sensor.setText(context.getResources().getString(R.string.lux_meter));
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_lux_meter_log));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_lux_meter_log, null));
                 break;
             case PSLabSensor.BAROMETER:
                 holder.sensor.setText(context.getResources().getString(R.string.baro_meter));
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_barometer_log));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_barometer_log, null));
                 break;
             case PSLabSensor.GYROSCOPE:
                 holder.sensor.setText(context.getResources().getString(R.string.gyroscope));
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.gyroscope_logo));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.gyroscope_logo, null));
                 break;
             case PSLabSensor.COMPASS:
                 holder.sensor.setText(context.getResources().getString(R.string.compass));
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_compass_log));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_compass_log, null));
                 break;
             case PSLabSensor.ACCELEROMETER:
                 holder.sensor.setText(context.getResources().getString(R.string.accelerometer));
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_accelerometer));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_accelerometer, null));
                 break;
             case PSLabSensor.THERMOMETER:
                 holder.sensor.setText(R.string.thermometer);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.thermometer_logo));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.thermometer_logo, null));
                 break;
             case PSLabSensor.ROBOTIC_ARM:
                 holder.sensor.setText(R.string.robotic_arm);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.robotic_arm));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.robotic_arm, null));
                 break;
             case PSLabSensor.WAVE_GENERATOR:
                 holder.sensor.setText(R.string.wave_generator);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_wave_generator));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_wave_generator, null));
                 break;
             case PSLabSensor.OSCILLOSCOPE:
                 holder.sensor.setText(R.string.oscilloscope);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_oscilloscope));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_oscilloscope, null));
                 break;
             case PSLabSensor.POWER_SOURCE:
                 holder.sensor.setText(R.string.power_source);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_power_source));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_power_source, null));
                 break;
             case PSLabSensor.MULTIMETER:
                 holder.sensor.setText(R.string.multimeter);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_multimeter));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_multimeter, null));
                 break;
             case PSLabSensor.LOGIC_ANALYZER:
                 holder.sensor.setText(R.string.logical_analyzer);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_logic_analyzer));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_logic_analyzer, null));
                 break;
             case PSLabSensor.GAS_SENSOR:
                 holder.sensor.setText(R.string.gas_sensor);
-                holder.tileIcon.setImageDrawable(context.getResources().getDrawable(R.drawable.tile_icon_gas));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_gas, null));
                 break;
             case PSLabSensor.SOUND_METER:
                 holder.sensor.setText(R.string.sound_meter);
-                holder.tileIcon.setImageDrawable(context.getDrawable(R.drawable.tile_icon_gas));
+                holder.tileIcon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), R.drawable.tile_icon_gas, null));
                 break;
             default:
                 break;


### PR DESCRIPTION
**Fixes** #2206 getDrawable() replaced with ResourcesCompat.getDrawable()

**Changes**: 
- Replaced all instances of getResources().getDrawable() with ResourcesCompat.getDrawable()


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding any value.
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] I have reformatted code and fixed indentation in every file included in this pull request
- [x] My code does not contain any extra lines or extra spaces.
- [x] I have requested reviews from maintainers.