### PR TITLE
chore: fix comment pipeline

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -61,7 +61,7 @@ jobs:
 
             let comment_id;
             for (const comment of comments.data) {
-              if (comment.user.type === 'Bot') {
+              if (comment.user.login === 'github-actions[bot]') {
                 comment_id = comment.id;
                 break;
               }
@@ -103,7 +103,7 @@ jobs:
 
             let comment_id;
             for (const comment of comments.data) {
-              if (comment.user.type === 'Bot') {
+              if (comment.user.login === 'github-actions[bot]') {
                 comment_id = comment.id;
                 break;
               }


### PR DESCRIPTION
Fixes our comment pipeline (_pull-request-comment.yml_).

## Changes 
- Our comment pipeline was configured to update any existing comments with a `user.type` of _Bot_ (essentially any comment made by any bot), to provide the artifacts for the latest build whenever a pull request was synchronized.
- This worked fine as initially we didn't have any other bot commenting on our PRs. 
- However, after we introduced the _sourcery-ai[bot]_ for reviewing PRs, the comment workflow clashed with it and updated the first comment of _sourcery-ai[bot]_ instead.
- This is now fixed in this PR, where we now look for comments specifically made by the _github-actions[bot]_.

## Screenshots / Recordings  
Here is a screenshot showing the problem described above: -

![Screenshot 2024-08-21 171204](https://github.com/user-attachments/assets/0e34ef17-426c-43a3-80a4-dd1a06fcf3f4)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the comment pipeline to target comments made by github-actions[bot] to avoid conflicts with other bots.

CI:
- Update the comment pipeline to specifically target comments made by the github-actions[bot] instead of any bot, preventing conflicts with other bots like sourcery-ai[bot].

<!-- Generated by sourcery-ai[bot]: end summary -->