### PR TITLE
fix: crash if empty log is analysed

### DIFF
--- a/app/src/main/java/io/pslab/fragment/LALogicLinesFragment.java
+++ b/app/src/main/java/io/pslab/fragment/LALogicLinesFragment.java
@@ -218,7 +218,12 @@ public class LALogicLinesFragment extends Fragment {
         setAdapters();
         LogicalAnalyzerActivity laActivity = (LogicalAnalyzerActivity) getActivity();
         if (laActivity.isPlayback) {
-            setPlayBackData(laActivity.recordedLAData);
+            if (laActivity.recordedLAData.isEmpty()) {
+                CustomSnackBar.showSnackBar(container, getString(R.string.no_playback_data),
+                        null, null, Snackbar.LENGTH_SHORT);
+            } else {
+                setPlayBackData(laActivity.recordedLAData);
+            }
         }
         return rootView;
     }
@@ -349,7 +354,7 @@ public class LALogicLinesFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 if (channelMode > 0) {
-                    if (scienceLab.isConnected()) {
+                    if (scienceLab != null && scienceLab.isConnected()) {
                         analyze_button.setClickable(false);
 
                         // Change all variables to default value

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1054,4 +1054,5 @@
     <string name="github_developers_link">https://github.com/fossasia/pslab-android/graphs/contributors</string>
     <string name="limit_dangerous">\"Dangerous\"</string>
     <string name="limit_average">Average</string>
+    <string name="no_playback_data">No data to display</string>
 </resources>


### PR DESCRIPTION
Fixes #2360

## Changes 
- add check if loaded data is empty and display a warning
- add a null-check which prevents a NullPointerException if of PSLab is connected

## Screenshots / Recordings  
![Screenshot_20230126-233013](https://user-images.githubusercontent.com/11596220/214965775-2c2bf6b0-19ff-4a40-aa42-8ee09609c9a8.png)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.