### PR TITLE
chore: updated minSdk of the app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 
     defaultConfig {
         applicationId = "io.pslab"
-        minSdk = 31
+        minSdk = 24
         targetSdk = 34
         versionCode = 25
         versionName = "3.1.1"


### PR DESCRIPTION
Fixes #2419 
Changes the minSdk of the app from 31 to 24.
Some features of the app would not work at versions 23 and below, hence 24 would be the minimum possible Sdk the app can support.
## Changes 
- app/build.gradle.kts

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.