### PR TITLE
fix: fixed pull-request pipeline

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,6 +20,16 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
 
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr
+          path: pr/
+
       - name: Build with Gradle
         run: |
           bash ./gradlew build --stacktrace
@@ -30,12 +40,3 @@ jobs:
           name: apk-files
           path: |
             app/build/outputs/apk/debug/app-debug.apk
-
-      - name: Save PR number
-        run: |
-          mkdir -p ./pr
-          echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pr
-          path: pr/


### PR DESCRIPTION
Fixes our _pull-request_ pipeline to save and upload the PR number artifact before building.

## Changes 
- Currently, our _pull-request_ pipeline is configured to save and upload the PR number artifact after the _build_ action finishes.
- This causes the uploading to be skipped in case the build fails, and hence, the _pull-request-comment_ workflow fails.
- The pipeline is updated to save the PR number and upload it before the build starts, so that the _pull-request-comment_ workflow can fetch the details and appropriately make a comment showing the build status.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the pull-request pipeline to save and upload the PR number artifact before the build process begins. This change ensures that the pull-request-comment workflow can access the PR details and comment on the build status, even if the build fails.

- **CI**:
    - Updated the pull-request pipeline to save and upload the PR number artifact before the build starts, ensuring the pull-request-comment workflow can fetch the details even if the build fails.

<!-- Generated by sourcery-ai[bot]: end summary -->