### PR TITLE
feat: added Automatic Measurements

### DIFF
--- a/app/src/main/java/io/pslab/adapters/OscilloscopeMeasurementsAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/OscilloscopeMeasurementsAdapter.java
@@ -39,9 +39,16 @@ public class OscilloscopeMeasurementsAdapter extends RecyclerView.Adapter<Oscill
             double negativePeak = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.NEGATIVE_PEAK);
             DecimalFormat df = new DecimalFormat("#.##");
             df.setRoundingMode(RoundingMode.CEILING);
-            String string = "Vpp: " + df.format(amplitude) + " V\nVp+: " + df.format(positivePeak) + " V  Vp-: " + df.format(negativePeak) + " V\nf: " + df.format(frequency) + " Hz  P: " + df.format(period) + " ms";
-            measurementsView.setTextColor(channelColor);
-            measurementsView.setText(string);
+            if (frequency >= 1000) {
+                frequency /= 1000;
+                String string = "Vpp: " + df.format(amplitude) + " V\nVp+: " + df.format(positivePeak) + " V  Vp-: " + df.format(negativePeak) + " V\nf: " + df.format(frequency) + " kHz  P: " + df.format(period) + " ms";
+                measurementsView.setTextColor(channelColor);
+                measurementsView.setText(string);
+            } else {
+                String string = "Vpp: " + df.format(amplitude) + " V\nVp+: " + df.format(positivePeak) + " V  Vp-: " + df.format(negativePeak) + " V\nf: " + df.format(frequency) + " Hz  P: " + df.format(period) + " ms";
+                measurementsView.setTextColor(channelColor);
+                measurementsView.setText(string);
+            }
         }
     }
 

--- a/app/src/main/java/io/pslab/adapters/OscilloscopeMeasurementsAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/OscilloscopeMeasurementsAdapter.java
@@ -1,0 +1,70 @@
+package io.pslab.adapters;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+
+import io.pslab.R;
+import io.pslab.activity.OscilloscopeActivity.ChannelMeasurements;
+import io.pslab.activity.OscilloscopeActivity.CHANNEL;
+import io.pslab.others.OscilloscopeMeasurements;
+
+public class OscilloscopeMeasurementsAdapter extends RecyclerView.Adapter<OscilloscopeMeasurementsAdapter.ViewHolder> {
+
+    private final String[] channels;
+    private final Integer[] channelColors;
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+
+        private final TextView measurementsView;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            this.measurementsView = itemView.findViewById(R.id.textview_measurements);
+        }
+
+        public void setMeasurements(@NonNull String channelString, @NonNull Integer channelColor) {
+            CHANNEL channel = CHANNEL.valueOf(channelString);
+            double frequency = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.FREQUENCY);
+            double amplitude = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.AMPLITUDE);
+            double period = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.PERIOD);
+            double positivePeak = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.POSITIVE_PEAK);
+            double negativePeak = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.NEGATIVE_PEAK);
+            DecimalFormat df = new DecimalFormat("#.##");
+            df.setRoundingMode(RoundingMode.CEILING);
+            String string = "Vpp: " + df.format(amplitude) + " V\nVp+: " + df.format(positivePeak) + " V  Vp-: " + df.format(negativePeak) + " V\nf: " + df.format(frequency) + " Hz  P: " + df.format(period) + " ms";
+            measurementsView.setTextColor(channelColor);
+            measurementsView.setText(string);
+        }
+    }
+
+    public OscilloscopeMeasurementsAdapter(@NonNull String[] channels, @NonNull Integer[] channelColors) {
+        this.channels = channels;
+        this.channelColors = channelColors;
+    }
+
+    @NonNull
+    @Override
+    public OscilloscopeMeasurementsAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View itemView = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.measurement_item, parent, false);
+        return new ViewHolder(itemView);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull OscilloscopeMeasurementsAdapter.ViewHolder holder, int position) {
+        holder.setMeasurements(channels[position], channelColors[position]);
+    }
+
+    @Override
+    public int getItemCount() {
+        return channels.length;
+    }
+}

--- a/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
+++ b/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
@@ -124,7 +124,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 38400;
-                            ((OscilloscopeActivity) getActivity()).timebase = 1024;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         default:
@@ -203,7 +203,7 @@ public class TimebaseTriggerFragment extends Fragment {
                             ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
                             ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 38400;
-                            ((OscilloscopeActivity) getActivity()).timebase = 1024;
+                            ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 7:

--- a/app/src/main/java/io/pslab/others/OscilloscopeMeasurements.java
+++ b/app/src/main/java/io/pslab/others/OscilloscopeMeasurements.java
@@ -1,0 +1,47 @@
+package io.pslab.others;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.pslab.activity.OscilloscopeActivity.ChannelMeasurements;
+import io.pslab.activity.OscilloscopeActivity.CHANNEL;
+
+
+public class OscilloscopeMeasurements {
+
+    public final static Map<CHANNEL, HashMap<ChannelMeasurements, Double>> channel = new HashMap<>();
+
+    static {
+        channel.put(CHANNEL.CH1, new HashMap<ChannelMeasurements, Double>() {{
+            put(ChannelMeasurements.FREQUENCY, 0.00);
+            put(ChannelMeasurements.PERIOD, 0.00);
+            put(ChannelMeasurements.AMPLITUDE, 0.00);
+            put(ChannelMeasurements.POSITIVE_PEAK, 0.00);
+            put(ChannelMeasurements.NEGATIVE_PEAK, 0.00);
+        }});
+
+        channel.put(CHANNEL.CH2, new HashMap<ChannelMeasurements, Double>() {{
+            put(ChannelMeasurements.FREQUENCY, 0.00);
+            put(ChannelMeasurements.PERIOD, 0.00);
+            put(ChannelMeasurements.AMPLITUDE, 0.00);
+            put(ChannelMeasurements.POSITIVE_PEAK, 0.00);
+            put(ChannelMeasurements.NEGATIVE_PEAK, 0.00);
+        }});
+
+        channel.put(CHANNEL.CH3, new HashMap<ChannelMeasurements, Double>() {{
+            put(ChannelMeasurements.FREQUENCY, 0.00);
+            put(ChannelMeasurements.PERIOD, 0.00);
+            put(ChannelMeasurements.AMPLITUDE, 0.00);
+            put(ChannelMeasurements.POSITIVE_PEAK, 0.00);
+            put(ChannelMeasurements.NEGATIVE_PEAK, 0.00);
+        }});
+
+        channel.put(CHANNEL.MIC, new HashMap<ChannelMeasurements, Double>() {{
+            put(ChannelMeasurements.FREQUENCY, 0.00);
+            put(ChannelMeasurements.PERIOD, 0.00);
+            put(ChannelMeasurements.AMPLITUDE, 0.00);
+            put(ChannelMeasurements.POSITIVE_PEAK, 0.00);
+            put(ChannelMeasurements.NEGATIVE_PEAK, 0.00);
+        }});
+    }
+}

--- a/app/src/main/res/layout/activity_oscilloscope.xml
+++ b/app/src/main/res/layout/activity_oscilloscope.xml
@@ -316,6 +316,15 @@
                 android:layout_marginBottom="@dimen/osc_main_margin"
                 android:layout_toStartOf="@+id/layout_dock_os1" />
 
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignTop="@id/layout_chart_os"
+                android:layout_alignEnd="@id/layout_chart_os"
+                android:background="@color/black"
+                android:padding="@dimen/osc_recyclerview_padding" />
+
         </RelativeLayout>
 
         <View

--- a/app/src/main/res/layout/activity_oscilloscope.xml
+++ b/app/src/main/res/layout/activity_oscilloscope.xml
@@ -322,8 +322,8 @@
                 android:layout_height="wrap_content"
                 android:layout_alignTop="@id/layout_chart_os"
                 android:layout_alignEnd="@id/layout_chart_os"
-                android:background="@color/black"
-                android:padding="@dimen/osc_recyclerview_padding" />
+                android:layout_marginEnd="@dimen/osc_recyclerview_padding"
+                android:background="@color/black" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/measurement_item.xml
+++ b/app/src/main/res/layout/measurement_item.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="#00FFFFFF">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/recycler_view_margin"
+        android:elevation="@dimen/measurements_card_elevation"
+        android:padding="@dimen/measurements_card_padding"
+        app:cardBackgroundColor="#4DFFFFFF"
+        app:cardCornerRadius="@dimen/measurements_card_radius"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="#00FFFFFF">
+
+            <TextView
+                android:id="@+id/textview_measurements"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/osc_spinner_margin"
+                android:layout_marginTop="@dimen/osc_spinner_margin"
+                android:layout_marginEnd="@dimen/osc_spinner_margin"
+                android:layout_marginBottom="@dimen/osc_spinner_margin"
+                android:background="#00FFFFFF"
+                android:textSize="@dimen/osc_axis_text_size"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.cardview.widget.CardView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/measurement_item.xml
+++ b/app/src/main/res/layout/measurement_item.xml
@@ -9,7 +9,7 @@
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/recycler_view_margin"
+        android:layout_marginTop="@dimen/recycler_view_margin"
         android:elevation="@dimen/measurements_card_elevation"
         android:padding="@dimen/measurements_card_padding"
         app:cardBackgroundColor="#4DFFFFFF"
@@ -33,6 +33,8 @@
                 android:layout_marginEnd="@dimen/osc_spinner_margin"
                 android:layout_marginBottom="@dimen/osc_spinner_margin"
                 android:background="#00FFFFFF"
+                android:paddingStart="@dimen/osc_recyclerview_padding"
+                android:paddingEnd="@dimen/osc_recyclerview_padding"
                 android:textSize="@dimen/osc_axis_text_size"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/menu/activity_landscape_menu.xml
+++ b/app/src/main/res/menu/activity_landscape_menu.xml
@@ -30,4 +30,11 @@
         android:icon="@drawable/menu_icon_guide"
         android:title="@string/show_guide"
         app:showAsAction="always" />
+    <item
+        android:id="@+id/measurements"
+        android:checkable="true"
+        android:title="@string/measurements"
+        app:actionViewClass="android.widget.CheckBox"
+        app:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -138,7 +138,7 @@
     <dimen name="multimeter_length_0">0dp</dimen>
     <dimen name="multimeter_knob_width_xhdpi">192dp</dimen>
     <dimen name="multimeter_knob_height_xhdpi">190dp</dimen>
-    
+
     <dimen name="multimeter_knobcircle_radius_1_xl_tablet">173dp</dimen>
     <dimen name="multimeter_knobcircle_radius_2_xl_tablet">167dp</dimen>
     <dimen name="multimeter_knobcircle_radius_3_xl_tablet">176dp</dimen>
@@ -176,6 +176,10 @@
     <dimen name="osc_spinner_margin_bottom">13dp</dimen>
     <dimen name="osc_text_size_large">18sp</dimen>
     <dimen name="osc_spinner_padding">2dp</dimen>
+    <dimen name="osc_recyclerview_padding">4dp</dimen>
+    <dimen name="measurements_card_radius">4dp</dimen>
+    <dimen name="measurements_card_elevation">8dp</dimen>
+    <dimen name="measurements_card_padding">4dp</dimen>
 
     <dimen name="modified_spinner_height">40dp</dimen>
     <dimen name="spinner_text_size">15sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1156,6 +1156,7 @@
     <string name="channels">Channels</string>
     <string name="timebase_trigger_title">Timebase \u0026 Trigger</string>
     <string name="title_offsets">Offsets</string>
+    <string name="measurements">Automatic Measurements</string>
     <string name="title_xy_plot">XY Plot</string>
 
 </resources>


### PR DESCRIPTION
Resolves #2491 
Implements _Automatic Measurements_ of waveform characteristics within the app.

**Automatic Measurements**:
- The oscilloscope as of now doesn’t have a feature to automatically measure and display characteristics of the waveform such as amplitude, frequency, period, etc.
- This feature can be added which would calculate the characteristics of the waveform using algorithms and display them.

The UI for the feature is implemented in the form of a _Checkable MenuItem_ in the _Menu_ of the _OscilloscopeActivity_. Checking it would activate the feature, showing the measurements in _TextViews_ populated inside a _RecyclerView_.

## Changes 
- The feature is added in such a way that it doesn't cause **crowding** of elements in the _OscilloscopeActivity_, and can be used whenever wanted by activating it.
- When activated, common waveform characteristics such as _frequency_, _period_, _amplitude_, etc. of the waveforms selected are calculated using **software** algorithms within the app and the data is used to populate the _RecyclerView_ after every successful capture.
- In order to distinguish between different channels, it is made sure that the color of the text in any particular _TextView_ always **syncs** with the color of its parent waveform.

This feature has been developed for and tested with all the channels (i.e., _CH1_, _CH2_, _CH3_, _In-Built MIC_, _PSLab MIC_).

## Screenshots / Recordings  
Here, is a demonstration of the feature:-

https://github.com/fossasia/pslab-android/assets/125425881/6207b9ff-ab9c-437c-83df-2150982b8d68

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@CloudyPadmal @marcnause Your views on this ? Any suggestions regarding the layouts or anything else are most welcome.
@marcnause Could you also please test this feature and confirm that everything works fine (there may be very minute errors in the frequencies displayed, these are very normal given the hardware limitations and the number of samples being used to calculate the frequencies and periods) ?