### PR TITLE
prevent duplicates in Bluetooth scan list

### DIFF
--- a/app/src/main/java/io/pslab/fragment/BluetoothScanFragment.java
+++ b/app/src/main/java/io/pslab/fragment/BluetoothScanFragment.java
@@ -45,7 +45,7 @@ public class BluetoothScanFragment extends DialogFragment {
             String action = intent.getAction();
             if (BluetoothDevice.ACTION_FOUND.equals(action)) {
                 BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
-                if (device != null) {
+                if (device != null && !bluetoothDevices.contains(device)) {
                     String deviceName = device.getName();
                     deviceList.add(deviceName == null ? device.getAddress() : deviceName);
                     bluetoothDevices.add(device);


### PR DESCRIPTION
## Changes 
- Filter known Bluetooth devices (my TV always showed up in the list twice)

## Screenshots / Recordings  
Before
![Screenshot_20220401-224613](https://user-images.githubusercontent.com/11596220/161340969-8245ff37-7fc6-47af-bc98-7a909254fc97.png)

After
![Screenshot_20220401-224850](https://user-images.githubusercontent.com/11596220/161340998-468c4ef2-1212-4a1f-a3ba-d75a2a2dddb1.png)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.