### PR TITLE
fix: fixed PSLAB MIC channel

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -507,7 +507,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                             }
                         }
 
-                        if ((!isInBuiltMicSelected || !isAudioInputSelected) && audioJack != null) {
+                        if ((!isInBuiltMicSelected) && audioJack != null) {
                             audioJack.release();
                             audioJack = null;
                         }

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -243,10 +243,10 @@ public class ChannelParametersFragment extends Fragment {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = isChecked;
                 ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
-                ((OscilloscopeActivity) getActivity()).isMICSelected = !isChecked;
                 if (isChecked) {
                     ((OscilloscopeActivity) getActivity()).maxTimebase = 38.4f;
                     if (pslabMicCheckBox.isChecked()) {
+                        ((OscilloscopeActivity) getActivity()).isMICSelected = false;
                         pslabMicCheckBox.setChecked(false);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
                     }
@@ -265,9 +265,9 @@ public class ChannelParametersFragment extends Fragment {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 ((OscilloscopeActivity) getActivity()).isMICSelected = isChecked;
                 ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
-                ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = !isChecked;
                 if (isChecked) {
                     if (builtInMicCheckBox.isChecked()) {
+                        ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = false;
                         builtInMicCheckBox.setChecked(false);
                         ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
                     }


### PR DESCRIPTION
Fixes #2521
Fixes toggling logic between the _In-Built MIC_ and _PSLab MIC_ channels.

## Changes 
- Issue #2521 as described by @marcnause was a result of faulty toggling logic between the MIC channels, due to which switching _OFF_ one channel caused the other one to automatically switch _ON_, now fixed.

## Screenshots / Recordings  
Here is a screen recording -

https://github.com/user-attachments/assets/d1e51c4a-9bca-4e20-9392-0609f5ec8b37

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause Could you please test and confirm if this issue has been fixed now ?

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix toggling logic between the In-Built MIC and PSLab MIC channels to resolve issue #2521, ensuring that turning off one channel does not automatically turn on the other.

Bug Fixes:
- Correct toggling logic between the In-Built MIC and PSLab MIC channels to prevent automatic switching when one channel is turned off.

<!-- Generated by sourcery-ai[bot]: end summary -->