### PR TITLE
fix: fixed the In-Built MIC to work properly after toggling the PSLab MIC

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -14,6 +14,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.util.Log;
 import android.view.Display;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -336,12 +337,12 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                         if (isInBuiltMicSelected || (isMICSelected && scienceLab.isConnected())) {
                             captureTask = new CaptureTask();
                             captureTask.execute(CHANNEL.MIC.toString());
-                        }
-                        synchronized (lock) {
-                            try {
-                                lock.wait();
-                            } catch (InterruptedException e) {
-                                e.printStackTrace();
+                            synchronized (lock) {
+                                try {
+                                    lock.wait();
+                                } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -14,7 +14,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
-import android.util.Log;
 import android.view.Display;
 import android.view.Menu;
 import android.view.MenuItem;

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -10,7 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -245,7 +246,10 @@ public class ChannelParametersFragment extends Fragment {
                 ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
                 ((OscilloscopeActivity) getActivity()).isMICSelected = !isChecked;
                 if (isChecked) {
-                    pslabMicCheckBox.setChecked(false);
+                    if(pslabMicCheckBox.isChecked()) {
+                        pslabMicCheckBox.setChecked(false);
+                        ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
+                    }
                     if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
                         requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;
@@ -261,7 +265,10 @@ public class ChannelParametersFragment extends Fragment {
                 ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
                 ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = !isChecked;
                 if (isChecked) {
-                    builtInMicCheckBox.setChecked(false);
+                    if(builtInMicCheckBox.isChecked()) {
+                        builtInMicCheckBox.setChecked(false);
+                        ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
+                    }
                     if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
                         requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;


### PR DESCRIPTION
Fixes #2421 and #2173 
This issue was arising primarily due to the following two reasons:-

1. In the ChannelParametersFragment, whenever one checkbox was checked, the other was being unchecked without correcting the state of isAudioInputSelected, causing it to get toggled two times, resulting in it being false, even when one of the audio inputs was selected.
2. In the OscilloscopeActivity, the synchronized method was placed in the wrong scope, causing lock.wait() to get executed even when there was no PSLab Device connected. As there was no input, the thread would keep waiting forever, as lock.notify() would never be called. Hence, it would never detect a change in isAudioInputSelected.

## Changes 
- app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java - corrected the state of isAudioInputSelected whenever a checkbox is checked, due to another getting unchecked.
- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java - corrected the scope of the synchronized method, so that lock.wait() only gets executed if the PSLab Device is connected.

## Screenshots / Recordings  
This is a screenshot of the OscilloscopeActivity, after following the required steps to reproduce the issue, as mentioned in #2421.
![WhatsApp Image 2024-05-19 at 6 29 45 PM](https://github.com/fossasia/pslab-android/assets/125425881/c562bc39-083d-4f21-a307-570011cc4b07)
As one can see, the issue is resolved.

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.