### PR TITLE
fix: fixes scaling of axes for waveforms having negative DC components

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1230,7 +1230,11 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         yPadding = yRange * 0.1;
         if (maxPeriod > 0) {
             xAxisScale = Math.min((maxPeriod * 5), maxTimebase);
-            yAxisScale = maxY + yPadding;
+            if (Math.abs(maxY) >= Math.abs(minY)) {
+                yAxisScale = maxY + yPadding;
+            } else {
+                yAxisScale = -1 * (minY - yPadding);
+            }
             samples = 512;
             timeGap = (2 * xAxisScale * 1000.0) / samples;
         } else {


### PR DESCRIPTION
Fixes #2475 
Updates the Auto-Scale algorithm to support scaling for waveforms having negative DC components.

## Changes 
- app/src/main/java/io/pslab/activity/OscilloscopeActivity.java

## Screenshots / Recordings  
Here is a demonstration - 

https://github.com/fossasia/pslab-android/assets/125425881/26eefe1f-e510-4c11-928c-f867acfff05d

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause Could you please test this fix?