### PR TITLE
feat: added Auto-Scale

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1174,7 +1174,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         double yRange;
         double yPadding;
         double[] voltage = new double[512];
-        for (int i = 0; i < dataEntries.size(); i++) {
+        for (int i = 0; i < dataParamsChannels.length; i++) {
             if (!Objects.equals(dataParamsChannels[i], CHANNEL.MIC.toString())) {
                 ArrayList<Entry> entryArrayList = dataEntries.get(i);
                 for (int j = 0; j < entryArrayList.size(); j++) {

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1223,6 +1223,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
             xAxisScale = maxTimebase;
         }
         yAxisScale = maxY + yPadding;
+        samples = 512;
+        timeGap = (xAxisScale * 1000.0) / samples;
     }
 
     public class XYPlotTask extends AsyncTask<String, Void, Void> {

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1175,7 +1175,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         double yPadding;
         double[] voltage = new double[512];
         for (int i = 0; i < dataParamsChannels.length; i++) {
-            if (!Objects.equals(dataParamsChannels[i], CHANNEL.MIC.toString())) {
+            if (dataEntries.size() > i) {
                 ArrayList<Entry> entryArrayList = dataEntries.get(i);
                 for (int j = 0; j < entryArrayList.size(); j++) {
                     Entry entry = entryArrayList.get(j);
@@ -1189,26 +1189,12 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                         minY = entry.getY();
                     }
                 }
-                double frequency = analyticsClass.findFrequency(voltage, timeGap / 1000000.0);
-                double period = (1 / frequency) * 1000.0;
-                if (period > maxPeriod) {
-                    maxPeriod = period;
+                final double frequency;
+                if (Objects.equals(dataParamsChannels[i], CHANNEL.MIC.toString())) {
+                    frequency = analyticsClass.findFrequency(voltage, ((double) 1 / SAMPLING_RATE));
+                } else {
+                    frequency = analyticsClass.findFrequency(voltage, timeGap / 1000000.0);
                 }
-            } else {
-                ArrayList<Entry> entryArrayList = dataEntries.get(i);
-                for (int j = 0; j < entryArrayList.size(); j++) {
-                    Entry entry = entryArrayList.get(j);
-                    if (j < voltage.length - 1) {
-                        voltage[j] = entry.getY();
-                    }
-                    if (entry.getY() > maxY) {
-                        maxY = entry.getY();
-                    }
-                    if (entry.getY() < minY) {
-                        minY = entry.getY();
-                    }
-                }
-                double frequency = analyticsClass.findFrequency(voltage, ((double) 1 / SAMPLING_RATE));
                 double period = (1 / frequency) * 1000.0;
                 if (period > maxPeriod) {
                     maxPeriod = period;

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1224,7 +1224,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         }
         yAxisScale = maxY + yPadding;
         samples = 512;
-        timeGap = (xAxisScale * 1000.0) / samples;
+        timeGap = (2 * xAxisScale * 1000.0) / samples;
     }
 
     public class XYPlotTask extends AsyncTask<String, Void, Void> {

--- a/app/src/main/java/io/pslab/communication/AnalyticsClass.java
+++ b/app/src/main/java/io/pslab/communication/AnalyticsClass.java
@@ -10,7 +10,6 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.transform.DftNormalization;
 import org.apache.commons.math3.transform.FastFourierTransformer;
 import org.apache.commons.math3.transform.TransformType;
-
 import io.pslab.filters.BandstopFilter;
 import io.pslab.filters.Lfilter;
 
@@ -23,8 +22,6 @@ import static org.apache.commons.lang3.math.NumberUtils.max;
 import static org.apache.commons.math3.util.FastMath.abs;
 import static org.apache.commons.math3.util.FastMath.exp;
 import static org.apache.commons.math3.util.FastMath.sin;
-
-import com.github.mikephil.charting.data.Entry;
 
 /**
  * Created by akarshan on 5/13/17.
@@ -334,34 +331,6 @@ public class AnalyticsClass {
             }
         }
         return frequency[index];
-    }
-
-    public double getPeriod(ArrayList<Entry> entryArrayList) {
-        ArrayList<Double> peaks = new ArrayList<>();
-
-        boolean increasing = false;
-        double prevY = entryArrayList.get(0).getY();
-        for (int i = 1; i < entryArrayList.size(); i++) {
-            double currY = entryArrayList.get(i).getY();
-            if (currY > prevY && !increasing) {
-                peaks.add((double) entryArrayList.get(i).getX());
-                increasing = true;
-            } else if (currY < prevY && increasing) {
-                increasing = false;
-            }
-            prevY = currY;
-        }
-        ArrayList<Double> periods = new ArrayList<>();
-        for (int i = 1; i < peaks.size(); i++) {
-            double period = peaks.get(i) - peaks.get(i - 1);
-            periods.add(period);
-        }
-
-        double totalPeriod = 0;
-        for (double period : periods) {
-            totalPeriod += period;
-        }
-        return totalPeriod / periods.size();
     }
 
     public ArrayList<double[]> amplitudeSpectrum(double[] voltage, int samplingInterval, int nHarmonics) {

--- a/app/src/main/java/io/pslab/communication/AnalyticsClass.java
+++ b/app/src/main/java/io/pslab/communication/AnalyticsClass.java
@@ -10,6 +10,7 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.transform.DftNormalization;
 import org.apache.commons.math3.transform.FastFourierTransformer;
 import org.apache.commons.math3.transform.TransformType;
+
 import io.pslab.filters.BandstopFilter;
 import io.pslab.filters.Lfilter;
 
@@ -22,6 +23,8 @@ import static org.apache.commons.lang3.math.NumberUtils.max;
 import static org.apache.commons.math3.util.FastMath.abs;
 import static org.apache.commons.math3.util.FastMath.exp;
 import static org.apache.commons.math3.util.FastMath.sin;
+
+import com.github.mikephil.charting.data.Entry;
 
 /**
  * Created by akarshan on 5/13/17.
@@ -331,6 +334,34 @@ public class AnalyticsClass {
             }
         }
         return frequency[index];
+    }
+
+    public double getPeriod(ArrayList<Entry> entryArrayList) {
+        ArrayList<Double> peaks = new ArrayList<>();
+
+        boolean increasing = false;
+        double prevY = entryArrayList.get(0).getY();
+        for (int i = 1; i < entryArrayList.size(); i++) {
+            double currY = entryArrayList.get(i).getY();
+            if (currY > prevY && !increasing) {
+                peaks.add((double) entryArrayList.get(i).getX());
+                increasing = true;
+            } else if (currY < prevY && increasing) {
+                increasing = false;
+            }
+            prevY = currY;
+        }
+        ArrayList<Double> periods = new ArrayList<>();
+        for (int i = 1; i < peaks.size(); i++) {
+            double period = peaks.get(i) - peaks.get(i - 1);
+            periods.add(period);
+        }
+
+        double totalPeriod = 0;
+        for (double period : periods) {
+            totalPeriod += period;
+        }
+        return totalPeriod / periods.size();
     }
 
     public ArrayList<double[]> amplitudeSpectrum(double[] voltage, int samplingInterval, int nHarmonics) {

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -245,7 +245,8 @@ public class ChannelParametersFragment extends Fragment {
                 ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
                 ((OscilloscopeActivity) getActivity()).isMICSelected = !isChecked;
                 if (isChecked) {
-                    if(pslabMicCheckBox.isChecked()) {
+                    ((OscilloscopeActivity) getActivity()).maxTimebase = 38.4f;
+                    if (pslabMicCheckBox.isChecked()) {
                         pslabMicCheckBox.setChecked(false);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
                     }
@@ -253,6 +254,8 @@ public class ChannelParametersFragment extends Fragment {
                         requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;
                     }
+                } else {
+                    ((OscilloscopeActivity) getActivity()).maxTimebase = 102.4f;
                 }
             }
         });
@@ -264,7 +267,7 @@ public class ChannelParametersFragment extends Fragment {
                 ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
                 ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = !isChecked;
                 if (isChecked) {
-                    if(builtInMicCheckBox.isChecked()) {
+                    if (builtInMicCheckBox.isChecked()) {
                         builtInMicCheckBox.setChecked(false);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
                     }
@@ -285,7 +288,7 @@ public class ChannelParametersFragment extends Fragment {
                 ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = true;
             } else {
                 CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
-                        "This feature won't work.",null,null, Snackbar.LENGTH_SHORT);
+                        "This feature won't work.", null, null, Snackbar.LENGTH_SHORT);
                 if (builtInMicCheckBox.isChecked())
                     builtInMicCheckBox.toggle();
             }

--- a/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
+++ b/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
@@ -46,6 +46,7 @@ public class TimebaseTriggerFragment extends Fragment {
         textViewTrigger = v.findViewById(R.id.tv_trigger_values_tt);
         spinnerTriggerChannelSelect = v.findViewById(R.id.spinner_trigger_channel_tt);
         checkBoxTrigger = v.findViewById(R.id.checkbox_trigger_tt);
+        seekBarTimebase.setSaveEnabled(false);
 
         boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
 
@@ -54,7 +55,7 @@ public class TimebaseTriggerFragment extends Fragment {
             textViewTimeBase.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
         }
 
-        if(OscilloscopeActivity.isInBuiltMicSelected){
+        if (OscilloscopeActivity.isInBuiltMicSelected) {
             seekBarTimebase.setMax(6);
             seekBarTimebase.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
                 @Override
@@ -63,8 +64,8 @@ public class TimebaseTriggerFragment extends Fragment {
                     switch (progress) {
                         case 0:
                             textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 875;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(875);
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 0.875;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(0.875);
                             ((OscilloscopeActivity) getActivity()).timebase = 875;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = 2;
@@ -133,8 +134,7 @@ public class TimebaseTriggerFragment extends Fragment {
                 }
             });
             seekBarTimebase.setProgress(0);
-        }
-        else {
+        } else {
             seekBarTimebase.setMax(8);
             seekBarTimebase.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
                 @Override
@@ -143,8 +143,8 @@ public class TimebaseTriggerFragment extends Fragment {
                     switch (progress) {
                         case 0:
                             textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 875;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(875);
+                            ((OscilloscopeActivity) getActivity()).xAxisScale = 0.875;
+                            ((OscilloscopeActivity) getActivity()).setXAxisScale(0.875);
                             ((OscilloscopeActivity) getActivity()).timebase = 875;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = 2;

--- a/app/src/main/res/menu/activity_landscape_menu.xml
+++ b/app/src/main/res/menu/activity_landscape_menu.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/auto_scale"
+        android:iconTint="@color/white"
+        android:title="@string/auto_scale"
+        app:showAsAction="always" />
+    <item
         android:id="@+id/run_stop"
         android:iconTint="@color/white"
         android:title="@string/control_stop"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1056,6 +1056,7 @@
     <string name="limit_average">Average</string>
     <string name="no_playback_data">No data to display</string>
     <string name="privacy_policy">Privacy Policy</string>
+    <string name="auto_scale">Auto</string>
     <string name="control_stop">Stop</string>
     <string name="control_run">Run</string>
 </resources>


### PR DESCRIPTION
Resolves #2459 
Adds the Auto-Scale feature to the Oscilloscope screen.

**Auto-Scale:**
1. This allows adjustment of the X-axis and Y-axis scale according to the acquired waveform in order to properly display it on the oscilloscope display.
2. This feature would use algorithms to identify the present waveforms, measure their amplitudes and periods, and then scale the axes to properly display them.

The UI for the feature is implemented as a **button** in the **Toolbar** which can be used to scale the axes according to the inputs from the channels.

The feature analyzes the inputs from **all the active channels** and sets the scale of the axes to an appropriate value to properly display all the present waveforms. 

## Changes 
- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
- app/src/main/res/menu/activity_landscape_menu.xml
- app/src/main/res/values/strings.xml

## Screenshots / Recordings  

https://github.com/fossasia/pslab-android/assets/125425881/e35af1d4-b933-4f93-990b-a7d9a5d522a1

**Note:-**
Although this feature is developed for all the channels and can also be used if multiple channels are active at once, I have tested this only with one channel active, the In-Built-MIC input **only**.
@marcnause Could you please help me with testing this feature using all the other channels as well as when more than one channel is active (e.g.;- _CH1_ with _CH2_, all three active, etc.).

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.