### PR TITLE
fix: updated multimeter screen layout to make it visible properly

### DIFF
--- a/app/src/main/res/layout-hdpi/activity_multimeter.xml
+++ b/app/src/main/res/layout-hdpi/activity_multimeter.xml
@@ -87,7 +87,7 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/dimen_zero_dp"
             android:layout_marginBottom="@dimen/multimeter_constraint_1"
-            app:layout_constraintBottom_toTopOf="@+id/bottom_view"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/display_box">
@@ -427,13 +427,6 @@
                 app:layout_constraintStart_toStartOf="@+id/lower_right_box" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <View
-            android:id="@+id/bottom_view"
-            android:layout_width="@dimen/dimen_zero_dp"
-            android:layout_height="@dimen/dimen_zero_dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout-sw600dp/activity_multimeter.xml
+++ b/app/src/main/res/layout-sw600dp/activity_multimeter.xml
@@ -88,8 +88,8 @@
             android:layout_width="match_parent"
             android:layout_height="@dimen/dimen_zero_dp"
             android:layout_marginTop="@dimen/multimeter_view_top_margin"
-            android:layout_marginBottom="@dimen/multimeter_constraint_1"
-            app:layout_constraintBottom_toTopOf="@+id/bottom_view"
+            android:layout_marginBottom="@dimen/multimeter_constraint_2"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/display_box">
@@ -137,7 +137,7 @@
                 android:id="@+id/upper_line"
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/multimeter_line_width"
-                android:layout_marginTop="@dimen/multimeter_constraint_2"
+                android:layout_marginTop="@dimen/multimeter_constraint_5"
                 android:background="@color/black"
                 android:visibility="invisible"
                 app:layout_constraintTop_toBottomOf="@+id/ch3" />
@@ -147,10 +147,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/multimeter_line_width"
                 android:layout_marginStart="@dimen/multimeter_constraint_1"
-                android:layout_marginLeft="@dimen/multimeter_constraint_1"
                 android:layout_marginEnd="@dimen/multimeter_constraint_1"
-                android:layout_marginRight="@dimen/multimeter_constraint_1"
-                android:layout_marginBottom="@dimen/multimeter_constraint_3"
+                android:layout_marginBottom="@dimen/multimeter_constraint_5"
                 android:visibility="invisible"
                 app:layout_constraintBottom_toTopOf="@+id/id4"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -431,8 +429,8 @@
 
             <TextView
                 android:id="@+id/id1"
-                android:layout_width="12dp"
-                android:layout_height="14dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:gravity="center"
                 android:scaleX="1.5"
@@ -467,13 +465,6 @@
                 app:layout_constraintStart_toStartOf="@+id/lower_right_box" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <View
-            android:id="@+id/bottom_view"
-            android:layout_width="@dimen/dimen_zero_dp"
-            android:layout_height="@dimen/dimen_zero_dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout-xhdpi/activity_multimeter.xml
+++ b/app/src/main/res/layout-xhdpi/activity_multimeter.xml
@@ -88,7 +88,7 @@
             android:layout_height="@dimen/dimen_zero_dp"
             android:layout_marginTop="@dimen/multimeter_view_top_margin"
             android:layout_marginBottom="@dimen/multimeter_constraint_1"
-            app:layout_constraintBottom_toTopOf="@+id/bottom_view"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/display_box">
@@ -433,13 +433,6 @@
                 app:layout_constraintStart_toStartOf="@+id/lower_right_box" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <View
-            android:id="@+id/bottom_view"
-            android:layout_width="@dimen/dimen_zero_dp"
-            android:layout_height="@dimen/dimen_zero_dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_multimeter.xml
+++ b/app/src/main/res/layout/activity_multimeter.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
@@ -9,7 +10,9 @@
         android:id="@+id/top_app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:theme="@style/AppTheme.AppBarOverlay"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/multimeter_toolbar"
@@ -87,7 +90,7 @@
             android:layout_height="@dimen/dimen_zero_dp"
             android:layout_marginTop="@dimen/multimeter_view_top_margin"
             android:layout_marginBottom="@dimen/multimeter_constraint_1"
-            app:layout_constraintBottom_toTopOf="@+id/bottom_view"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/display_box">
@@ -429,12 +432,6 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <View
-            android:id="@+id/bottom_view"
-            android:layout_width="@dimen/dimen_zero_dp"
-            android:layout_height="@dimen/dimen_zero_dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/values-hdpi/dimens.xml
+++ b/app/src/main/res/values-hdpi/dimens.xml
@@ -7,8 +7,8 @@
 
     <dimen name="multimeter_knob_width">170dp</dimen>
     <dimen name="multimeter_knob_height">168dp</dimen>
-    <dimen name="multimeter_knobcircle_radius_1">97dp</dimen>
-    <dimen name="multimeter_knobcircle_radius_2">93dp</dimen>
-    <dimen name="multimeter_knobcircle_radius_3">99dp</dimen>
+    <dimen name="multimeter_knobcircle_radius_1">101dp</dimen>
+    <dimen name="multimeter_knobcircle_radius_2">97dp</dimen>
+    <dimen name="multimeter_knobcircle_radius_3">103dp</dimen>
 
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -133,7 +133,8 @@
     <dimen name="multimeter_end_box_rightmargin">12dp</dimen>
     <dimen name="multimeter_layout_margin_2">10dp</dimen>
     <dimen name="multimeter_layout_margin_1">5dp</dimen>
-    <dimen name="multimeter_constraint_4">15dp</dimen>
+    <dimen name="multimeter_constraint_4">10dp</dimen>
+    <dimen name="multimeter_constraint_5">37dp</dimen>
     <dimen name="multimeter_length_0">0dp</dimen>
     <dimen name="multimeter_knob_width_xhdpi">192dp</dimen>
     <dimen name="multimeter_knob_height_xhdpi">190dp</dimen>


### PR DESCRIPTION
Fixes #2342 and #2394 
This issue was arising due to a redundant View bottom_view being present in the layouts, something which has already been implemented in activity_multimeter_main.xml.
## Changes 
- app/src/main/res/layout-hdpi/activity_multimeter.xml,
app/src/main/res/layout-sw600dp/activity_multimeter.xml,
app/src/main/res/layout-xhdpi/activity_multimeter.xml,
app/src/main/res/layout/activity_multimeter.xml - Removed bottom_view and fixed some other constraints, hardcoding.
- app/src/main/res/values-hdpi/dimens.xml,
 app/src/main/res/values/dimens.xml - Fixed some dimensions and added others to improve the layouts.

## Screenshots / Recordings  
- app/src/main/res/layout-xhdpi/activity_multimeter.xml:-
![multimeter_screenshot_1](https://github.com/fossasia/pslab-android/assets/125425881/4480e134-1543-4bb6-a195-469745e5e6d7)
- app/src/main/res/layout-hdpi/activity_multimeter.xml:-
![Screenshot 2024-05-16 155425](https://github.com/fossasia/pslab-android/assets/125425881/43efbea1-a20d-4f2e-b7e1-02a4ee8a5b9f)
- app/src/main/res/layout-sw600dp/activity_multimeter.xml:-
![Screenshot 2024-05-16 155527](https://github.com/fossasia/pslab-android/assets/125425881/e22ec407-b358-464f-962a-f5a009901974)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.