### PR TITLE
chore: update dependencies and migrate buildConfig to Gradle Build files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 
@@ -60,7 +63,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
-    implementation("com.google.android.material:material:1.11.0")
+    implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.preference:preference:1.2.1")
     implementation("androidx.browser:browser:1.8.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
@@ -101,9 +104,9 @@ dependencies {
     implementation("org.osmdroid:osmdroid-android:6.1.18")
     implementation("org.osmdroid:osmdroid-mapsforge:6.1.18")
     implementation("org.osmdroid:osmdroid-geopackage:6.1.18") {
-        exclude("org.osmdroid.gpkg");
-        exclude("ormlite-core");
-        exclude("com.j256.ormlite");
+        exclude("org.osmdroid.gpkg")
+        exclude("ormlite-core")
+        exclude("com.j256.ormlite")
     }
 
     // Realm

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,6 @@ android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true
 org.gradle.warning.mode=all
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 # When configured, Gradle will run in incubating parallel mode.


### PR DESCRIPTION
Fixes #2403 and #2399.
Updates dependencies in the project to the latest versions and migrates the buildConfig setting to Gradle Build files.

## Changes 
build.gradle.kts :-
- update com.google.android.material:material from 1.11.0 to 1.12.0
- add buildConfig setting

gradle.properties :- 
- remove android.defaults.buildfeatures.buildConfig

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.