### PR TITLE
feat: added privacy policy in the menu drawer

### DIFF
--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -305,6 +305,12 @@ public class MainActivity extends AppCompatActivity {
                         }
                         startActivity(new Intent(MainActivity.this, CreateConfigActivity.class));
                         break;
+                    case R.id.nav_privacy_policy:
+                        customTabService.launchUrl("https://pslab.io/privacy-policy/");
+                        if (drawer != null) {
+                            drawer.closeDrawers();
+                        }
+                        break;
                     default:
                         navItemIndex = 0;
                 }

--- a/app/src/main/res/drawable/baseline_article_24.xml
+++ b/app/src/main/res/drawable/baseline_article_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M19,3L5,3c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM14,17L7,17v-2h7v2zM17,13L7,13v-2h10v2zM17,9L7,9L7,7h10v2z"/>
+    
+</vector>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -56,5 +56,9 @@
             android:id="@+id/nav_share_app"
             android:icon="@drawable/share_icon"
             android:title="@string/nav_share" />
+        <item
+            android:id="@+id/nav_privacy_policy"
+            android:icon="@drawable/baseline_article_24"
+            android:title="@string/privacy_policy"/>
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1055,4 +1055,5 @@
     <string name="limit_dangerous">\"Dangerous\"</string>
     <string name="limit_average">Average</string>
     <string name="no_playback_data">No data to display</string>
+    <string name="privacy_policy">Privacy Policy</string>
 </resources>


### PR DESCRIPTION
Fixes #2396 
Adds a privacy policy button just below the share button in the menu drawer with an appropriate icon. This button is linked to privacy policy of our organization which is opened upon clicking it, using customTabService.

## Changes 
- app/src/main/java/io/pslab/activity/MainActivity.java
- app/src/main/res/drawable/baseline_article_24.xml
- app/src/main/res/menu/activity_main_drawer.xml
- app/src/main/res/values/strings.xml

## Screenshots / Recordings  
![WhatsApp Image 2024-05-16 at 9 31 40 PM](https://github.com/fossasia/pslab-android/assets/125425881/e73e3178-66ac-462c-ba72-e37cb625e21d)
![WhatsApp Image 2024-05-16 at 9 31 41 PM](https://github.com/fossasia/pslab-android/assets/125425881/e41cc942-a635-41df-a2fb-067aaecdac2a)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.