### PR TITLE
fix: time interval unit UI

### DIFF
--- a/app/src/main/res/layout/activity_create_config.xml
+++ b/app/src/main/res/layout/activity_create_config.xml
@@ -83,7 +83,7 @@
                         android:layout_width="@dimen/width_zero"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:layout_weight="@dimen/weight_three"
+                        android:layout_weight="@dimen/weight_four"
                         android:hint="@string/time_interval_hint"
                         android:imeOptions="actionDone"
                         android:inputType="number"
@@ -94,7 +94,7 @@
                         android:layout_width="@dimen/width_zero"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center"
-                        android:layout_weight="@dimen/weight_one" />
+                        android:layout_weight="@dimen/weight_three" />
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
Fixes #2188 

## Changes 
-  Fixes time interval Unit UI so it shows up correctly in portrait mode

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->
- Landscape Mode
<img width="703" alt="Screenshot 2024-09-10 at 11 12 02 PM" src="https://github.com/user-attachments/assets/37b535f2-16d3-43f3-9e50-aac3f66f2ed9">

- Portrait Mode
<img width="400" alt="Screenshot 2024-09-10 at 11 12 23 PM" src="https://github.com/user-attachments/assets/d12b1e03-e517-4822-b79c-90bffaeb4499">


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [ ] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [ ] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.