### PR TITLE
Fixes #2271 crash on closing WaveGenerator Screen

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -1370,7 +1370,8 @@ public class WaveGeneratorActivity extends AppCompatActivity {
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-        produceSoundTask.cancel(true);
+        if(produceSoundTask != null)
+            produceSoundTask.cancel(true);
         produceSoundTask = null;
         isPlayingSound = false;
     }


### PR DESCRIPTION
**Fixes** #2271 

**Changes**: 
- Null check was added in onBackPressed of WaveGeneratorActiviy for the produceSoundTask object.

**Screen shots for the changes**:


https://user-images.githubusercontent.com/54733471/139240354-f19d8022-649d-4761-b5b0-459a9b946fda.mp4

 

**Checklist**: 
- [x] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding any value.
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] I have reformatted code and fixed indentation in every file included in this pull request
- [x] My code does not contain any extra lines or extra spaces.
- [x] I have requested reviews from maintainers.