### PR TITLE
fix: fixed VL53L0X

### DIFF
--- a/app/src/main/java/io/pslab/communication/sensors/VL53L0X.java
+++ b/app/src/main/java/io/pslab/communication/sensors/VL53L0X.java
@@ -171,9 +171,9 @@ public class VL53L0X {
             }
             int configControl = i2c.readByte(ADDRESS, MSRC_CONFIG_CONTROL) | (DISABLE_SIGNAL_RATE_MSRC | DISABLE_SIGNAL_RATE_PRE_RANGE);
 
-            i2c.write(ADDRESS, new int[configControl], MSRC_CONFIG_CONTROL);
+            i2c.write(ADDRESS, new int[]{configControl}, MSRC_CONFIG_CONTROL);
 
-            i2c.write(ADDRESS, new int[0xFF], SYSTEM_SEQUENCE_CONFIG);
+            i2c.write(ADDRESS, new int[]{0xFF}, SYSTEM_SEQUENCE_CONFIG);
 
             spadConfig();
 


### PR DESCRIPTION
Fixes a bug in the communication class for the **VL53L0X** sensor (`VL53L0X.java`).
This didn't affect the functioning of the sensor but caused the sensor readings to fail if it was used more than once after connecting the _PSLab_.

## Changes 
- Fixes a configuration issue wherein an empty array was being written to the sensor registers.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix configuration issue in VL53L0X sensor communication class to ensure proper sensor readings when used multiple times after connecting the PSLab.

Bug Fixes:
- Fix configuration issue in VL53L0X sensor communication class to prevent sensor readings from failing when used multiple times after connecting the PSLab.

<!-- Generated by sourcery-ai[bot]: end summary -->