### PR TITLE
fix: fixes crash in PSLabPinLayoutFragment by allocating larger heap size

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         android:roundIcon="@drawable/app_icon_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:largeHeap="true"
         tools:replace="android:icon,android:allowBackup">
         <uses-library
             android:name="org.apache.http.legacy"


### PR DESCRIPTION
Fixes #2461 
Fixes the java _OutOfMemoryError_ occuring in the _PSLabPinLayoutFragment_ by allocating a larger heap size for the application.
## Changes 
- app/src/main/AndroidManifest.xml

## Screenshots / Recordings  
N/A

@marcnause Could you please confirm if this error has been solved ?

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.