### PR TITLE
feat: added Position Controls

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1148,12 +1148,14 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
             dataParamsChannels = paramsChannels.clone();
 
             List<ILineDataSet> dataSets = new ArrayList<>();
-            for (int i = 0; i < Math.min(entries.size(), paramsChannels.length); i++) {
-                ArrayList<Entry> entryArrayList = entries.get(i);
-                for (int j = 0; j < entryArrayList.size(); j++) {
-                    Entry entry = entryArrayList.get(j);
-                    entry.setX((float) (entry.getX() - xOffsets.get(paramsChannels[i])));
-                    entry.setY((float) (entry.getY() + yOffsets.get(paramsChannels[i])));
+            if (!isFourierTransformSelected) {
+                for (int i = 0; i < Math.min(entries.size(), paramsChannels.length); i++) {
+                    ArrayList<Entry> entryArrayList = entries.get(i);
+                    for (int j = 0; j < entryArrayList.size(); j++) {
+                        Entry entry = entryArrayList.get(j);
+                        entry.setX((float) (entry.getX() - xOffsets.get(paramsChannels[i])));
+                        entry.setY((float) (entry.getY() + yOffsets.get(paramsChannels[i])));
+                    }
                 }
             }
             for (int i = 0; i < Math.min(entries.size(), paramsChannels.length); i++) {

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -134,6 +134,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
     public String curveFittingChannel2;
     public String xyPlotXAxisChannel;
     public String xyPlotYAxisChannel;
+    public HashMap<String, Double> xOffsets;
+    public HashMap<String, Double> yOffsets;
     public double trigger;
     public Plot2D graph;
     @BindView(R.id.layout_dock_os1)
@@ -268,6 +270,18 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         timebase = 875;
         samples = 512;
         timeGap = 2;
+
+        xOffsets = new HashMap<>();
+        xOffsets.put(CHANNEL.CH1.toString(), 0.0);
+        xOffsets.put(CHANNEL.CH2.toString(), 0.0);
+        xOffsets.put(CHANNEL.CH3.toString(), 0.0);
+        xOffsets.put(CHANNEL.MIC.toString(), 0.0);
+        yOffsets = new HashMap<>();
+        yOffsets.put(CHANNEL.CH1.toString(), 0.0);
+        yOffsets.put(CHANNEL.CH2.toString(), 0.0);
+        yOffsets.put(CHANNEL.CH3.toString(), 0.0);
+        yOffsets.put(CHANNEL.MIC.toString(), 0.0);
+
         sineFit = true;
         squareFit = false;
         isDataAnalysisFragSelected = false;
@@ -1134,6 +1148,14 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
             dataParamsChannels = paramsChannels.clone();
 
             List<ILineDataSet> dataSets = new ArrayList<>();
+            for (int i = 0; i < Math.min(entries.size(), paramsChannels.length); i++) {
+                ArrayList<Entry> entryArrayList = entries.get(i);
+                for (int j = 0; j < entryArrayList.size(); j++) {
+                    Entry entry = entryArrayList.get(j);
+                    entry.setX((float) (entry.getX() - xOffsets.get(paramsChannels[i])));
+                    entry.setY((float) (entry.getY() + yOffsets.get(paramsChannels[i])));
+                }
+            }
             for (int i = 0; i < Math.min(entries.size(), paramsChannels.length); i++) {
                 LineDataSet dataSet;
                 dataSet = new LineDataSet(entries.get(i), paramsChannels[i]);

--- a/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
@@ -1,6 +1,7 @@
 package io.pslab.fragment;
 
 import android.os.Bundle;
+
 import androidx.fragment.app.Fragment;
 
 import android.view.LayoutInflater;
@@ -29,13 +30,15 @@ public class DataAnalysisFragment extends Fragment {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        View v = inflater.inflate(R.layout.fragment_data_analysis, container, false);
+        View v = inflater.inflate(R.layout.fragment_data_analysis_main, container, false);
         String[] curveFits = {"Sine Fit", "Square Fit"};
         String[] channels = {"None", "CH1", "CH2", "CH3", "MIC"};
 
         spinnerCurveFit = v.findViewById(R.id.spinner_curve_fit_da);
         spinnerChannelSelect1 = v.findViewById(R.id.spinner_channel_select_da1);
         spinnerChannelSelect2 = v.findViewById(R.id.spinner_channel_select_da2);
+        Spinner spinnerChannelSelectHorizontalOffset = v.findViewById(R.id.spinner_channel_select_horizontal_offset);
+        Spinner spinnerChannelSelectVerticalOffset = v.findViewById(R.id.spinner_channel_select_vertical_offset);
         checkBoxFouierTransform = v.findViewById(R.id.checkBox_fourier_da);
         boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
         ArrayAdapter<String> curveFitAdapter;
@@ -55,10 +58,15 @@ public class DataAnalysisFragment extends Fragment {
         spinnerCurveFit.setAdapter(curveFitAdapter);
         spinnerChannelSelect1.setAdapter(adapter);
         spinnerChannelSelect2.setAdapter(adapter);
+        spinnerChannelSelectHorizontalOffset.setAdapter(adapter);
+        spinnerChannelSelectVerticalOffset.setAdapter(adapter);
 
         spinnerCurveFit.setSelection(curveFitAdapter.getPosition("Sine Fit"), true);
         spinnerChannelSelect1.setSelection(adapter.getPosition("None"), true);
         spinnerChannelSelect2.setSelection(adapter.getPosition("None"), true);
+        spinnerChannelSelectHorizontalOffset.setSelection(adapter.getPosition("None"), true);
+        spinnerChannelSelectVerticalOffset.setSelection(adapter.getPosition("None"), true);
+
         spinnerCurveFit.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {

--- a/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
@@ -132,7 +132,7 @@ public class DataAnalysisFragment extends Fragment {
 
             @Override
             public void onNothingSelected(AdapterView<?> adapterView) {
-
+                // Do nothing
             }
         });
 
@@ -146,7 +146,7 @@ public class DataAnalysisFragment extends Fragment {
 
             @Override
             public void onNothingSelected(AdapterView<?> adapterView) {
-
+                // Do nothing
             }
         });
 
@@ -164,12 +164,12 @@ public class DataAnalysisFragment extends Fragment {
 
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) {
-
+                // Do nothing
             }
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-
+                // Do nothing
             }
         });
         seekBarHorizontalOffset.setProgress(0);
@@ -184,12 +184,12 @@ public class DataAnalysisFragment extends Fragment {
 
             @Override
             public void onStartTrackingTouch(SeekBar seekBar) {
-
+                // Do nothing
             }
 
             @Override
             public void onStopTrackingTouch(SeekBar seekBar) {
-
+                // Do nothing
             }
         });
         seekBarVerticalOffset.setProgress(50);

--- a/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
@@ -11,10 +11,13 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.SeekBar;
 import android.widget.Spinner;
+import android.widget.TextView;
 
 import io.pslab.R;
 import io.pslab.activity.OscilloscopeActivity;
+import io.pslab.others.FloatSeekBar;
 
 public class DataAnalysisFragment extends Fragment {
 
@@ -22,6 +25,12 @@ public class DataAnalysisFragment extends Fragment {
     private Spinner spinnerChannelSelect1;
     private Spinner spinnerChannelSelect2;
     private CheckBox checkBoxFouierTransform;
+    private Spinner spinnerChannelSelectHorizontalOffset;
+    private Spinner spinnerChannelSelectVerticalOffset;
+    private FloatSeekBar seekBarHorizontalOffset;
+    private FloatSeekBar seekBarVerticalOffset;
+    private TextView textViewHorizontalOffset;
+    private TextView textViewVerticalOffset;
 
     public static DataAnalysisFragment newInstance() {
         return new DataAnalysisFragment();
@@ -37,8 +46,12 @@ public class DataAnalysisFragment extends Fragment {
         spinnerCurveFit = v.findViewById(R.id.spinner_curve_fit_da);
         spinnerChannelSelect1 = v.findViewById(R.id.spinner_channel_select_da1);
         spinnerChannelSelect2 = v.findViewById(R.id.spinner_channel_select_da2);
-        Spinner spinnerChannelSelectHorizontalOffset = v.findViewById(R.id.spinner_channel_select_horizontal_offset);
-        Spinner spinnerChannelSelectVerticalOffset = v.findViewById(R.id.spinner_channel_select_vertical_offset);
+        spinnerChannelSelectHorizontalOffset = v.findViewById(R.id.spinner_channel_select_horizontal_offset);
+        spinnerChannelSelectVerticalOffset = v.findViewById(R.id.spinner_channel_select_vertical_offset);
+        seekBarHorizontalOffset = v.findViewById(R.id.seekbar_horizontal_offset);
+        seekBarVerticalOffset = v.findViewById(R.id.seekbar_vertical_offset);
+        textViewHorizontalOffset = v.findViewById(R.id.textview_horizontal_offset);
+        textViewVerticalOffset = v.findViewById(R.id.textview_vertical_offset);
         checkBoxFouierTransform = v.findViewById(R.id.checkBox_fourier_da);
         boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
         ArrayAdapter<String> curveFitAdapter;
@@ -108,6 +121,78 @@ public class DataAnalysisFragment extends Fragment {
 
             }
         });
+
+        spinnerChannelSelectHorizontalOffset.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                if (spinnerChannelSelectHorizontalOffset.getSelectedItem() != "None") {
+                    seekBarHorizontalOffset.setValue(((OscilloscopeActivity) getActivity()).xOffsets.get(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString()));
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+
+        spinnerChannelSelectVerticalOffset.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> adapterView, View view, int i, long l) {
+                if (spinnerChannelSelectVerticalOffset.getSelectedItem() != "None") {
+                    seekBarVerticalOffset.setValue(((OscilloscopeActivity) getActivity()).yOffsets.get(spinnerChannelSelectVerticalOffset.getSelectedItem().toString()));
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> adapterView) {
+
+            }
+        });
+
+        if (((OscilloscopeActivity) getActivity()).xAxisScale == 875) {
+            seekBarHorizontalOffset.setters(0, ((OscilloscopeActivity) getActivity()).xAxisScale / 1000.0);
+        } else {
+            seekBarHorizontalOffset.setters(0, ((OscilloscopeActivity) getActivity()).xAxisScale);
+        }
+        seekBarHorizontalOffset.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
+                textViewHorizontalOffset.setText(String.format("%sms", seekBarHorizontalOffset.getValue()));
+                ((OscilloscopeActivity) getActivity()).xOffsets.put(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString(), seekBarHorizontalOffset.getValue());
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+
+            }
+        });
+        seekBarHorizontalOffset.setProgress(0);
+
+        seekBarVerticalOffset.setters(-1 * ((OscilloscopeActivity) getActivity()).yAxisScale, ((OscilloscopeActivity) getActivity()).yAxisScale);
+        seekBarVerticalOffset.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
+                textViewVerticalOffset.setText(String.format("%sV", seekBarVerticalOffset.getValue()));
+                ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+
+            }
+        });
+        seekBarVerticalOffset.setProgress(50);
 
         checkBoxFouierTransform.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override

--- a/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
+++ b/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
@@ -68,7 +68,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(0.875);
                             ((OscilloscopeActivity) getActivity()).timebase = 875;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 1:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
@@ -76,7 +76,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
                             ((OscilloscopeActivity) getActivity()).timebase = 1000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 2:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
@@ -84,7 +84,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
                             ((OscilloscopeActivity) getActivity()).timebase = 2000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 4;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 3:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
@@ -92,7 +92,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
                             ((OscilloscopeActivity) getActivity()).timebase = 4000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 4:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
@@ -100,7 +100,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
                             ((OscilloscopeActivity) getActivity()).timebase = 8000;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 5:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
@@ -108,7 +108,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
                             ((OscilloscopeActivity) getActivity()).timebase = 25600;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 25;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 6:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
@@ -116,7 +116,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 38400;
                             ((OscilloscopeActivity) getActivity()).timebase = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 38;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         default:
                             break;
@@ -147,7 +147,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(0.875);
                             ((OscilloscopeActivity) getActivity()).timebase = 875;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 1:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
@@ -155,7 +155,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
                             ((OscilloscopeActivity) getActivity()).timebase = 1000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 2;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 2:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
@@ -163,7 +163,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
                             ((OscilloscopeActivity) getActivity()).timebase = 2000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 4;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 3:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
@@ -171,7 +171,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
                             ((OscilloscopeActivity) getActivity()).timebase = 4000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 4:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
@@ -179,7 +179,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
                             ((OscilloscopeActivity) getActivity()).timebase = 8000;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 8;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 5:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
@@ -187,7 +187,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
                             ((OscilloscopeActivity) getActivity()).timebase = 25600;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 25;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 6:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
@@ -195,7 +195,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 38400;
                             ((OscilloscopeActivity) getActivity()).timebase = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 38;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 7:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 51.20));
@@ -203,7 +203,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(51.20);
                             ((OscilloscopeActivity) getActivity()).timebase = 51200;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 50;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 8:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 102.40));
@@ -211,7 +211,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(102.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 102400;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
-                            ((OscilloscopeActivity) getActivity()).timeGap = 100;
+                            ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase)/ ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         default:
                             break;

--- a/app/src/main/res/layout/fragment_data_analysis.xml
+++ b/app/src/main/res/layout/fragment_data_analysis.xml
@@ -29,7 +29,6 @@
         android:id="@+id/spinner_channel_select_da2"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/osc_spinner_height"
-        android:layout_marginEnd="@dimen/osc_cb_margin"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/layout/fragment_data_analysis.xml
+++ b/app/src/main/res/layout/fragment_data_analysis.xml
@@ -12,33 +12,30 @@
         android:layout_width="wrap_content"
         android:layout_height="@dimen/osc_spinner_height"
         android:layout_marginStart="@dimen/osc_cb_margin"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
     <Spinner
         android:id="@+id/spinner_channel_select_da1"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/osc_spinner_height"
-        android:layout_marginEnd="@dimen/osc_cb_margin"
-        android:layout_marginStart="@dimen/osc_cb_margin"
-        app:layout_constraintLeft_toRightOf="@+id/spinner_curve_fit_da"
-        app:layout_constraintRight_toLeftOf="@+id/spinner_channel_select_da2"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Spinner
         android:id="@+id/spinner_channel_select_da2"
         android:layout_width="wrap_content"
         android:layout_height="@dimen/osc_spinner_height"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
 
     <CheckBox
         android:id="@+id/checkBox_fourier_da"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/osc_cb_margin"
+        android:layout_marginTop="@dimen/osc_cb_margin"
         android:text="@string/fourier_transforms"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent" />
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/fragment_data_analysis_main.xml
+++ b/app/src/main/res/layout/fragment_data_analysis_main.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include
+        android:id="@+id/include"
+        layout="@layout/fragment_data_analysis"
+        android:layout_width="@dimen/dimen_zero_dp"
+        android:layout_height="@dimen/dimen_zero_dp"
+        android:layout_marginEnd="@dimen/osc_divider_line"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/guideline2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <include
+        layout="@layout/position_controls"
+        android:layout_width="@dimen/dimen_zero_dp"
+        android:layout_height="@dimen/dimen_zero_dp"
+        android:layout_marginStart="@dimen/osc_divider_line"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/guideline2"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/position_controls.xml
+++ b/app/src/main/res/layout/position_controls.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/rounded_custom_border">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.5" />
+
+    <io.pslab.others.FloatSeekBar
+        android:id="@+id/seekbar_vertical_offset"
+        android:layout_width="@dimen/dimen_zero_dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toStartOf="@+id/textview_vertical_offset"
+        app:layout_constraintStart_toEndOf="@+id/spinner_channel_select_vertical_offset"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <io.pslab.others.FloatSeekBar
+        android:id="@+id/seekbar_horizontal_offset"
+        android:layout_width="@dimen/dimen_zero_dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/textview_horizontal_offset"
+        app:layout_constraintStart_toEndOf="@+id/spinner_channel_select_horizontal_offset"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
+    <Spinner
+        android:id="@+id/spinner_channel_select_vertical_offset"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/osc_cb_margin"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textview_vertical_offset"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/osc_cb_margin"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Spinner
+        android:id="@+id/spinner_channel_select_horizontal_offset"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/osc_cb_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
+    <TextView
+        android:id="@+id/textview_horizontal_offset"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/osc_cb_margin"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/position_controls.xml
+++ b/app/src/main/res/layout/position_controls.xml
@@ -11,7 +11,7 @@
         android:layout_width="@dimen/dimen_zero_dp"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="@+id/spinner_channel_select_vertical_offset"
-        app:layout_constraintEnd_toStartOf="@+id/textview_vertical_offset"
+        app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toEndOf="@+id/spinner_channel_select_vertical_offset"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -20,7 +20,7 @@
         android:layout_width="@dimen/dimen_zero_dp"
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/textview_horizontal_offset"
+        app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toEndOf="@+id/spinner_channel_select_horizontal_offset"
         app:layout_constraintTop_toTopOf="@+id/spinner_channel_select_horizontal_offset" />
 
@@ -34,11 +34,12 @@
 
     <TextView
         android:id="@+id/textview_vertical_offset"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/osc_cb_margin"
         app:layout_constraintBottom_toBottomOf="@+id/spinner_channel_select_vertical_offset"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/seekbar_vertical_offset"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Spinner
@@ -51,11 +52,19 @@
 
     <TextView
         android:id="@+id/textview_horizontal_offset"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/osc_cb_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/seekbar_horizontal_offset"
         app:layout_constraintTop_toTopOf="@+id/spinner_channel_select_horizontal_offset" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.8" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/position_controls.xml
+++ b/app/src/main/res/layout/position_controls.xml
@@ -6,18 +6,11 @@
     android:layout_height="match_parent"
     android:background="@drawable/rounded_custom_border">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/guideline"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.5" />
-
     <io.pslab.others.FloatSeekBar
         android:id="@+id/seekbar_vertical_offset"
         android:layout_width="@dimen/dimen_zero_dp"
         android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintBottom_toBottomOf="@+id/spinner_channel_select_vertical_offset"
         app:layout_constraintEnd_toStartOf="@+id/textview_vertical_offset"
         app:layout_constraintStart_toEndOf="@+id/spinner_channel_select_vertical_offset"
         app:layout_constraintTop_toTopOf="parent" />
@@ -29,14 +22,13 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/textview_horizontal_offset"
         app:layout_constraintStart_toEndOf="@+id/spinner_channel_select_horizontal_offset"
-        app:layout_constraintTop_toTopOf="@+id/guideline" />
+        app:layout_constraintTop_toTopOf="@+id/spinner_channel_select_horizontal_offset" />
 
     <Spinner
         android:id="@+id/spinner_channel_select_vertical_offset"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/osc_spinner_height"
         android:layout_marginStart="@dimen/osc_cb_margin"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -45,18 +37,17 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/osc_cb_margin"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintBottom_toBottomOf="@+id/spinner_channel_select_vertical_offset"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <Spinner
         android:id="@+id/spinner_channel_select_horizontal_offset"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_height="@dimen/osc_spinner_height"
         android:layout_marginStart="@dimen/osc_cb_margin"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guideline" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <TextView
         android:id="@+id/textview_horizontal_offset"
@@ -65,6 +56,6 @@
         android:layout_marginEnd="@dimen/osc_cb_margin"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guideline" />
+        app:layout_constraintTop_toTopOf="@+id/spinner_channel_select_horizontal_offset" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Resolves #2458 
Adds the Position Controls feature to the Oscilloscope screen.

**Horizontal & Vertical Position Controls**:
- Another feature would be to control the horizontal and vertical position of the waveform on the oscilloscope display, for manual measurements.
- The horizontal position control moves the waveform back and forth on the display and can be used to either align the waveform with the horizontal divisions of the display or to view different sections of the waveform.
- The vertical position control moves the waveform up and down on the display and can be used for manual measurements in a similar way as the horizontal position control.

The UI for the feature is implemented in the _DataAnalysisFragment_, using _Spinners_ for selecting the channels and _SeekBars_ for choosing the offset value, arranged in a layout as discussed with everyone before.

## Changes 
- app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
- app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
- app/src/main/res/layout/fragment_data_analysis.xml
- app/src/main/res/layout/fragment_data_analysis_main.xml
- app/src/main/res/layout/position_controls.xml

## Screenshots / Recordings  
Here is a demo of the feature using the _In-Built MIC_-

https://github.com/fossasia/pslab-android/assets/125425881/f5d4f58d-cb07-4588-a652-8a09c616b3f4

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause @CloudyPadmal @mariobehling This feature is now ready for testing and review.