### PR TITLE
feat: added prominent disclosure dialogs for permissions

### DIFF
--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -55,6 +55,7 @@ import io.pslab.fragment.PSLabPinLayoutFragment;
 import io.pslab.others.CustomSnackBar;
 import io.pslab.others.CustomTabService;
 import io.pslab.others.InitializationVariable;
+import io.pslab.others.PSLabPermission;
 import io.pslab.others.ScienceLabCommon;
 import io.pslab.receivers.USBDetachReceiver;
 
@@ -80,8 +81,6 @@ public class MainActivity extends AppCompatActivity {
     private CustomTabsServiceConnection customTabsServiceConnection;
 
     public static int navItemIndex = 0;
-
-    int PERMISSION_ID = 44;
 
     private static final String TAG_DEVICE = "device";
     private static final String TAG_INSTRUMENTS = "instruments";
@@ -157,35 +156,7 @@ public class MainActivity extends AppCompatActivity {
             CURRENT_TAG = TAG_INSTRUMENTS;
             loadHomeFragment();
         }
-        
-        checkPermissions();
     }
-
-    private void checkPermissions() {
-        if(checkSelfPermission(android.Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED && checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-            //Permission granted
-        } else {
-            requestLocationPermissions();
-        }
-    }
-
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        if (requestCode == PERMISSION_ID && grantResults[0] == PackageManager.PERMISSION_GRANTED && grantResults[1] == PackageManager.PERMISSION_GRANTED) {
-            //Permission granted
-        } else {
-            Toast.makeText(this, "This app requires permission to access your location.", Toast.LENGTH_SHORT).show();
-        }
-    }
-
-    private void requestLocationPermissions() {
-        ActivityCompat.requestPermissions(this, new String[]{
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_COARSE_LOCATION,
-        }, PERMISSION_ID);
-    }
-
     private void loadHomeFragment() {
         selectNavMenu();
         setToolbarTitle(activityTitles[navItemIndex]);

--- a/app/src/main/java/io/pslab/activity/SplashActivity.java
+++ b/app/src/main/java/io/pslab/activity/SplashActivity.java
@@ -1,9 +1,13 @@
 package io.pslab.activity;
 
+import android.Manifest;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 import android.widget.ImageView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -39,17 +43,18 @@ public class SplashActivity extends AppCompatActivity {
             exitSplashScreen();
         }
     }
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        if(requestCode == PSLabPermission.PERMISSIONS_REQUIRED) {
+            exitSplashScreen();
+        }
+    }
 
     @Override
     public void onBackPressed() {
         super.onBackPressed();
         handler.removeCallbacks(runnable);
-    }
-
-    @Override
-    public void onRequestPermissionsResult(
-            int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        exitSplashScreen();
     }
 
     private void exitSplashScreen() {

--- a/app/src/main/java/io/pslab/others/PSLabPermission.java
+++ b/app/src/main/java/io/pslab/others/PSLabPermission.java
@@ -1,13 +1,22 @@
 package io.pslab.others;
 
+
 import android.Manifest;
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.pm.PackageManager;
+import android.util.Log;
+import android.view.View;
+import android.widget.Toast;
+
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
+import io.pslab.activity.SplashActivity;
 
 /**
  * Created by Padmal on 11/3/18.
@@ -32,12 +41,17 @@ public class PSLabPermission {
     private String[] mapPermissions = new String[] {
             Manifest.permission.ACCESS_FINE_LOCATION
     };
+    List<String> listPermissionsNeeded = new ArrayList<>();
 
     public static final int ALL_PERMISSION = 100;
     public static final int LOG_PERMISSION = 101;
     public static final int MAP_PERMISSION = 102;
     public static final int GPS_PERMISSION = 103;
     public static final int CSV_PERMISSION = 104;
+
+    public static int REQUEST_CODE = 0;
+
+    public static int PERMISSIONS_REQUIRED = 0;
 
     private static final PSLabPermission pslabPermission = new PSLabPermission();
 
@@ -46,9 +60,7 @@ public class PSLabPermission {
     }
 
     private PSLabPermission() {/**/}
-
     public boolean checkPermissions(Activity activity, int mode) {
-        List<String> listPermissionsNeeded = new ArrayList<>();
         if (mode == ALL_PERMISSION) {
             for (String permission : allPermissions) {
                 if (ContextCompat.checkSelfPermission(activity, permission)
@@ -85,9 +97,51 @@ public class PSLabPermission {
                 }
             }
         }
+        PERMISSIONS_REQUIRED = listPermissionsNeeded.size();
         if (!listPermissionsNeeded.isEmpty()) {
-            ActivityCompat.requestPermissions(activity, listPermissionsNeeded.toArray(
-                    new String[listPermissionsNeeded.size()]), mode);
+            for(String permission : listPermissionsNeeded) {
+                if (Objects.equals(permission, Manifest.permission.ACCESS_FINE_LOCATION)) {
+                    AlertDialog.Builder alert = new AlertDialog.Builder(activity);
+                    alert.setTitle("Location Permission Disclosure");
+                    alert.setCancelable(false);
+                    alert.setMessage("PSLab requires access to location data to show the location of measurements on a map.");
+                    alert.setPositiveButton("ACCEPT", (dialog, which) -> {
+                        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, ++REQUEST_CODE);
+                    });
+                    alert.setNegativeButton("DENY", (dialog, which) -> {
+                        Toast.makeText(activity, "Please grant the permission.", Toast.LENGTH_SHORT).show();
+                        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, ++REQUEST_CODE);
+                    });
+                    AlertDialog alertDialog = alert.create();
+                    alertDialog.show();
+                } else if (Objects.equals(permission, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                    AlertDialog.Builder alert = new AlertDialog.Builder(activity);
+                    alert.setTitle("Storage Permission Disclosure");
+                    alert.setMessage("PSLab requires access to storage to enable the storage and import of sensor data.");
+                    alert.setPositiveButton("ACCEPT", (dialog, which) -> {
+                        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, ++REQUEST_CODE);
+                    });
+                    alert.setNegativeButton("DENY", (dialog, which) -> {
+                        Toast.makeText(activity, "Please grant the permission.", Toast.LENGTH_SHORT).show();
+                        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, ++REQUEST_CODE);
+                    });
+                    AlertDialog alertDialog = alert.create();
+                    alertDialog.show();
+                } else if (Objects.equals(permission, Manifest.permission.RECORD_AUDIO)) {
+                    AlertDialog.Builder alert = new AlertDialog.Builder(activity);
+                    alert.setTitle("Audio Permission Disclosure");
+                    alert.setMessage("PSLab requires access to record audio for recording data using the Built-In MIC.");
+                    alert.setPositiveButton("ACCEPT", (dialog, which) -> {
+                        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.RECORD_AUDIO}, ++REQUEST_CODE);
+                    });
+                    alert.setNegativeButton("DENY", (dialog, which) -> {
+                        Toast.makeText(activity, "Please grant the permission.", Toast.LENGTH_SHORT).show();
+                        ActivityCompat.requestPermissions(activity, new String[]{Manifest.permission.RECORD_AUDIO}, ++REQUEST_CODE);
+                    });
+                    AlertDialog alertDialog = alert.create();
+                    alertDialog.show();
+                }
+            }
             return false;
         }
         return true;


### PR DESCRIPTION
Fixes #2411 
Adds prominent disclosure dialogs before requesting for each permission. Migrates request for all permissions to PSLabPermission.java.
## Changes 
- app/src/main/java/io/pslab/activity/MainActivity.java
- app/src/main/java/io/pslab/activity/SplashActivity.java
- app/src/main/java/io/pslab/others/PSLabPermission.java

## Screenshots / Recordings  
![WhatsApp Image 2024-05-17 at 6 25 09 PM](https://github.com/fossasia/pslab-android/assets/125425881/c7d95caa-08c4-43c5-ba54-a955c8c6fc96)
![WhatsApp Image 2024-05-17 at 6 25 10 PM (1)](https://github.com/fossasia/pslab-android/assets/125425881/de487a6c-a3f9-4e32-a1e7-220e0396206a)
![WhatsApp Image 2024-05-17 at 6 25 10 PM](https://github.com/fossasia/pslab-android/assets/125425881/8314a11f-0d87-4584-80c9-dc1ddffb5c69)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.