### PR TITLE
chore: bump com.android.application from 8.4.1 to 8.5.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,5 +9,5 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "8.4.1" apply false
+    id("com.android.application") version "8.5.2" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon May 13 19:46:35 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Superseeds #2532 

## Changes 
- Bumps com.android.application from 8.4.1 to 8.5.2 

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the com.android.application plugin to version 8.5.2 in the build configuration.

Build:
- Bump com.android.application plugin version from 8.4.1 to 8.5.2 in build.gradle.kts.

<!-- Generated by sourcery-ai[bot]: end summary -->