### PR TITLE
fix: fixed the background of buttons when the phase button was selected for digital waves

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -391,7 +391,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 setSeekBar(seekBar);
                 pwmBtnFreq.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
-                pwmBtnDuty.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
+                pwmBtnDuty.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
             }
         });
 


### PR DESCRIPTION
Fixes #2443
The background of the duty button was wrongly configured to show as selected whenever the phase button was selected.
## Changes 
- app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java

## Screenshots / Recordings  
![Screenshot_20240529_152739](https://github.com/fossasia/pslab-android/assets/125425881/a414695d-e0fa-4d92-8fa9-920e311858df)
As one can see, the background of the button is now fixed.

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.