### PR TITLE
fix: fixed the plots for the data captured through the In-Built-MIC

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1,6 +1,7 @@
 package io.pslab.activity;
 
 
+import static io.pslab.others.AudioJack.SAMPLING_RATE;
 import static io.pslab.others.MathUtils.map;
 
 import android.annotation.SuppressLint;
@@ -1027,12 +1028,14 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                         xDataString = new String[n];
                     }
                     for (int i = 0; i < n; i++) {
+                        float j = (float) (((double) i /SAMPLING_RATE)*1000000.0);
+                        j = j / ((timebase == 875) ? 1:1000);
                         float audioValue = (float) map(buffer[i], -32768, 32767, -3, 3);
                         if (!isFourierTransformSelected) {
                             if (noOfChannels == 1) {
-                                xDataString[i] = String.valueOf(2.0 * i);
+                                xDataString[i] = String.valueOf(j);
                             }
-                            entries.get(entries.size() - 1).add(new Entry(i, audioValue));
+                            entries.get(entries.size() - 1).add(new Entry(j, audioValue));
                         } else {
                             if (i < n / 2) {
                                 float y = (float) fftOut[i].abs() / samples;

--- a/app/src/main/java/io/pslab/others/AudioJack.java
+++ b/app/src/main/java/io/pslab/others/AudioJack.java
@@ -19,7 +19,7 @@ public class AudioJack {
 
     private static final String TAG = "AudioJack";
 
-    private static final int SAMPLING_RATE = 44100;
+    public static final int SAMPLING_RATE = 44100;
     private static final int RECORDING_CHANNEL = AudioFormat.CHANNEL_IN_MONO;
     private static final int RECORDER_AUDIO_ENCODING = AudioFormat.ENCODING_PCM_16BIT;
 


### PR DESCRIPTION
Fixes #2428 
This issue was primarily arising due to two reasons:
**1. No manipulation of the xData before plotting -** The xData was not being manipulated before plotting in the case of the In-Built-MIC as it was being done in the other channels. As a result, the data sampled at 44,100 Hz (sampling period approx. 2.26 microseconds) was being plotted at intervals of 1 microsecond, which was causing a waveform of the wrong frequency to be displayed.

**2. Wrong configuration of the millisecond scales -** The xData was not being changed in the case of the In-Built-MIC when the user shifted to the millisecond scales using the seekBar in the TimebaseTriggerFragment, as it was being done in the case of the other channels. The xData was not being divided by 1000 when the millisecond scales were selected.

## Changes 
**- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java -** Added the required data manipulations before plotting it.
**- app/src/main/java/io/pslab/others/AudioJack.java -** Made SAMPLING_RATE public to access it inside OscilloscopeActivity.


## Screenshots / Recordings 
The following is a screenshot for an audio wave of 1000Hz generated by a tone generator, captured by the In-Built-MIC:
![Screenshot_20240525_082500](https://github.com/fossasia/pslab-android/assets/125425881/3123dfa8-3d2b-444f-811c-2c72d499f6e7)
As one can see, the plot is now fixed.

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.