### PR TITLE
fix: sensor crash due to permission error

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="io.pslab">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -11,6 +12,8 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"
+        tools:ignore="HighSamplingRate" />
 
     <uses-feature
         android:name="android.hardware.sensor.light"


### PR DESCRIPTION
**Fixes** #2320 

**Changes**: 
- Added permission check to manifest

**Screen shots for the changes**: 
> N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [X] I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard-coding any value.
- [X] No modifications done at the end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [X] I have reformatted code and fixed indentation in every file included in this pull request
- [X] My code does not contain any extra lines or extra spaces.
- [ ] I have requested reviews from maintainers.