### PR TITLE
fix: made the phase buttons invisible for Analog Wave 1 and Digital Wave SQR1

### DIFF
--- a/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
+++ b/app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java
@@ -687,6 +687,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnCtrlWave2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
 
                 btnCtrlPhase.setEnabled(false);  //disable phase for wave
+                btnCtrlPhase.setVisibility(View.INVISIBLE);
                 wavePhaseValue.setText("--");
 
                 selectWaveform(WaveGeneratorConstants.wave.get(waveBtnActive).get(WaveConst.WAVETYPE));
@@ -703,6 +704,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnCtrlWave1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
 
                 btnCtrlPhase.setEnabled(true); // enable phase for wave2
+                btnCtrlPhase.setVisibility(View.VISIBLE);
 
                 selectWaveform(WaveGeneratorConstants.wave.get(waveBtnActive).get(WaveConst.WAVETYPE));
 
@@ -718,6 +720,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setEnabled(false);  //phase disabled for sq1
+                pwmBtnPhase.setVisibility(View.INVISIBLE);
                 pwmPhaseValue.setText("--");
                 fetchPropertyValue(pwmBtnActive, WaveConst.FREQUENCY, getString(R.string.unit_hz), pwmFreqValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
@@ -731,6 +734,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setEnabled(true);
+                pwmBtnPhase.setVisibility(View.VISIBLE);
                 fetchPropertyValue(pwmBtnActive, WaveConst.PHASE, getString(R.string.deg_text), pwmPhaseValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
                 break;
@@ -743,6 +747,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
                 btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 pwmBtnPhase.setEnabled(true);
+                pwmBtnPhase.setVisibility(View.VISIBLE);
                 fetchPropertyValue(pwmBtnActive, WaveConst.PHASE, getString(R.string.deg_text), pwmPhaseValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
                 break;
@@ -755,6 +760,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnPwmSq3.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 btnPwmSq4.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
                 pwmBtnPhase.setEnabled(true);
+                pwmBtnPhase.setVisibility(View.VISIBLE);
                 fetchPropertyValue(pwmBtnActive, WaveConst.PHASE, getString(R.string.deg_text), pwmPhaseValue);
                 fetchPropertyValue(pwmBtnActive, WaveConst.DUTY, getString(R.string.unit_percent), pwmDutyValue);
                 break;
@@ -764,6 +770,7 @@ public class WaveGeneratorActivity extends GuideActivity {
                 btnCtrlWave1.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded, null));
                 btnCtrlWave2.setBackground(ResourcesCompat.getDrawable(getResources(), R.drawable.btn_back_rounded_light, null));
                 btnCtrlPhase.setEnabled(false);  //disable phase for wave
+                pwmBtnPhase.setVisibility(View.INVISIBLE);
                 wavePhaseValue.setText("--");
                 selectWaveform(WaveGeneratorConstants.wave.get(waveBtnActive).get(WaveConst.WAVETYPE));
                 fetchPropertyValue(waveBtnActive, WaveConst.FREQUENCY, getString(R.string.deg_text), waveFreqValue);


### PR DESCRIPTION
Fixes #2444 
Toggles the visibility of the phase buttons to set them to _INVISIBLE_ for Analog Wave 1 and Digital Wave SQR1 as a phase change for these waves isn't supported by our hardware.

## Changes 
- app/src/main/java/io/pslab/activity/WaveGeneratorActivity.java

## Screenshots / Recordings  
Here are screenshots showing the screen when Analog Wave 1 and Digital Wave SQR1 are selected.

![Screenshot_20240531_142450](https://github.com/fossasia/pslab-android/assets/125425881/def0ba3b-97a8-4275-a076-2d8cd9e13e0c)

![Screenshot_20240531_142530](https://github.com/fossasia/pslab-android/assets/125425881/24d37ea0-3a11-44f1-9ed3-a169bbb89aad)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.