### PR TITLE
fix: fixes the cutting on the waveform output of the In-Built-MIC

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -115,7 +115,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
     public boolean isCH2Selected;
     public boolean isCH3Selected;
     public boolean isMICSelected;
-    public boolean isInBuiltMicSelected;
+    public static boolean isInBuiltMicSelected;
     public boolean isAudioInputSelected;
     public boolean isTriggerSelected;
     public boolean isFourierTransformSelected;

--- a/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
+++ b/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
@@ -54,99 +54,182 @@ public class TimebaseTriggerFragment extends Fragment {
             textViewTimeBase.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
         }
 
-        seekBarTimebase.setMax(8);
-        seekBarTimebase.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
-            @Override
-            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                //samples are in the power of 2 so that sinefit can be applied
-                switch (progress) {
-                    case 0:
-                        textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 875;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(875);
-                        ((OscilloscopeActivity) getActivity()).timebase = 875;
-                        ((OscilloscopeActivity) getActivity()).samples = 512;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 2;
-                        break;
-                    case 1:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 1;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
-                        ((OscilloscopeActivity) getActivity()).timebase = 1000;
-                        ((OscilloscopeActivity) getActivity()).samples = 512;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 2;
-                        break;
-                    case 2:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 2;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
-                        ((OscilloscopeActivity) getActivity()).timebase = 2000;
-                        ((OscilloscopeActivity) getActivity()).samples = 512;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 4;
-                        break;
-                    case 3:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 4;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
-                        ((OscilloscopeActivity) getActivity()).timebase = 4000;
-                        ((OscilloscopeActivity) getActivity()).samples = 512;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 8;
-                        break;
-                    case 4:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 8;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
-                        ((OscilloscopeActivity) getActivity()).timebase = 8000;
-                        ((OscilloscopeActivity) getActivity()).samples = 1024;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 8;
-                        break;
-                    case 5:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 25.60;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
-                        ((OscilloscopeActivity) getActivity()).timebase = 25600;
-                        ((OscilloscopeActivity) getActivity()).samples = 1024;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 25;
-                        break;
-                    case 6:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
-                        ((OscilloscopeActivity) getActivity()).timebase = 38400;
-                        ((OscilloscopeActivity) getActivity()).timebase = 1024;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 38;
-                        break;
-                    case 7:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 51.20));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 51.20;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(51.20);
-                        ((OscilloscopeActivity) getActivity()).timebase = 51200;
-                        ((OscilloscopeActivity) getActivity()).samples = 1024;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 50;
-                        break;
-                    case 8:
-                        textViewTimeBase.setText(getString(R.string.timebase_milisec, 102.40));
-                        ((OscilloscopeActivity) getActivity()).xAxisScale = 102.40;
-                        ((OscilloscopeActivity) getActivity()).setXAxisScale(102.40);
-                        ((OscilloscopeActivity) getActivity()).timebase = 102400;
-                        ((OscilloscopeActivity) getActivity()).samples = 1024;
-                        ((OscilloscopeActivity) getActivity()).timeGap = 100;
-                        break;
+        if(OscilloscopeActivity.isInBuiltMicSelected){
+            seekBarTimebase.setMax(6);
+            seekBarTimebase.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                    //samples are in the power of 2 so that sinefit can be applied
+                    switch (progress) {
+                        case 0:
+                            textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 875;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(875);
+                            ((OscilloscopeActivity) getActivity()).timebase = 875;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            break;
+                        case 1:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 1;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
+                            ((OscilloscopeActivity) getActivity()).timebase = 1000;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            break;
+                        case 2:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 2;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
+                            ((OscilloscopeActivity) getActivity()).timebase = 2000;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 4;
+                            break;
+                        case 3:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 4;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
+                            ((OscilloscopeActivity) getActivity()).timebase = 4000;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            break;
+                        case 4:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 8;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
+                            ((OscilloscopeActivity) getActivity()).timebase = 8000;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            break;
+                        case 5:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 25.60;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
+                            ((OscilloscopeActivity) getActivity()).timebase = 25600;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 25;
+                            break;
+                        case 6:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
+                            ((OscilloscopeActivity) getActivity()).timebase = 38400;
+                            ((OscilloscopeActivity) getActivity()).timebase = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 38;
+                            break;
+                        default:
+                            break;
+                    }
                 }
-            }
 
-            @Override
-            public void onStartTrackingTouch(SeekBar seekBar) {
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {
 
-            }
+                }
 
-            @Override
-            public void onStopTrackingTouch(SeekBar seekBar) {
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {
 
-            }
-        });
-        seekBarTimebase.setProgress(0);
+                }
+            });
+            seekBarTimebase.setProgress(0);
+        }
+        else {
+            seekBarTimebase.setMax(8);
+            seekBarTimebase.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+                @Override
+                public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                    //samples are in the power of 2 so that sinefit can be applied
+                    switch (progress) {
+                        case 0:
+                            textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 875;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(875);
+                            ((OscilloscopeActivity) getActivity()).timebase = 875;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            break;
+                        case 1:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 1;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
+                            ((OscilloscopeActivity) getActivity()).timebase = 1000;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            break;
+                        case 2:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 2;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
+                            ((OscilloscopeActivity) getActivity()).timebase = 2000;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 4;
+                            break;
+                        case 3:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 4;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
+                            ((OscilloscopeActivity) getActivity()).timebase = 4000;
+                            ((OscilloscopeActivity) getActivity()).samples = 512;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            break;
+                        case 4:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 8;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
+                            ((OscilloscopeActivity) getActivity()).timebase = 8000;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            break;
+                        case 5:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 25.60;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
+                            ((OscilloscopeActivity) getActivity()).timebase = 25600;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 25;
+                            break;
+                        case 6:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
+                            ((OscilloscopeActivity) getActivity()).timebase = 38400;
+                            ((OscilloscopeActivity) getActivity()).timebase = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 38;
+                            break;
+                        case 7:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 51.20));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 51.20;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(51.20);
+                            ((OscilloscopeActivity) getActivity()).timebase = 51200;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 50;
+                            break;
+                        case 8:
+                            textViewTimeBase.setText(getString(R.string.timebase_milisec, 102.40));
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 102.40;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(102.40);
+                            ((OscilloscopeActivity) getActivity()).timebase = 102400;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
+                            ((OscilloscopeActivity) getActivity()).timeGap = 100;
+                            break;
+                        default:
+                            break;
+                    }
+                }
 
+                @Override
+                public void onStartTrackingTouch(SeekBar seekBar) {
+
+                }
+
+                @Override
+                public void onStopTrackingTouch(SeekBar seekBar) {
+
+                }
+            });
+            seekBarTimebase.setProgress(0);
+        }
         seekBarTrigger.setters(-16.5, 16.5);
         seekBarTrigger.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override


### PR DESCRIPTION
Fixes #2436
Fixes the cutting of the waveform output of the In-Built-MIC by limiting the maximum value of the timebase scale to 38.4ms whenever the In-Built-MIC is selected.

## Changes 
- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
- app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java

## Screenshots / Recordings  
![Screenshot_20240528_140425](https://github.com/fossasia/pslab-android/assets/125425881/b8f2ec1f-94af-4faf-b799-e10d79bf8b10)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.