### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,16 +13,18 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 11 ]
     steps:
     - name: Download repository
       uses: actions/checkout@v2
     
-    - name: Setup Java
+    - name: Setup Java ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
         
     - name: Build with Gradle
       run: bash ./gradlew build --stacktrace


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. A matrix, or array was created in case you would like to add additional builds of the openjdk to test on.

**Fixes** N/A <!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->
The fix is in the CI/CD GitHub workflow to use Zulu as the distribution of the JDK instead of AdoptOpenJDK, as it is discontinued.

Please see more details at Foojay.io:
https://foojay.io/today/github-actions-with-java-part-2/

**Changes**: 
- GitHub Actions setup-java's distribution as `zulu` instead of `adopt`
- Created a simple matrix, just in case you want to use JDK 17 or 18ea release

**Screen shots for the changes**: 
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration --> N/A


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] Created PR on the Development branch
- [x] No modifications done source code.