### PR TITLE
fix: fixed the layout of the oscilloscope screen

### DIFF
--- a/app/src/main/res/layout/fragment_channel_parameters.xml
+++ b/app/src/main/res/layout/fragment_channel_parameters.xml
@@ -32,11 +32,10 @@
         android:id="@+id/checkBox_ch3_cp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/osc_cb_margin"
         android:layout_marginTop="@dimen/osc_cb_margin"
+        android:layout_marginEnd="@dimen/osc_cb_margin"
         android:textStyle="normal|bold"
-        app:layout_constraintEnd_toStartOf="@id/mic_radio_group"
-        app:layout_constraintStart_toEndOf="@id/spinner_channel_select_cp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -104,17 +103,17 @@
         android:id="@+id/mic_radio_group"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/osc_cb_margin"
         android:layout_marginEnd="@dimen/osc_cb_margin"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:layout_marginBottom="@dimen/osc_cb_margin"
+        android:orientation="horizontal"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <CheckBox
             android:id="@+id/built_in_mic_cb"
             style="@style/Base.Widget.AppCompat.CompoundButton.RadioButton"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_marginEnd="@dimen/osc_tv_margin"
             android:text="@string/built_in_mic_option"
             android:textStyle="normal|bold"
@@ -125,8 +124,7 @@
             android:id="@+id/pslab_mic_cb"
             style="@style/Base.Widget.AppCompat.CompoundButton.RadioButton"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/osc_cb_margin"
+            android:layout_height="match_parent"
             android:text="@string/pslab_mic_option"
             android:textStyle="normal|bold"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Fixes #2445 
Fixes the layout of the Channel Parameters Fragment in the Oscilloscope Activity to make it usable and adaptable on a large number of screen sizes.
## Changes 
- app/src/main/res/layout/fragment_channel_parameters.xml
## Screenshots / Recordings  
In order to achieve adaptability to a number of screen sizes, I propose a different arrangement of elements in the Channel Parameters Fragment. Following are the screenshots on two different device sizes (including the one on which the issue was found out):

![Screenshot_20240530_111146](https://github.com/fossasia/pslab-android/assets/125425881/2cb5cb7e-77f5-45bd-a402-6a3809dc3733)
![Screenshot_20240530_111305](https://github.com/fossasia/pslab-android/assets/125425881/325762aa-d008-469a-a635-bc0b0b25cdee)
![Screenshot_1717047654](https://github.com/fossasia/pslab-android/assets/125425881/915b4cd0-352b-4d29-8372-d97389ec9fc4)

As one can see, I have adjusted the position of the audio input radio buttons.
Please share your comments on this new layout @mariobehling @CloudyPadmal @marcnause.
Edit:-
Added screenshots of the new layout after testing by @marcnause.

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.