### PR TITLE
fix: fixed the graph to clear whenever no channel is active

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -511,6 +511,10 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                             audioJack.release();
                             audioJack = null;
                         }
+
+                        if (!(((isCH1Selected || isCH2Selected || isCH3Selected || isMICSelected) && scienceLab.isConnected()) || isInBuiltMicSelected)) {
+                            mChart.clearValues();
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -341,6 +341,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
 
         final Runnable runnable = new Runnable() {
 
+            private final List<String> channels = new ArrayList<>();
+
             @Override
             public void run() {
                 //Thread to check which checkbox is enabled
@@ -350,154 +352,35 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                             audioJack = new AudioJack("input");
                         }
 
-                        if (scienceLab.isConnected() && isCH1Selected && !isCH2Selected && !isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH1.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH2Selected && !isCH1Selected && !isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH2.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH3Selected && !isCH1Selected && !isCH2Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH3.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (isAudioInputSelected && !isCH1Selected && !isCH2Selected && !isCH3Selected && !isXYPlotSelected) {
-                            if (isInBuiltMicSelected || (isMICSelected && scienceLab.isConnected())) {
-                                captureTask = new CaptureTask();
-                                captureTask.execute(CHANNEL.MIC.toString());
-                                synchronized (lock) {
-                                    try {
-                                        lock.wait();
-                                    } catch (InterruptedException e) {
-                                        e.printStackTrace();
-                                    }
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH1Selected && isCH2Selected && !isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH1.toString(), CHANNEL.CH2.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH1Selected && !isCH2Selected && isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH1.toString(), CHANNEL.CH3.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isAudioInputSelected && isCH1Selected && !isCH3Selected && !isCH2Selected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH1.toString(), CHANNEL.MIC.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH2Selected && isCH3Selected && !isCH1Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH2.toString(), CHANNEL.CH3.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH2Selected && isAudioInputSelected && !isCH3Selected && !isCH1Selected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH2.toString(), CHANNEL.MIC.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH3Selected && isAudioInputSelected && !isCH2Selected && !isCH1Selected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH3.toString(), CHANNEL.MIC.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-
-                        if (scienceLab.isConnected() && isCH1Selected && isCH2Selected && isCH3Selected && !isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH1.toString(), CHANNEL.CH2.toString(), CHANNEL.CH3.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
-                        if (scienceLab.isConnected() && isCH1Selected && isCH2Selected && isCH3Selected && isAudioInputSelected && !isXYPlotSelected) {
-                            captureTask = new CaptureTask();
-                            captureTask.execute(CHANNEL.CH1.toString(), CHANNEL.CH2.toString(), CHANNEL.CH3.toString(), CHANNEL.MIC.toString());
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
-                                }
-                            }
-                        }
+                        channels.clear();
 
                         if (scienceLab.isConnected() && isXYPlotSelected) {
                             xyPlotTask = new XYPlotTask();
                             xyPlotTask.execute(xyPlotAxis1, xyPlotAxis2);
+                            synchronized (lock) {
+                                try {
+                                    lock.wait();
+                                } catch (InterruptedException e) {
+                                    e.printStackTrace();
+                                }
+                            }
+                        } else {
+                            if (scienceLab.isConnected()) {
+                                if (isCH1Selected) {
+                                    channels.add(CHANNEL.CH1.toString());
+                                }
+                                if (isCH2Selected) {
+                                    channels.add(CHANNEL.CH2.toString());
+                                }
+                                if (isCH3Selected) {
+                                    channels.add(CHANNEL.CH3.toString());
+                                }
+                            }
+                            if (isAudioInputSelected && isInBuiltMicSelected || (scienceLab.isConnected() && isMICSelected)) {
+                                channels.add(CHANNEL.MIC.toString());
+                            }
+                            captureTask = new CaptureTask();
+                            captureTask.execute(channels.toArray(new String[0]));
                             synchronized (lock) {
                                 try {
                                     lock.wait();

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -512,8 +512,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                             audioJack = null;
                         }
 
-                        if (!(((isCH1Selected || isCH2Selected || isCH3Selected || isMICSelected) && scienceLab.isConnected()) || isInBuiltMicSelected)) {
-                            mChart.clearValues();
+                        if (!(((isCH1Selected || isCH2Selected || isCH3Selected || isMICSelected) && scienceLab.isConnected()) || isInBuiltMicSelected) && !mChart.isEmpty()) {
+                            mChart.post(() -> mChart.clearValues());
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #2460 
Clears the graph whenever all the channels are toggled OFF.
## Changes 
- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java

## Screenshots / Recordings  

https://github.com/fossasia/pslab-android/assets/125425881/4db79832-fe22-410d-b7f9-89b0e4ff6727

**Note:-**
Again, this is tested only with the In-Built MIC as shown.
@marcnause Could you please test this with all the other channels and when more than one channels are active as well ?

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the issue where the graph was not clearing when no channels were active. It also refactors the channel selection logic to improve code readability and maintainability.

- **Bug Fixes**:
    - Cleared the graph whenever all channels are toggled off to prevent displaying outdated data.
- **Enhancements**:
    - Refactored the channel selection logic to use a list for better readability and maintainability.

<!-- Generated by sourcery-ai[bot]: end summary -->