### PR TITLE
fix:#2274 back btn in wavegen activity

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -674,7 +674,7 @@ public class WaveGeneratorActivity extends AppCompatActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home:
-                if(produceSoundTask!=null)
+                if(produceSoundTask != null)
                     produceSoundTask.cancel(true);
                 produceSoundTask = null;
                 isPlayingSound = false;


### PR DESCRIPTION
**Fixes** #2274<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

**Changes**: 
<!-- Add here what changes were made in this issue and if possible provide links. -->
`WavegeneratorActivity.java` i have added `if statement` in order to avoid null values.
LineNo: 677, 678
**Screen shots for the changes**: 
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration -->

https://user-images.githubusercontent.com/54708414/139336070-53fd8fe8-1221-4899-898b-bdb63f7eed90.mp4

Now back btn working.

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding any value.
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [X] I have reformatted code and fixed indentation in every file included in this pull request
- [X] My code does not contain any extra lines or extra spaces.
- [X] I have requested reviews from maintainers.