### PR TITLE
chore: setup fastlane

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -28,6 +28,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Setup Ruby
+        if: ${{ github.repository == 'fossasia/pslab-android' }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Prepare Bundler
+        if: ${{ github.repository == 'fossasia/pslab-android' }}
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
@@ -132,6 +145,14 @@ jobs:
           git branch -D apk
           git branch -m apk
           git push --force origin apk
+
+      - name: Update app in Open Testing track
+        if: ${{ github.repository == 'fossasia/pslab-android' }}
+        run: |
+          bundle exec fastlane uploadToOpenTesting
+          if [[ $? -ne 0 ]]; then
+              exit 1
+          fi
 
       - name: Run Release Drafter
         uses: release-drafter/release-drafter@v6

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fastlane"

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,0 +1,2 @@
+json_key_file("./scripts/fastlane.json") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
+package_name("io.pslab") # e.g. com.krausefx.app

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,6 @@
+default_platform(:android)
+platform :android do
+  lane :uploadToOpenTesting do
+    upload_to_play_store(track: "beta",aab:"app/build/outputs/bundle/release/app-release.aab")
+  end
+end


### PR DESCRIPTION
Configures _fastlane_ in our repository to automate uploads to the PlayStore Open Testing track.

## Changes 
- Whenever a new commit is pushed, the release APK is pushed to the _beta_ (open testing) track in the Google PlayStore.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.