### PR TITLE
feat: added dedicated horizontal orientation layouts for the Wave Generator screen

### DIFF
--- a/app/src/main/res/layout-land/activity_wave_generator.xml
+++ b/app/src/main/res/layout-land/activity_wave_generator.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="5dp">
+
+        <include
+            layout="@layout/wave_generator_preview"
+            android:layout_width="@dimen/dimen_zero_dp"
+            android:layout_height="@dimen/dimen_zero_dp"
+            app:layout_constraintBottom_toTopOf="@+id/main_guideline1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <include
+            layout="@layout/wave_generator_wave_controls"
+            android:layout_width="@dimen/dimen_zero_dp"
+            android:layout_height="@dimen/dimen_zero_dp"
+            app:layout_constraintBottom_toTopOf="@+id/main_guideline2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/main_guideline1" />
+
+        <include
+            android:id="@+id/wave_generator_main_controls"
+            layout="@layout/wave_generator_main_controls"
+            android:layout_width="@dimen/dimen_zero_dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/main_guideline2" />
+
+        <include
+            layout="@layout/wave_generator_analog_mode_layout"
+            android:layout_width="@dimen/dimen_zero_dp"
+            android:layout_height="@dimen/dimen_zero_dp"
+            android:visibility="visible"
+            app:layout_constraintBottom_toTopOf="@id/main_guideline3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/wave_generator_main_controls" />
+
+        <include
+            layout="@layout/wave_generator_digital_mode_layout"
+            android:layout_width="@dimen/dimen_zero_dp"
+            android:layout_height="@dimen/dimen_zero_dp"
+            android:visibility="invisible"
+            app:layout_constraintBottom_toTopOf="@id/main_guideline3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/wave_generator_main_controls" />
+
+        <include
+            layout="@layout/wave_generator_seekbar"
+            android:layout_width="@dimen/dimen_zero_dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="@dimen/wave_seekbar_margin"
+            app:layout_constraintTop_toBottomOf="@id/main_guideline3" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/main_guideline1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.3" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/main_guideline2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.55" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/main_guideline3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.9" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout-land/wave_generator_wave_controls.xml
+++ b/app/src/main/res/layout-land/wave_generator_wave_controls.xml
@@ -22,7 +22,7 @@
             android:background="@drawable/rectangle_border" />
 
         <TextView
-            android:id="@+id/contol_title_text"
+            android:id="@+id/control_title_text"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
@@ -38,7 +38,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_below="@id/contol_title_text"
+            android:layout_below="@id/control_title_text"
             android:layout_marginLeft="@dimen/ctrl_inside_rl_padding"
             android:layout_marginRight="@dimen/ctrl_inside_rl_padding"
             android:layout_marginBottom="@dimen/ctrl_inside_rl_padding"
@@ -342,8 +342,8 @@
 
             <Button
                 android:id="@+id/pwm_btn_freq"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
+                android:layout_width="@dimen/dimen_zero_dp"
+                android:layout_height="@dimen/dimen_zero_dp"
                 android:layout_marginStart="@dimen/margin_btn"
                 android:layout_marginTop="@dimen/margin_btn"
                 android:background="@drawable/btn_back_rounded"

--- a/app/src/main/res/layout-land/wave_generator_wave_controls.xml
+++ b/app/src/main/res/layout-land/wave_generator_wave_controls.xml
@@ -1,0 +1,399 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <RelativeLayout
+        android:id="@+id/square_mode_controls"
+        android:layout_width="@dimen/length_0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:background="@color/white"
+        android:paddingLeft="@dimen/ctrl_inside_rl_padding"
+        android:paddingRight="@dimen/ctrl_inside_rl_padding"
+        android:paddingBottom="@dimen/ctrl_inside_rl_padding"
+        android:visibility="visible">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/back_margin_top"
+            android:background="@drawable/rectangle_border" />
+
+        <TextView
+            android:id="@+id/contol_title_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="@dimen/ctrl_title_text_margin"
+            android:background="@color/white"
+            android:paddingLeft="@dimen/ctrl_title_text_padding"
+            android:paddingRight="@dimen/ctrl_title_text_padding"
+            android:text="@string/text_analog"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_size_wavegen"
+            android:textStyle="bold" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/contol_title_text"
+            android:layout_marginLeft="@dimen/ctrl_inside_rl_padding"
+            android:layout_marginRight="@dimen/ctrl_inside_rl_padding"
+            android:layout_marginBottom="@dimen/ctrl_inside_rl_padding"
+            android:padding="@dimen/margin_btn">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.5" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline4_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.33" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline4_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.66" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline4_3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.83" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/guideline5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.5" />
+
+            <Button
+                android:id="@+id/ctrl_btn_wave1"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/wave1"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toTopOf="@id/guideline5"
+                app:layout_constraintEnd_toStartOf="@+id/guideline4"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/ctrl_btn_wave2"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:layout_marginEnd="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/wave2"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toTopOf="@id/guideline5"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/guideline4"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/ctrl_btn_freq"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_freq"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/guideline4_1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/guideline5" />
+
+            <Button
+                android:id="@+id/ctrl_btn_phase"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_phase"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/guideline4_2"
+                app:layout_constraintStart_toStartOf="@id/guideline4_1"
+                app:layout_constraintTop_toTopOf="@+id/guideline5" />
+
+            <ImageButton
+                android:id="@+id/ctrl_img_btn_sin"
+                android:layout_width="@dimen/dimen_zero_dp"
+                android:layout_height="@dimen/dimen_zero_dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:layout_marginEnd="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded"
+                android:src="@drawable/ic_sin"
+                android:stateListAnimator="@animator/selector_animator"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/guideline4_3"
+                app:layout_constraintStart_toStartOf="@id/guideline4_2"
+                app:layout_constraintTop_toTopOf="@+id/guideline5" />
+
+            <ImageButton
+                android:id="@+id/ctrl_img_btn_tri"
+                android:layout_width="@dimen/dimen_zero_dp"
+                android:layout_height="@dimen/dimen_zero_dp"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:layout_marginEnd="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:src="@drawable/ic_triangular"
+                android:stateListAnimator="@animator/selector_animator"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@id/guideline4_3"
+                app:layout_constraintTop_toTopOf="@+id/guideline5" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </RelativeLayout>
+
+    <RelativeLayout
+        android:id="@+id/pwm_mode_controls"
+        android:layout_width="@dimen/length_0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:background="@color/white"
+        android:paddingLeft="@dimen/ctrl_inside_rl_padding"
+        android:paddingRight="@dimen/ctrl_inside_rl_padding"
+        android:paddingBottom="@dimen/ctrl_inside_rl_padding"
+        android:visibility="gone">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="@dimen/back_margin_top"
+            android:background="@drawable/rectangle_border" />
+
+        <TextView
+            android:id="@+id/control_title_pwm"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:layout_marginTop="@dimen/ctrl_title_text_margin"
+            android:background="@color/white"
+            android:paddingLeft="@dimen/ctrl_title_text_padding"
+            android:paddingRight="@dimen/ctrl_title_text_padding"
+            android:text="@string/text_digital"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_size_wavegen"
+            android:textStyle="bold" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@id/control_title_pwm"
+            android:layout_marginLeft="@dimen/ctrl_inside_rl_padding"
+            android:layout_marginRight="@dimen/ctrl_inside_rl_padding"
+            android:layout_marginBottom="@dimen/ctrl_inside_rl_padding"
+            android:padding="@dimen/margin_btn">
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/cr_guideline2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.25" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/cr_guideline14"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.5" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/cr_guideline15"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.5" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/cr_guideline3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.75" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/cr_guideline3_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.33" />
+
+            <androidx.constraintlayout.widget.Guideline
+                android:id="@+id/cr_guideline3_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintGuide_begin="@dimen/constraint_guide_begin"
+                app:layout_constraintGuide_percent="0.66" />
+
+            <Button
+                android:id="@+id/pwm_btn_sq1"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_sq1"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toTopOf="@+id/cr_guideline14"
+                app:layout_constraintEnd_toStartOf="@+id/cr_guideline2"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/pwm_btn_sq2"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_sq2"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toTopOf="@+id/cr_guideline14"
+                app:layout_constraintEnd_toStartOf="@+id/cr_guideline15"
+                app:layout_constraintStart_toStartOf="@+id/cr_guideline2"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/pwm_btn_sq3"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_sq3"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toTopOf="@+id/cr_guideline14"
+                app:layout_constraintEnd_toStartOf="@+id/cr_guideline3"
+                app:layout_constraintStart_toStartOf="@+id/cr_guideline15"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Button
+                android:id="@+id/pwm_btn_sq4"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:layout_marginEnd="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_sq4"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toTopOf="@+id/cr_guideline14"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/cr_guideline3"
+                app:layout_constraintTop_toTopOf="parent" />
+
+
+            <Button
+                android:id="@+id/pwm_btn_freq"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_freq"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/cr_guideline3_1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/cr_guideline14" />
+
+            <Button
+                android:id="@+id/pwm_btn_duty"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:layout_marginEnd="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_duty"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/cr_guideline3_2"
+                app:layout_constraintTop_toTopOf="@+id/cr_guideline14" />
+
+            <Button
+                android:id="@+id/pwm_btn_phase"
+                android:layout_width="@dimen/length_0dp"
+                android:layout_height="@dimen/length_0dp"
+                android:layout_marginStart="@dimen/margin_btn"
+                android:layout_marginTop="@dimen/margin_btn"
+                android:background="@drawable/btn_back_rounded_light"
+                android:stateListAnimator="@animator/selector_animator"
+                android:text="@string/text_phase"
+                android:textAllCaps="false"
+                android:textColor="@color/white"
+                android:textSize="@dimen/text_size_wavegen"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/cr_guideline3_2"
+                app:layout_constraintStart_toStartOf="@id/cr_guideline3_1"
+                app:layout_constraintTop_toTopOf="@+id/cr_guideline14" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </RelativeLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/wave_generator_preview.xml
+++ b/app/src/main/res/layout/wave_generator_preview.xml
@@ -1,13 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/preview_layout"
-    android:layout_width="@dimen/dimen_zero_dp"
-    android:layout_height="@dimen/dimen_zero_dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@color/black">
 
     <com.github.mikephil.charting.charts.LineChart
         android:id="@+id/chart_preview"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="#000" />
-</LinearLayout>
+        android:layout_width="@dimen/dimen_zero_dp"
+        android:layout_height="@dimen/dimen_zero_dp"
+        android:background="#000"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixes #2432 
Adds dedicated horizontal orientation layouts for the Wave Generator screen, to make it more user-friendly and usable in the horizontal orientation as well, using ScrollViews.

## Changes/Additions
- app/src/main/res/layout-land/activity_wave_generator.xml
- app/src/main/res/layout-land/wave_generator_wave_controls.xml
- app/src/main/res/layout/wave_generator_preview.xml

## Screenshots / Recordings  
A recording of the Wave Generator screen in the horizontal orientation:-

https://github.com/fossasia/pslab-android/assets/125425881/eb37f52b-7226-473d-a5f9-68a410a7a7f0

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.