### PR TITLE
fix: remove superfluous characters after version string

### DIFF
--- a/app/src/main/java/io/pslab/communication/PacketHandler.java
+++ b/app/src/main/java/io/pslab/communication/PacketHandler.java
@@ -5,10 +5,13 @@ import android.util.Log;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import io.pslab.interfaces.HttpCallback;
@@ -52,7 +55,12 @@ public class PacketHandler {
             sendByte(mCommandsProto.GET_VERSION);
             // Read "<PSLAB Version String>\n"
             commonRead(VERSION_STRING_LENGTH + 1);
-            version = new String(Arrays.copyOfRange(buffer, 0, VERSION_STRING_LENGTH), Charset.forName("UTF-8"));
+            // Only use first line, just like in the Python implementation.
+            version = new BufferedReader(
+                    new InputStreamReader(
+                            new ByteArrayInputStream(buffer, 0, VERSION_STRING_LENGTH),
+                            StandardCharsets.UTF_8))
+                    .readLine();
         } catch (IOException e) {
             Log.e("Error in Communication", e.toString());
         }
@@ -214,7 +222,7 @@ public class PacketHandler {
                 public void success(JSONObject jsonObject) {
                     try {
                         //Server will send byte array
-                        buffer = (byte[])jsonObject.get("data");
+                        buffer = (byte[]) jsonObject.get("data");
                         bytesRead[0] = buffer.length;
                     } catch (JSONException e) {
                         e.printStackTrace();


### PR DESCRIPTION
Fixes #2424

## Changes 
- Only the first line of the version String is used to display the version. This is the same way the Python software handles the version information (see get_version method in https://github.com/fossasia/pslab-python/blob/development/pslab/serial_handler.py)

## Screenshots / Recordings  
![Screenshot_20240520-231613](https://github.com/fossasia/pslab-android/assets/11596220/3f22ffeb-aa49-43d8-b7fa-c0e8170b8cdc)
![Screenshot_20240520-231608](https://github.com/fossasia/pslab-android/assets/11596220/0f8b1de0-7b91-4cdc-b086-0a51e35ec703)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.