### PR TITLE
fix: prevent potential app crashes in Connect Device screen

### DIFF
--- a/app/src/main/java/io/pslab/fragment/ESPFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ESPFragment.java
@@ -1,5 +1,6 @@
 package io.pslab.fragment;
 
+import android.app.Activity;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.util.Log;
@@ -50,9 +51,10 @@ public class ESPFragment extends DialogFragment {
             public void onClick(View v) {
                 espIPAddress = espIPEditText.getText().toString();
                 espConnectBtn.onEditorAction(EditorInfo.IME_ACTION_DONE);
-                if (espIPAddress.length() == 0) {
-                    CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
-                            getString(R.string.incorrect_IP_address_message),null,null, Snackbar.LENGTH_SHORT);
+                Activity activity;
+                if (espIPAddress.isEmpty() && ((activity = getActivity()) != null)) {
+                    CustomSnackBar.showSnackBar(activity.findViewById(android.R.id.content),
+                            getString(R.string.incorrect_IP_address_message), null, null, Snackbar.LENGTH_SHORT);
 
                 } else {
                     new ESPTask().execute();
@@ -64,14 +66,15 @@ public class ESPFragment extends DialogFragment {
             @Override
             public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
-                        espConnectBtn.performClick();
-                        return true;
-                    }
-                    return false;
+                    espConnectBtn.performClick();
+                    return true;
                 }
+                return false;
+            }
         });
         return rootView;
     }
+
     @Override
     public void onResume() {
         super.onResume();
@@ -113,9 +116,10 @@ public class ESPFragment extends DialogFragment {
         protected void onPostExecute(String result) {
             espConnectProgressBar.setVisibility(View.GONE);
             espConnectBtn.setVisibility(View.VISIBLE);
-            if (result.length() == 0) {
-                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
-                        getString(R.string.incorrect_IP_address_message),null,null,Snackbar.LENGTH_SHORT);
+            Activity activity;
+            if (result.isEmpty() && ((activity = getActivity()) != null)) {
+                CustomSnackBar.showSnackBar(activity.findViewById(android.R.id.content),
+                        getString(R.string.incorrect_IP_address_message), null, null, Snackbar.LENGTH_SHORT);
             } else {
                 Log.v("Response", result);
             }


### PR DESCRIPTION
Fixes #2415

## Changes 
- Check if Activity is null before accessing it.
- Use isEmpty() instead of length check

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.