### PR TITLE
Issue #2267: About us section just after launching app does not close navigation drawer and take longer time than usual 

### DIFF
--- a/app/src/main/java/io/pslab/fragment/AboutUsFragment.java
+++ b/app/src/main/java/io/pslab/fragment/AboutUsFragment.java
@@ -40,7 +40,7 @@ public class AboutUsFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_about_us, container, false);
-        simulateDayNight(0);
+        simulateDayNight(3);
         ButterKnife.bind(this, view);
         View aboutPage = new AboutPage(getActivity())
                 .isRTL(false)


### PR DESCRIPTION
**Fixes** #2267 <!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

**Changes**: 

- mode of the device - from only light mode to choose according to device<!-- Add here what changes were made in this issue and if possible provide links. -->

**Screen shots for the changes**: 

https://user-images.githubusercontent.com/75962762/141722622-1c709ce5-0ee7-4db0-b51f-04af8fd77ad7.mp4


<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding any value.
- [x] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [ ] I have reformatted code and fixed indentation in every file included in this pull request
- [x] My code does not contain any extra lines or extra spaces.
- [x] I have requested reviews from maintainers.