### PR TITLE
fix: fixed Power Source

### DIFF
--- a/app/src/main/java/io/pslab/communication/ScienceLab.java
+++ b/app/src/main/java/io/pslab/communication/ScienceLab.java
@@ -145,10 +145,17 @@ public class ScienceLab {
         squareWaveFrequency.put("SQR2", 0.0);
         squareWaveFrequency.put("SQR3", 0.0);
         squareWaveFrequency.put("SQR4", 0.0);
-        dacChannels.put("PCS", new DACChannel("PCS", new double[]{0, 3.3}, 0, 0));
-        dacChannels.put("PV3", new DACChannel("PV3", new double[]{0, 3.3}, 1, 1));
-        dacChannels.put("PV2", new DACChannel("PV2", new double[]{-3.3, 3.3}, 2, 0));
-        dacChannels.put("PV1", new DACChannel("PV1", new double[]{-5., 5.}, 3, 1));
+        if (CommunicationHandler.PSLAB_VERSION == 6) {
+            dacChannels.put("PCS", new DACChannel("PCS", new double[]{0, 3.3}, 0, 0));
+            dacChannels.put("PV3", new DACChannel("PV3", new double[]{0, 3.3}, 1, 1));
+            dacChannels.put("PV2", new DACChannel("PV2", new double[]{-3.3, 3.3}, 2, 0));
+            dacChannels.put("PV1", new DACChannel("PV1", new double[]{-5., 5.}, 3, 1));
+        } else {
+            dacChannels.put("PCS", new DACChannel("PCS", new double[]{0, 3.3}, 0, 0));
+            dacChannels.put("PV3", new DACChannel("PV3", new double[]{0, 3.3}, 1, 1));
+            dacChannels.put("PV2", new DACChannel("PV2", new double[]{-3.3, 3.3}, 2, 2));
+            dacChannels.put("PV1", new DACChannel("PV1", new double[]{-5., 5.}, 3, 3));
+        }
         values.put("PV1", 0.);
         values.put("PV2", 0.);
         values.put("PV3", 0.);


### PR DESCRIPTION
Fixes #2525 

## Changes 
- Issue #2525 reported by @marcnause was arising due to support for V5 **hardware** being removed mistakenly in 94ff43e9e86b44c8ec17fd60ae3a3f59324f712a merged in PR #2510.
- The change is now reverted.

## Screenshots / Recordings  
NA

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause Could you please test and confirm if the _Power Source_ works well on your V5 hardware ? The controllers would still sync in, resulting in a wrong value being displayed for the complementary controller, whenever a controller is set. However, that remains as a visual bug, which doesn't cause much of an issue in the functioning (discussed during our weekly GSoC meet).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Revert changes to restore support for V5 hardware in the Power Source functionality, addressing issue #2525.

Bug Fixes:
- Restore support for V5 hardware by reverting changes that mistakenly removed it, ensuring compatibility with the Power Source functionality.

<!-- Generated by sourcery-ai[bot]: end summary -->