### PR TITLE
feat: add automatically generated oss license screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ android {
                 "proguard-rules.pro"
             )
             resValue("string", "version", "${defaultConfig.versionName}")
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (GITHUB_BUILD) signingConfigs.getByName("release") else null
         }
     }
     lint {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.application")
+    id("com.google.android.gms.oss-licenses-plugin")
 }
 
 apply(plugin = "realm-android")
@@ -17,7 +18,7 @@ android {
         targetSdk = 34
         versionCode = System.getenv("VERSION_CODE")?.toInt() ?: 1
         versionName = System.getenv("VERSION_NAME") ?: "1.0.0"
-        resConfigs("en","ru","ar","si","pl")
+        resConfigs("en", "ru", "ar", "si", "pl")
     }
 
     signingConfigs {
@@ -43,7 +44,7 @@ android {
                 "proguard-rules.pro"
             )
             resValue("string", "version", "${defaultConfig.versionName}")
-            signingConfig = if (GITHUB_BUILD) signingConfigs.getByName("release") else null
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
     lint {
@@ -114,4 +115,8 @@ dependencies {
 
     // Realm
     implementation("com.github.realm:realm-android-adapters:v4.0.0")
+
+    // OSS license plugin
+    implementation("com.google.android.gms:play-services-oss-licenses:17.1.0")
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -120,6 +120,12 @@
         <activity
             android:name=".activity.DustSensorActivity"
             android:screenOrientation="fullSensor" />
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/OssLicenseScreenTheme" />
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/OssLicenseScreenTheme" />
 
         <receiver android:name=".receivers.USBDetachReceiver" />
 

--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -32,6 +32,7 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.snackbar.Snackbar;
 
@@ -324,6 +325,10 @@ public class MainActivity extends AppCompatActivity {
                             drawer.closeDrawers();
                         }
                         break;
+                    case R.id.nav_third_party_libs:
+                        OssLicensesMenuActivity.setActivityTitle(getString(R.string.third_party_libs));
+                        startActivity(new Intent(MainActivity.this, OssLicensesMenuActivity.class));
+                        break;
                     default:
                         navItemIndex = 0;
                 }
@@ -472,7 +477,7 @@ public class MainActivity extends AppCompatActivity {
     private void attemptToGetUSBPermission() {
         if (!("android.hardware.usb.action.USB_DEVICE_ATTACHED".equals(getIntent().getAction()))) {
             if (communicationHandler.isDeviceFound() && !usbManager.hasPermission(communicationHandler.mUsbDevice)) {
-                mPermissionIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
+                    mPermissionIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
                 IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
                 registerReceiver(mUsbReceiver, filter);
                 receiverRegister = true;

--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -477,7 +477,7 @@ public class MainActivity extends AppCompatActivity {
     private void attemptToGetUSBPermission() {
         if (!("android.hardware.usb.action.USB_DEVICE_ATTACHED".equals(getIntent().getAction()))) {
             if (communicationHandler.isDeviceFound() && !usbManager.hasPermission(communicationHandler.mUsbDevice)) {
-                    mPermissionIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
+                mPermissionIntent = PendingIntent.getBroadcast(this, 0, new Intent(ACTION_USB_PERMISSION), 0);
                 IntentFilter filter = new IntentFilter(ACTION_USB_PERMISSION);
                 registerReceiver(mUsbReceiver, filter);
                 receiverRegister = true;

--- a/app/src/main/res/drawable/baseline_attribution_24.xml
+++ b/app/src/main/res/drawable/baseline_attribution_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,8.5c-0.91,0 -2.75,0.46 -2.75,1.38v4.62h1.5V19h2.5v-4.5h1.5V9.88C14.75,8.97 12.91,8.5 12,8.5z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10s10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8s8,3.58 8,8S16.42,20 12,20z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,6.5m-1.5,0a1.5,1.5 0,1 1,3 0a1.5,1.5 0,1 1,-3 0"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_star_24.xml
+++ b/app/src/main/res/drawable/baseline_star_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+    
+</vector>

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -45,7 +45,7 @@
         <item
             android:id="@+id/nav_rate"
             android:checkable="true"
-            android:icon="@android:drawable/btn_star"
+            android:icon="@drawable/baseline_star_24"
             android:title="@string/rateapp" />
         <item
             android:id="@+id/nav_buy_pslab"
@@ -64,6 +64,10 @@
         <item
             android:id="@+id/nav_privacy_policy"
             android:icon="@drawable/baseline_article_24"
-            android:title="@string/privacy_policy"/>
+            android:title="@string/privacy_policy" />
+        <item
+            android:id="@+id/nav_third_party_libs"
+            android:icon="@drawable/baseline_attribution_24"
+            android:title="@string/third_party_libs" />
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1088,7 +1088,7 @@
     <string name="unit_volts">\u0020V</string>
     <string name="no_playback_data">No data to display</string>
     <string name="privacy_policy">Privacy Policy</string>
-    <string name="third_party_libs">Open source licenses</string>
+    <string name="third_party_libs">Open Source Licenses</string>
     <string name="auto_scale_error">No input found</string>
     <string name="auto_scale">Auto</string>
     <string name="control_stop">Stop</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1088,6 +1088,7 @@
     <string name="unit_volts">\u0020V</string>
     <string name="no_playback_data">No data to display</string>
     <string name="privacy_policy">Privacy Policy</string>
+    <string name="third_party_libs">Open source licenses</string>
     <string name="auto_scale_error">No input found</string>
     <string name="auto_scale">Auto</string>
     <string name="control_stop">Stop</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -16,6 +16,11 @@
         <item name="colorPrimaryDark">@color/darkWhite</item>
     </style>
 
+    <style name="OssLicenseScreenTheme" parent="AppTheme">
+        <item name="windowActionBar">true</item>
+        <item name="windowNoTitle">false</item>
+    </style>
+
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,8 @@ buildscript {
     }
     dependencies {
         classpath("io.realm:realm-gradle-plugin:10.18.0")
+        classpath("com.google.android.gms:oss-licenses-plugin:0.10.6")
+
     }
 }
 


### PR DESCRIPTION
Fixes #2498

## Changes 
- I replaced the image of the star in the navigation drawer, the old image was a little bit blurry on my device. The new one should look better.
- I added a new entry called "Open source licenses" to the navigation drawer. It takes the user to an automatically generated overview of 3rd party libraries which are used in the app. Each entry contains a link to the license of the library or the text of the library. (**Only release builds contain the list of libraries, debug build will contain a placeholder.**) 

## Screenshots / Recordings  

https://github.com/user-attachments/assets/e395bff7-9300-444d-ae87-db94204e29d7

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce an automatically generated open source licenses screen accessible from the navigation drawer, and improve the quality of the star image in the navigation drawer. Update the build configuration to include the Google OSS Licenses Plugin.

New Features:
- Add a new entry called 'Open source licenses' to the navigation drawer, which directs users to an automatically generated overview of third-party libraries used in the app, including links to their licenses.

Enhancements:
- Replace the star image in the navigation drawer with a higher quality version to improve visual clarity.

Build:
- Integrate the Google OSS Licenses Plugin into the project by adding it to the build configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->