### PR TITLE
refactor range select in oscilloscope

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -80,6 +80,7 @@ import io.pslab.others.CSVLogger;
 import io.pslab.others.CustomSnackBar;
 import io.pslab.others.GPSLogger;
 import io.pslab.others.LocalDataLog;
+import io.pslab.others.OscilloscopeAxisScale;
 import io.pslab.others.OscilloscopeMeasurements;
 import io.pslab.others.Plot2D;
 import io.pslab.others.ScienceLabCommon;
@@ -87,7 +88,7 @@ import io.realm.Realm;
 import io.realm.RealmObject;
 import io.realm.RealmResults;
 
-public class OscilloscopeActivity extends GuideActivity implements View.OnClickListener {
+public class OscilloscopeActivity extends GuideActivity implements View.OnClickListener, OscilloscopeAxisScale.AxisScaleSetListener {
 
     private static final CSVDataLine CSV_HEADER = new CSVDataLine()
             .add("Timestamp")
@@ -118,8 +119,6 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
     public double timeGap;
     public double timebase;
     public double maxTimebase = 102.4f;
-    public double xAxisScale = 875f;
-    public double yAxisScale = 16f;
     public boolean isCH1Selected;
     public boolean isCH2Selected;
     public boolean isCH3Selected;
@@ -128,19 +127,15 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
     public boolean isAudioInputSelected;
     public boolean isTriggerSelected;
     public boolean isTriggered;
-    public boolean isFourierTransformSelected;
+    private boolean isFourierTransformSelected;
     public boolean isXYPlotSelected;
     private boolean isDataAnalysisFragSelected;
     public boolean sineFit;
     public boolean squareFit;
-    public boolean isCH1FrequencyRequired;
-    public boolean isCH2FrequencyRequired;
     public String triggerChannel;
     public String triggerMode;
     public String curveFittingChannel1;
     public String curveFittingChannel2;
-    public String xyPlotXAxisChannel;
-    public String xyPlotYAxisChannel;
     public HashMap<String, Double> xOffsets;
     public HashMap<String, Double> yOffsets;
     public double trigger;
@@ -219,6 +214,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
     private ArrayList<ArrayList<Entry>> dataEntries = new ArrayList<>();
     private String[] dataParamsChannels;
 
+    private OscilloscopeAxisScale axisScale;
+
     public enum CHANNEL {CH1, CH2, CH3, MIC}
 
     private enum MODE {RISING, FALLING, DUAL}
@@ -242,12 +239,9 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY;
         getWindow().getDecorView().setSystemUiVisibility(flags);
         final View decorView = getWindow().getDecorView();
-        decorView.setOnSystemUiVisibilityChangeListener(new View.OnSystemUiVisibilityChangeListener() {
-            @Override
-            public void onSystemUiVisibilityChange(int i) {
-                if ((i & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
-                    decorView.setSystemUiVisibility(flags);
-                }
+        decorView.setOnSystemUiVisibilityChangeListener(i -> {
+            if ((i & View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
+                decorView.setSystemUiVisibility(flags);
             }
         });
         ButterKnife.bind(this);
@@ -285,6 +279,9 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         samples = 512;
         timeGap = 2;
 
+        axisScale = new OscilloscopeAxisScale();
+        axisScale.addAxisScaledListener(this);
+
         xOffsets = new HashMap<>();
         xOffsets.put(CHANNEL.CH1.toString(), 0.0);
         xOffsets.put(CHANNEL.CH2.toString(), 0.0);
@@ -302,11 +299,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         graph = new Plot2D(this, new float[]{}, new float[]{}, 1);
         curveFittingChannel1 = "None";
         curveFittingChannel2 = "None";
-        xyPlotXAxisChannel = CHANNEL.CH1.toString();
-        xyPlotYAxisChannel = CHANNEL.CH2.toString();
         analyticsClass = new AnalyticsClass();
-        isCH1FrequencyRequired = false;
-        isCH2FrequencyRequired = false;
 
         Display display = getWindowManager().getDefaultDisplay();
         Point size = new Point();
@@ -463,13 +456,10 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                     item.setIcon(R.drawable.ic_record_white);
                     CustomSnackBar.showSnackBar(mainLayout,
                             getString(R.string.csv_store_text) + " " + csvLogger.getCurrentFilePath()
-                            , getString(R.string.open), new View.OnClickListener() {
-                                @Override
-                                public void onClick(View view) {
-                                    Intent intent = new Intent(OscilloscopeActivity.this, DataLoggerActivity.class);
-                                    intent.putExtra(DataLoggerActivity.CALLER_ACTIVITY, getResources().getString(R.string.oscilloscope));
-                                    startActivity(intent);
-                                }
+                            , getString(R.string.open), view -> {
+                                Intent intent = new Intent(OscilloscopeActivity.this, DataLoggerActivity.class);
+                                intent.putExtra(DataLoggerActivity.CALLER_ACTIVITY, getResources().getString(R.string.oscilloscope));
+                                startActivity(intent);
                             }, Snackbar.LENGTH_SHORT);
                 } else if (!isRecording && !scienceLab.isConnected()) {
                     CustomSnackBar.showSnackBar(mainLayout, getString(R.string.device_not_connected), null, null, Snackbar.LENGTH_SHORT);
@@ -560,77 +550,74 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         playbackTimer.schedule(new TimerTask() {
             @Override
             public void run() {
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        try {
-                            if (currentPosition < recordedOscilloscopeData.size()) {
-                                OscilloscopeData data = recordedOscilloscopeData.get(currentPosition);
-                                int mode = data.getMode();
-                                List<ILineDataSet> dataSets = new ArrayList<>();
-                                ArrayList<ArrayList<Entry>> entries = new ArrayList<>();
-                                for (int i = 0; i < mode; i++) {
-                                    data = recordedOscilloscopeData.get(currentPosition);
-                                    entries.add(new ArrayList<>());
-                                    String[] xData = data.getDataX().split(" ");
-                                    String[] yData = data.getDataY().split(" ");
-                                    if (!isPlaybackFourierChecked) {
-                                        int n = Math.min(xData.length, yData.length);
-                                        for (int j = 0; j < n; j++) {
-                                            if (xData[j].length() > 0 && yData[j].length() > 0) {
-                                                entries.get(i).add(new Entry(Float.valueOf(xData[j]), Float.valueOf(yData[j])));
-                                            }
+                handler.post(() -> {
+                    try {
+                        if (currentPosition < recordedOscilloscopeData.size()) {
+                            OscilloscopeData data = recordedOscilloscopeData.get(currentPosition);
+                            int mode = data.getMode();
+                            List<ILineDataSet> dataSets = new ArrayList<>();
+                            ArrayList<ArrayList<Entry>> entries = new ArrayList<>();
+                            for (int i = 0; i < mode; i++) {
+                                data = recordedOscilloscopeData.get(currentPosition);
+                                entries.add(new ArrayList<>());
+                                String[] xData = data.getDataX().split(" ");
+                                String[] yData = data.getDataY().split(" ");
+                                if (!isPlaybackFourierChecked) {
+                                    int n = Math.min(xData.length, yData.length);
+                                    for (int j = 0; j < n; j++) {
+                                        if (xData[j].length() > 0 && yData[j].length() > 0) {
+                                            entries.get(i).add(new Entry(Float.parseFloat(xData[j]), Float.parseFloat(yData[j])));
                                         }
-                                        setLeftYAxisScale(16f, -16f);
-                                        setRightYAxisScale(16f, -16f);
-                                        setXAxisScale(data.getTimebase());
-                                    } else {
-                                        Complex[] yComplex = new Complex[yData.length];
-                                        for (int j = 0; j < yData.length; j++) {
-                                            yComplex[j] = Complex.valueOf(Double.valueOf(yData[j]));
-                                        }
-                                        Complex[] fftOut = fft(yComplex);
-                                        int n = fftOut.length;
-                                        double mA = 0;
-                                        double factor = samples * timeGap * 1e-3;
-                                        double mF = (n / 2 - 1) / factor;
-                                        for (int j = 0; j < n / 2; j++) {
-                                            float y = (float) fftOut[j].abs() / samples;
-                                            if (y > mA) {
-                                                mA = y;
-                                            }
-                                            entries.get(i).add(new Entry((float) (j / factor), y));
-                                        }
-                                        setLeftYAxisScale(mA, 0);
-                                        setRightYAxisScale(mA, 0);
-                                        setXAxisScale(mF);
                                     }
-                                    currentPosition++;
-                                    LineDataSet dataSet;
-                                    dataSet = new LineDataSet(entries.get(i), data.getChannel());
-                                    dataSet.setDrawCircles(false);
-                                    dataSet.setColor(channelColors[i]);
-                                    dataSets.add(dataSet);
-                                    ((OscilloscopePlaybackFragment) playbackFragment).setTimeBase(String.valueOf(data.getTimebase()));
+                                    axisScale.setLeftYAxisScale(16f, -16f);
+                                    axisScale.setRightYAxisScale(16f, -16f);
+                                    axisScale.setXAxisScale(data.getTimebase());
+                                } else {
+                                    Complex[] yComplex = new Complex[yData.length];
+                                    for (int j = 0; j < yData.length; j++) {
+                                        yComplex[j] = Complex.valueOf(Double.parseDouble(yData[j]));
+                                    }
+                                    Complex[] fftOut = fft(yComplex);
+                                    int n = fftOut.length;
+                                    double mA = 0;
+                                    double factor = samples * timeGap * 1e-3;
+                                    double mF = (n / 2 - 1) / factor;
+                                    for (int j = 0; j < n / 2; j++) {
+                                        float y = (float) fftOut[j].abs() / samples;
+                                        if (y > mA) {
+                                            mA = y;
+                                        }
+                                        entries.get(i).add(new Entry((float) (j / factor), y));
+                                    }
+                                    axisScale.setLeftYAxisScale(mA, 0);
+                                    axisScale.setRightYAxisScale(mA, 0);
+                                    axisScale.setXAxisScale(mF);
                                 }
-                                LineData lineData = new LineData(dataSets);
-                                mChart.setData(lineData);
-                                mChart.notifyDataSetChanged();
-                                mChart.invalidate();
-                            } else {
-                                playbackTimer.cancel();
-                                playbackTimer = null;
-                                playMenu.setIcon(R.drawable.ic_play_arrow_white_24dp);
-                                currentPosition = 0;
+                                currentPosition++;
+                                LineDataSet dataSet;
+                                dataSet = new LineDataSet(entries.get(i), data.getChannel());
+                                dataSet.setDrawCircles(false);
+                                dataSet.setColor(channelColors[i]);
+                                dataSets.add(dataSet);
+                                ((OscilloscopePlaybackFragment) playbackFragment).setTimeBase(String.valueOf(data.getTimebase()));
                             }
-                        } catch (Exception e) {
-                            if (playbackTimer != null) {
-                                playbackTimer.cancel();
-                                playbackTimer = null;
-                            }
+                            LineData lineData = new LineData(dataSets);
+                            mChart.setData(lineData);
+                            mChart.notifyDataSetChanged();
+                            mChart.invalidate();
+                        } else {
+                            playbackTimer.cancel();
+                            playbackTimer = null;
                             playMenu.setIcon(R.drawable.ic_play_arrow_white_24dp);
                             currentPosition = 0;
                         }
+                    } catch (Exception e) {
+                        if (playbackTimer != null) {
+                            playbackTimer.cancel();
+                            playbackTimer = null;
+                        }
+                        playMenu.setIcon(R.drawable.ic_play_arrow_white_24dp);
+                        currentPosition = 0;
                     }
                 });
 
@@ -645,12 +632,26 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         }
     }
 
+    public void setFourierTransformSelected(boolean isSelected) {
+        isFourierTransformSelected = isSelected;
+
+        if (isFourierTransformSelected) {
+            axisScale.setXAxisScale(maxFreq);
+            axisScale.setLeftYAxisScale(maxAmp, 0);
+            axisScale.setRightYAxisScale(maxAmp, 0);
+        } else {
+            axisScale.setXAxisScale(OscilloscopeAxisScale.DEFAULT_X_AXIS_SCALE);
+            axisScale.setLeftYAxisScale(OscilloscopeAxisScale.DEFAULT_Y_AXIS_SCALE);
+            axisScale.setRightYAxisScale(OscilloscopeAxisScale.DEFAULT_Y_AXIS_SCALE);
+        }
+    }
+
     private void logChannelData(String[] channels) {
         long timestamp = System.currentTimeMillis();
         int noOfChannels = channels.length;
         String dateTime = CSVLogger.FILE_NAME_FORMAT.format(new Date(timestamp));
         for (int i = 0; i < noOfChannels; i++) {
-            recordSensorData(new OscilloscopeData(timestamp + i, block, noOfChannels, channels[i], loggingXdata, loggingYdata[i], xAxisScale, lat, lon));
+            recordSensorData(new OscilloscopeData(timestamp + i, block, noOfChannels, channels[i], loggingXdata, loggingYdata[i], axisScale.getXAxisScale(), lat, lon));
             csvLogger.writeCSVFile(
                     new CSVDataLine()
                             .add(timestamp)
@@ -659,7 +660,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                             .add(channels[i])
                             .add(loggingXdata)
                             .add(loggingYdata[i])
-                            .add(xAxisScale)
+                            .add(axisScale.getXAxisScale())
                             .add(lat)
                             .add(lon)
             );
@@ -828,7 +829,12 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         y2.setEnabled(true);
     }
 
-    public void setXAxisScale(double timebase) {
+    public OscilloscopeAxisScale getAxisScale() {
+        return axisScale;
+    }
+
+    @Override
+    public void onXAxisScaleSet(double timebase) {
         x1.setAxisMinimum(0);
         x1.setAxisMaximum((float) timebase);
         if (timebase == 875f)
@@ -841,7 +847,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         mChart.invalidate();
     }
 
-    public void setLeftYAxisScale(double upperLimit, double lowerLimit) {
+    @Override
+    public void onLeftYAxisScaleSet(double upperLimit, double lowerLimit) {
         y1.setAxisMaximum((float) upperLimit);
         y1.setAxisMinimum((float) lowerLimit);
         if (upperLimit == 500f)
@@ -852,7 +859,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         mChart.invalidate();
     }
 
-    public void setRightYAxisScale(double upperLimit, double lowerLimit) {
+    @Override
+    public void onRightYAxisScaleSet(double upperLimit, double lowerLimit) {
         y2.setAxisMaximum((float) upperLimit);
         y2.setAxisMinimum((float) lowerLimit);
         if (upperLimit == 500f)
@@ -1089,12 +1097,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                     for (int i = 0; i < yDataString.size(); i++) {
                         loggingYdata[i] = StringUtils.join(" ", yDataString.get(i));
                     }
-                    runOnUiThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            logChannelData(paramsChannels);
-                        }
-                    });
+                    runOnUiThread(() -> logChannelData(paramsChannels));
                 }
 
             } catch (NullPointerException e) {
@@ -1176,15 +1179,6 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                 dataSets.add(dataSet);
             }
             LineData data = new LineData(dataSets);
-            if (isFourierTransformSelected) {
-                setXAxisScale(maxFreq);
-                setLeftYAxisScale(maxAmp, 0);
-                setRightYAxisScale(maxAmp, 0);
-            } else {
-                setXAxisScale(xAxisScale);
-                setLeftYAxisScale(yAxisScale, -1 * yAxisScale);
-                setRightYAxisScale(yAxisScale, -1 * yAxisScale);
-            }
             if (isMeasurementsChecked) {
                 RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(OscilloscopeActivity.this);
                 measurementsList.setItemAnimator(new DefaultItemAnimator());
@@ -1238,7 +1232,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         yRange = maxY - minY;
         yPadding = yRange * 0.1;
         if (maxPeriod > 0) {
-            xAxisScale = Math.min((maxPeriod * 5), maxTimebase);
+            double xAxisScale = Math.min((maxPeriod * 5), maxTimebase);
+            double yAxisScale;
             if (Math.abs(maxY) >= Math.abs(minY)) {
                 yAxisScale = maxY + yPadding;
             } else {
@@ -1246,6 +1241,11 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
             }
             samples = 512;
             timeGap = (2 * xAxisScale * 1000.0) / samples;
+
+            axisScale.setXAxisScale(xAxisScale);
+            // TODO: Anashuman, is this correct?
+            axisScale.setLeftYAxisScale(yAxisScale);
+            axisScale.setRightYAxisScale(yAxisScale);
         } else {
             Toast.makeText(this, getString(R.string.auto_scale_error), Toast.LENGTH_SHORT).show();
         }

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1244,7 +1244,6 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
             timeGap = (2 * xAxisScale * 1000.0) / samples;
 
             axisScale.setXAxisScale(xAxisScale);
-            // TODO: Anashuman, is this correct?
             axisScale.setLeftYAxisScale(yAxisScale);
             axisScale.setRightYAxisScale(yAxisScale);
         } else {

--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -635,11 +635,7 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
     public void setFourierTransformSelected(boolean isSelected) {
         isFourierTransformSelected = isSelected;
 
-        if (isFourierTransformSelected) {
-            axisScale.setXAxisScale(maxFreq);
-            axisScale.setLeftYAxisScale(maxAmp, 0);
-            axisScale.setRightYAxisScale(maxAmp, 0);
-        } else {
+        if (!isFourierTransformSelected) {
             axisScale.setXAxisScale(OscilloscopeAxisScale.DEFAULT_X_AXIS_SCALE);
             axisScale.setLeftYAxisScale(OscilloscopeAxisScale.DEFAULT_Y_AXIS_SCALE);
             axisScale.setRightYAxisScale(OscilloscopeAxisScale.DEFAULT_Y_AXIS_SCALE);
@@ -1179,6 +1175,11 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                 dataSets.add(dataSet);
             }
             LineData data = new LineData(dataSets);
+            if (isFourierTransformSelected) {
+                axisScale.setXAxisScale(maxFreq);
+                axisScale.setLeftYAxisScale(maxAmp, 0);
+                axisScale.setRightYAxisScale(maxAmp, 0);
+            }
             if (isMeasurementsChecked) {
                 RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(OscilloscopeActivity.this);
                 measurementsList.setItemAnimator(new DefaultItemAnimator());

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -28,7 +28,7 @@ public class ChannelParametersFragment extends Fragment {
 
     private static final int RECORD_AUDIO_REQUEST_CODE = 1;
 
-    private static final double[] VOLTAGE_VALUES = {16, 8, 4, 3, 2, 1.5, 1, 500, 160};
+    private static final double[] VOLTAGE_VALUES = {16, 8, 4, 3, 2, 1.5, 1, 0.5, 160};
 
     private Spinner spinnerRangeCh1;
     private Spinner spinnerRangeCh2;

--- a/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
+++ b/app/src/main/java/io/pslab/fragment/ChannelParametersFragment.java
@@ -2,22 +2,19 @@ package io.pslab.fragment;
 
 import android.Manifest;
 import android.app.AlertDialog;
-import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-
-import androidx.annotation.NonNull;
-import androidx.core.content.ContextCompat;
-import androidx.fragment.app.Fragment;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.Spinner;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 
 import com.google.android.material.snackbar.Snackbar;
 
@@ -25,43 +22,44 @@ import io.pslab.DataFormatter;
 import io.pslab.R;
 import io.pslab.activity.OscilloscopeActivity;
 import io.pslab.others.CustomSnackBar;
+import io.pslab.others.OscilloscopeAxisScale;
 
 public class ChannelParametersFragment extends Fragment {
 
     private static final int RECORD_AUDIO_REQUEST_CODE = 1;
 
-    private CheckBox checkBoxCH1;
-    private CheckBox checkBoxCH2;
-    private CheckBox checkBoxCH3;
+    private static final double[] VOLTAGE_VALUES = {16, 8, 4, 3, 2, 1.5, 1, 500, 160};
+
     private Spinner spinnerRangeCh1;
     private Spinner spinnerRangeCh2;
     private Spinner spinnerChannelSelect;
     private CheckBox builtInMicCheckBox;
     private CheckBox pslabMicCheckBox;
+    private OscilloscopeAxisScale axisScale;
 
     public static ChannelParametersFragment newInstance() {
         return new ChannelParametersFragment();
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
         View v = inflater.inflate(R.layout.fragment_channel_parameters, container, false);
 
-        final String[] ranges = {"+/-16V", "+/-8V", "+/-4V", "+/-3V", "+/-2V",
-                "+/-1" + DataFormatter.decSeparator + "5V", "+/-1V", "+/-500mV", "+/-160V"};
+        final String[] ranges = {"+/-16V", "+/-8V", "+/-4V", "+/-3V", "+/-2V", "+/-1" + DataFormatter.decSeparator + "5V", "+/-1V", "+/-500mV", "+/-160V"};
         final String[] channels = {"CH1", "CH2", "CH3", "MIC", "CAP", "RES", "VOL"};
         final String[] mics = {"MICROPHONE", "IN-BUILT MIC"};
+
+        axisScale = ((OscilloscopeActivity) getActivity()).getAxisScale();
 
         spinnerRangeCh1 = v.findViewById(R.id.spinner_range_ch1_cp);
         spinnerRangeCh2 = v.findViewById(R.id.spinner_range_ch2_cp);
         spinnerChannelSelect = v.findViewById(R.id.spinner_channel_select_cp);
 
         boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
-        checkBoxCH1 = v.findViewById(R.id.checkBox_ch1_cp);
-        checkBoxCH2 = v.findViewById(R.id.checkBox_ch2_cp);
-        checkBoxCH3 = v.findViewById(R.id.checkBox_ch3_cp);
+        CheckBox checkBoxCH1 = v.findViewById(R.id.checkBox_ch1_cp);
+        CheckBox checkBoxCH2 = v.findViewById(R.id.checkBox_ch2_cp);
+        CheckBox checkBoxCH3 = v.findViewById(R.id.checkBox_ch3_cp);
         checkBoxCH3.setText(getString(R.string.ch3_value, 3.3));
 
         builtInMicCheckBox = v.findViewById(R.id.built_in_mic_cb);
@@ -93,36 +91,7 @@ public class ChannelParametersFragment extends Fragment {
         spinnerRangeCh1.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                switch (position) {
-                    case 0:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(16, -16);
-                        break;
-                    case 1:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(8, -8);
-                        break;
-                    case 2:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(4, -4);
-                        break;
-                    case 3:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(3, -3);
-                        break;
-                    case 4:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(2, -2);
-                        break;
-                    case 5:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(1.5, -1.5);
-                        break;
-                    case 6:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(1, -1);
-                        break;
-                    case 7:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(500, -500);
-                        break;
-                    case 8:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(160, -160);
-                        openAlertDialogBox("CH1");
-                        break;
-                }
+                axisScale.setLeftYAxisScale(VOLTAGE_VALUES[position]);
             }
 
             @Override
@@ -134,36 +103,7 @@ public class ChannelParametersFragment extends Fragment {
         spinnerRangeCh2.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                switch (position) {
-                    case 0:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(16, -16);
-                        break;
-                    case 1:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(8, -8);
-                        break;
-                    case 2:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(4, -4);
-                        break;
-                    case 3:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(3, -3);
-                        break;
-                    case 4:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(2, -2);
-                        break;
-                    case 5:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(1.5, -1.5);
-                        break;
-                    case 6:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(1, -1);
-                        break;
-                    case 7:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(500, -500);
-                        break;
-                    case 8:
-                        ((OscilloscopeActivity) getActivity()).setRightYAxisScale(160, -160);
-                        openAlertDialogBox("CH2");
-                        break;
-                }
+                axisScale.setRightYAxisScale(VOLTAGE_VALUES[position]);
             }
 
             @Override
@@ -181,31 +121,31 @@ public class ChannelParametersFragment extends Fragment {
                         spinnerRangeCh1.setEnabled(true);
                         break;
                     case 1:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(16, -16);
+                        axisScale.setLeftYAxisScale(16, -16);
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         spinnerRangeCh1.setEnabled(false);
                         break;
                     case 2:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(3, -3);
+                        axisScale.setLeftYAxisScale(3, -3);
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         spinnerRangeCh1.setEnabled(false);
                         break;
                     case 3:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(3, -3);
+                        axisScale.setLeftYAxisScale(3, -3);
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         break;
                     case 4:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(3, 0);
+                        axisScale.setLeftYAxisScale(3, 0);
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         spinnerRangeCh1.setEnabled(false);
                         break;
                     case 5:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(3, 0);
+                        axisScale.setLeftYAxisScale(3, 0);
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         spinnerRangeCh1.setEnabled(false);
                         break;
                     case 6:
-                        ((OscilloscopeActivity) getActivity()).setLeftYAxisScale(3, 0);
+                        axisScale.setLeftYAxisScale(3, 0);
                         ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect.getSelectedItem().toString());
                         spinnerRangeCh1.setEnabled(false);
                         break;
@@ -218,63 +158,42 @@ public class ChannelParametersFragment extends Fragment {
             }
         });
 
-        checkBoxCH1.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isCH1Selected = isChecked;
-            }
-        });
+        checkBoxCH1.setOnCheckedChangeListener((buttonView, isChecked) -> ((OscilloscopeActivity) getActivity()).isCH1Selected = isChecked);
 
-        checkBoxCH2.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isCH2Selected = isChecked;
-            }
-        });
+        checkBoxCH2.setOnCheckedChangeListener((buttonView, isChecked) -> ((OscilloscopeActivity) getActivity()).isCH2Selected = isChecked);
 
-        checkBoxCH3.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isCH3Selected = isChecked;
-            }
-        });
-        builtInMicCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = isChecked;
-                ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
-                if (isChecked) {
-                    ((OscilloscopeActivity) getActivity()).maxTimebase = 38.4f;
-                    if (pslabMicCheckBox.isChecked()) {
-                        ((OscilloscopeActivity) getActivity()).isMICSelected = false;
-                        pslabMicCheckBox.setChecked(false);
-                        ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
-                    }
-                    if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-                        requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
-                        ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;
-                    }
-                } else {
-                    ((OscilloscopeActivity) getActivity()).maxTimebase = 102.4f;
+        checkBoxCH3.setOnCheckedChangeListener((buttonView, isChecked) -> ((OscilloscopeActivity) getActivity()).isCH3Selected = isChecked);
+        builtInMicCheckBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = isChecked;
+            ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
+            if (isChecked) {
+                ((OscilloscopeActivity) getActivity()).maxTimebase = 38.4f;
+                if (pslabMicCheckBox.isChecked()) {
+                    ((OscilloscopeActivity) getActivity()).isMICSelected = false;
+                    pslabMicCheckBox.setChecked(false);
+                    ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
                 }
+                if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+                    requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
+                    ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;
+                }
+            } else {
+                ((OscilloscopeActivity) getActivity()).maxTimebase = 102.4f;
             }
         });
 
-        pslabMicCheckBox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isMICSelected = isChecked;
-                ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
-                if (isChecked) {
-                    if (builtInMicCheckBox.isChecked()) {
-                        ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = false;
-                        builtInMicCheckBox.setChecked(false);
-                        ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
-                    }
-                    if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
-                        requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
-                        ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;
-                    }
+        pslabMicCheckBox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            ((OscilloscopeActivity) getActivity()).isMICSelected = isChecked;
+            ((OscilloscopeActivity) getActivity()).isAudioInputSelected = isChecked;
+            if (isChecked) {
+                if (builtInMicCheckBox.isChecked()) {
+                    ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = false;
+                    builtInMicCheckBox.setChecked(false);
+                    ((OscilloscopeActivity) getActivity()).isAudioInputSelected = true;
+                }
+                if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.RECORD_AUDIO) != PackageManager.PERMISSION_GRANTED) {
+                    requestPermissions(new String[]{Manifest.permission.RECORD_AUDIO}, RECORD_AUDIO_REQUEST_CODE);
+                    ((OscilloscopeActivity) getActivity()).isAudioInputSelected = false;
                 }
             }
         });
@@ -287,24 +206,14 @@ public class ChannelParametersFragment extends Fragment {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 ((OscilloscopeActivity) getActivity()).isInBuiltMicSelected = true;
             } else {
-                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content),
-                        "This feature won't work.", null, null, Snackbar.LENGTH_SHORT);
-                if (builtInMicCheckBox.isChecked())
-                    builtInMicCheckBox.toggle();
+                CustomSnackBar.showSnackBar(getActivity().findViewById(android.R.id.content), "This feature won't work.", null, null, Snackbar.LENGTH_SHORT);
+                if (builtInMicCheckBox.isChecked()) builtInMicCheckBox.toggle();
             }
         }
     }
 
     private void openAlertDialogBox(String inputSource) {
-        new AlertDialog.Builder(getActivity())
-                .setIcon(android.R.drawable.ic_dialog_alert)
-                .setTitle("Message")
-                .setMessage("Connect a 10MOhm resistor with " + inputSource)
-                .setPositiveButton("OK", new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                    }
-                })
-                .show();
+        new AlertDialog.Builder(getActivity()).setIcon(android.R.drawable.ic_dialog_alert).setTitle("Message").setMessage("Connect a 10MOhm resistor with " + inputSource).setPositiveButton("OK", (dialog, which) -> {
+        }).show();
     }
 }

--- a/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
@@ -1,40 +1,36 @@
 package io.pslab.fragment;
 
 import android.os.Bundle;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.Spinner;
-import android.widget.TextView;
 
 import androidx.fragment.app.Fragment;
 
 import io.pslab.R;
 import io.pslab.activity.OscilloscopeActivity;
 import io.pslab.others.FloatSeekBar;
+import io.pslab.others.OscilloscopeAxisScale;
 
 public class DataAnalysisFragment extends Fragment {
 
-    private Spinner spinnerCurveFit;
     private Spinner spinnerChannelSelect1;
     private Spinner spinnerChannelSelect2;
-    private CheckBox checkBoxFouierTransform;
     private Spinner spinnerChannelSelectHorizontalOffset;
     private Spinner spinnerChannelSelectVerticalOffset;
     private FloatSeekBar seekBarHorizontalOffset;
     private FloatSeekBar seekBarVerticalOffset;
     private EditText editTextHorizontalOffset;
     private EditText editTextVerticalOffset;
-    boolean _ignore = false;
+    private OscilloscopeAxisScale axisScale;
+    private boolean ignore = false;
 
     public static DataAnalysisFragment newInstance() {
         return new DataAnalysisFragment();
@@ -47,7 +43,7 @@ public class DataAnalysisFragment extends Fragment {
         String[] curveFits = {"Sine Fit", "Square Fit"};
         String[] channels = {"None", "CH1", "CH2", "CH3", "MIC"};
 
-        spinnerCurveFit = v.findViewById(R.id.spinner_curve_fit_da);
+        Spinner spinnerCurveFit = v.findViewById(R.id.spinner_curve_fit_da);
         spinnerChannelSelect1 = v.findViewById(R.id.spinner_channel_select_da1);
         spinnerChannelSelect2 = v.findViewById(R.id.spinner_channel_select_da2);
         spinnerChannelSelectHorizontalOffset = v.findViewById(R.id.spinner_channel_select_horizontal_offset);
@@ -56,10 +52,12 @@ public class DataAnalysisFragment extends Fragment {
         seekBarVerticalOffset = v.findViewById(R.id.seekbar_vertical_offset);
         editTextHorizontalOffset = v.findViewById(R.id.edittext_horizontal_offset);
         editTextVerticalOffset = v.findViewById(R.id.edittext_vertical_offset);
-        checkBoxFouierTransform = v.findViewById(R.id.checkBox_fourier_da);
+        CheckBox checkBoxFouierTransform = v.findViewById(R.id.checkBox_fourier_da);
         boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
         ArrayAdapter<String> curveFitAdapter;
         ArrayAdapter<String> adapter;
+
+        axisScale = ((OscilloscopeActivity) this.getActivity()).getAxisScale();
 
         if (tabletSize) {
             curveFitAdapter = new ArrayAdapter<>(this.getActivity(), R.layout.custom_spinner_tablet, curveFits);
@@ -154,15 +152,15 @@ public class DataAnalysisFragment extends Fragment {
             }
         });
 
-        if (((OscilloscopeActivity) getActivity()).xAxisScale == 875) {
-            seekBarHorizontalOffset.setters(0, ((OscilloscopeActivity) getActivity()).xAxisScale / 1000.0);
+        if (axisScale.getXAxisScale() == 875) {
+            seekBarHorizontalOffset.setters(0, axisScale.getXAxisScale() / 1000.0);
         } else {
-            seekBarHorizontalOffset.setters(0, ((OscilloscopeActivity) getActivity()).xAxisScale);
+            seekBarHorizontalOffset.setters(0, axisScale.getXAxisScale());
         }
         seekBarHorizontalOffset.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
-                if (!_ignore) {
+                if (!ignore) {
                     editTextHorizontalOffset.setText(String.format("%s", seekBarHorizontalOffset.getValue()));
                     ((OscilloscopeActivity) getActivity()).xOffsets.put(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString(), seekBarHorizontalOffset.getValue());
                 }
@@ -181,11 +179,12 @@ public class DataAnalysisFragment extends Fragment {
         seekBarHorizontalOffset.setProgress(100);
         seekBarHorizontalOffset.setProgress(0);
 
-        seekBarVerticalOffset.setters(-1 * ((OscilloscopeActivity) getActivity()).yAxisScale, ((OscilloscopeActivity) getActivity()).yAxisScale);
+        // TODO: Anashuman, is this correct?
+        seekBarVerticalOffset.setters(-1 * axisScale.getLeftYAxisScaleUpper(), axisScale.getLeftYAxisScaleUpper());
         seekBarVerticalOffset.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
-                if (!_ignore) {
+                if (!ignore) {
                     editTextVerticalOffset.setText(String.format("%s", seekBarVerticalOffset.getValue()));
                     ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
                 }
@@ -203,87 +202,70 @@ public class DataAnalysisFragment extends Fragment {
         });
         seekBarVerticalOffset.setProgress(50);
 
-        editTextHorizontalOffset.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-                editTextHorizontalOffset.setCursorVisible(true);
-                return false;
-            }
+        editTextHorizontalOffset.setOnTouchListener((v1, event) -> {
+            editTextHorizontalOffset.setCursorVisible(true);
+            return false;
         });
 
-        editTextHorizontalOffset.setOnEditorActionListener(new EditText.OnEditorActionListener() {
-            @Override
-            public boolean onEditorAction(TextView textView, int i, KeyEvent keyEvent) {
-                if (i == EditorInfo.IME_ACTION_DONE) {
-                    if (!editTextHorizontalOffset.getText().toString().isEmpty() && !editTextHorizontalOffset.getText().toString().equals("-") && !editTextHorizontalOffset.getText().toString().equals(".") && !editTextVerticalOffset.getText().toString().equals("-.")) {
-                        double xAxisScale = (((OscilloscopeActivity) getActivity()).xAxisScale == 875) ? ((OscilloscopeActivity) getActivity()).xAxisScale / 1000.0 : ((OscilloscopeActivity) getActivity()).xAxisScale;
-                        _ignore = true;
-                        if (Double.parseDouble(editTextHorizontalOffset.getText().toString()) > xAxisScale) {
-                            editTextHorizontalOffset.setText(String.format("%s", xAxisScale));
-                            seekBarHorizontalOffset.setValue(xAxisScale);
-                            ((OscilloscopeActivity) getActivity()).xOffsets.put(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString(), seekBarHorizontalOffset.getValue());
-                            _ignore = false;
-                        } else {
-                            seekBarHorizontalOffset.setValue(Double.parseDouble(editTextHorizontalOffset.getText().toString()));
-                            editTextHorizontalOffset.setText(String.format("%s", Double.parseDouble(editTextHorizontalOffset.getText().toString())));
-                            ((OscilloscopeActivity) getActivity()).xOffsets.put(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString(), seekBarHorizontalOffset.getValue());
-                            _ignore = false;
-                        }
+        editTextHorizontalOffset.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (!editTextHorizontalOffset.getText().toString().isEmpty() && !editTextHorizontalOffset.getText().toString().equals("-") && !editTextHorizontalOffset.getText().toString().equals(".") && !editTextVerticalOffset.getText().toString().equals("-.")) {
+                    double xAxisScale = (axisScale.getXAxisScale() == 875) ? axisScale.getXAxisScale() / 1000.0 : axisScale.getXAxisScale();
+                    ignore = true;
+                    if (Double.parseDouble(editTextHorizontalOffset.getText().toString()) > xAxisScale) {
+                        editTextHorizontalOffset.setText(String.format("%s", xAxisScale));
+                        seekBarHorizontalOffset.setValue(xAxisScale);
+                        ((OscilloscopeActivity) getActivity()).xOffsets.put(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString(), seekBarHorizontalOffset.getValue());
+                        ignore = false;
                     } else {
-                        seekBarHorizontalOffset.setProgress(0);
+                        seekBarHorizontalOffset.setValue(Double.parseDouble(editTextHorizontalOffset.getText().toString()));
+                        editTextHorizontalOffset.setText(String.format("%s", Double.parseDouble(editTextHorizontalOffset.getText().toString())));
+                        ((OscilloscopeActivity) getActivity()).xOffsets.put(spinnerChannelSelectHorizontalOffset.getSelectedItem().toString(), seekBarHorizontalOffset.getValue());
+                        ignore = false;
                     }
+                } else {
+                    seekBarHorizontalOffset.setProgress(0);
                 }
-                editTextHorizontalOffset.setCursorVisible(false);
-                return false;
             }
+            editTextHorizontalOffset.setCursorVisible(false);
+            return false;
         });
 
-        editTextVerticalOffset.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-                editTextVerticalOffset.setCursorVisible(true);
-                return false;
-            }
+        editTextVerticalOffset.setOnTouchListener((v12, event) -> {
+            editTextVerticalOffset.setCursorVisible(true);
+            return false;
         });
 
-        editTextVerticalOffset.setOnEditorActionListener(new EditText.OnEditorActionListener() {
-            @Override
-            public boolean onEditorAction(TextView textView, int i, KeyEvent keyEvent) {
-                if (i == EditorInfo.IME_ACTION_DONE) {
-                    if (!editTextVerticalOffset.getText().toString().isEmpty() && !editTextVerticalOffset.getText().toString().equals("-") && !editTextVerticalOffset.getText().toString().equals(".") && !editTextVerticalOffset.getText().toString().equals("-.")) {
-                        _ignore = true;
-                        if (Double.parseDouble(editTextVerticalOffset.getText().toString()) > ((OscilloscopeActivity) getActivity()).yAxisScale) {
-                            editTextVerticalOffset.setText(String.format("%s", ((OscilloscopeActivity) getActivity()).yAxisScale));
-                            seekBarVerticalOffset.setValue(((OscilloscopeActivity) getActivity()).yAxisScale);
-                            ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
-                            _ignore = false;
-                        } else if (Double.parseDouble(editTextVerticalOffset.getText().toString()) < -((OscilloscopeActivity) getActivity()).yAxisScale) {
-                            editTextVerticalOffset.setText(String.format("%s", -((OscilloscopeActivity) getActivity()).yAxisScale));
-                            seekBarVerticalOffset.setValue(-((OscilloscopeActivity) getActivity()).yAxisScale);
-                            ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
-                            _ignore = false;
-                        } else {
-                            seekBarVerticalOffset.setValue(Double.parseDouble(editTextVerticalOffset.getText().toString()));
-                            editTextVerticalOffset.setText(String.format("%s", Double.parseDouble(editTextVerticalOffset.getText().toString())));
-                            ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
-                            _ignore = false;
-                        }
+        editTextVerticalOffset.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                if (!editTextVerticalOffset.getText().toString().isEmpty() && !editTextVerticalOffset.getText().toString().equals("-") && !editTextVerticalOffset.getText().toString().equals(".") && !editTextVerticalOffset.getText().toString().equals("-.")) {
+                    ignore = true;
+                    if (Double.parseDouble(editTextVerticalOffset.getText().toString()) > axisScale.getXAxisScale()) {
+                        editTextVerticalOffset.setText(String.format("%s", axisScale.getXAxisScale()));
+                        seekBarVerticalOffset.setValue(axisScale.getXAxisScale());
+                        ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
+                        ignore = false;
+                    } else if (Double.parseDouble(editTextVerticalOffset.getText().toString()) < -axisScale.getXAxisScale()) {
+                        editTextVerticalOffset.setText(String.format("%s", -axisScale.getXAxisScale()));
+                        seekBarVerticalOffset.setValue(-axisScale.getXAxisScale());
+                        ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
+                        ignore = false;
                     } else {
-                        seekBarVerticalOffset.setProgress(50);
+                        seekBarVerticalOffset.setValue(Double.parseDouble(editTextVerticalOffset.getText().toString()));
+                        editTextVerticalOffset.setText(String.format("%s", Double.parseDouble(editTextVerticalOffset.getText().toString())));
+                        ((OscilloscopeActivity) getActivity()).yOffsets.put(spinnerChannelSelectVerticalOffset.getSelectedItem().toString(), seekBarVerticalOffset.getValue());
+                        ignore = false;
                     }
+                } else {
+                    seekBarVerticalOffset.setProgress(50);
                 }
-                editTextVerticalOffset.setCursorVisible(false);
-
-                return false;
             }
+            editTextVerticalOffset.setCursorVisible(false);
+
+            return false;
         });
 
-        checkBoxFouierTransform.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isFourierTransformSelected = isChecked;
-            }
-        });
+        checkBoxFouierTransform.setOnCheckedChangeListener((buttonView, isChecked) -> ((OscilloscopeActivity) getActivity()).setFourierTransformSelected(isChecked));
         return v;
     }
 }

--- a/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
+++ b/app/src/main/java/io/pslab/fragment/DataAnalysisFragment.java
@@ -179,7 +179,6 @@ public class DataAnalysisFragment extends Fragment {
         seekBarHorizontalOffset.setProgress(100);
         seekBarHorizontalOffset.setProgress(0);
 
-        // TODO: Anashuman, is this correct?
         seekBarVerticalOffset.setters(-1 * axisScale.getLeftYAxisScaleUpper(), axisScale.getLeftYAxisScaleUpper());
         seekBarVerticalOffset.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override

--- a/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
+++ b/app/src/main/java/io/pslab/fragment/TimebaseTriggerFragment.java
@@ -2,16 +2,13 @@ package io.pslab.fragment;
 
 import android.os.Bundle;
 import android.util.TypedValue;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.Spinner;
@@ -24,17 +21,17 @@ import org.apache.commons.lang3.math.NumberUtils;
 import io.pslab.R;
 import io.pslab.activity.OscilloscopeActivity;
 import io.pslab.others.FloatSeekBar;
+import io.pslab.others.OscilloscopeAxisScale;
 
 public class TimebaseTriggerFragment extends Fragment {
 
     private Spinner spinnerTriggerChannelSelect;
     private Spinner spinnerTriggerModeSelect;
-    private FloatSeekBar seekBarTimebase;
     private FloatSeekBar seekBarTrigger;
     private TextView textViewTimeBase;
     private EditText editTextTrigger;
-    private CheckBox checkBoxTrigger;
-    boolean _ignore = false;
+    private OscilloscopeAxisScale axisScale;
+    private boolean ignore = false;
 
 
     public static TimebaseTriggerFragment newInstance() {
@@ -48,14 +45,16 @@ public class TimebaseTriggerFragment extends Fragment {
         View v = inflater.inflate(R.layout.fragment_timebase_tigger, container, false);
 
         //seekBarTimebase = (SeekBar) v.findViewById(R.id.seekBar_timebase_tt);
-        seekBarTimebase = v.findViewById(R.id.seekBar_timebase_tt);
+        FloatSeekBar seekBarTimebase = v.findViewById(R.id.seekBar_timebase_tt);
         seekBarTrigger = v.findViewById(R.id.seekBar_trigger);
         textViewTimeBase = v.findViewById(R.id.tv_timebase_values_tt);
         editTextTrigger = v.findViewById(R.id.tv_trigger_values_tt);
         spinnerTriggerChannelSelect = v.findViewById(R.id.spinner_trigger_channel_tt);
         spinnerTriggerModeSelect = v.findViewById(R.id.spinner_trigger_mode_tt);
-        checkBoxTrigger = v.findViewById(R.id.checkbox_trigger_tt);
+        CheckBox checkBoxTrigger = v.findViewById(R.id.checkbox_trigger_tt);
         seekBarTimebase.setSaveEnabled(false);
+
+        axisScale = ((OscilloscopeActivity) this.getActivity()).getAxisScale();
 
         boolean tabletSize = getResources().getBoolean(R.bool.isTablet);
 
@@ -73,56 +72,49 @@ public class TimebaseTriggerFragment extends Fragment {
                     switch (progress) {
                         case 0:
                             textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 0.875;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(0.875);
+                            axisScale.setXAxisScale(0.875);
                             ((OscilloscopeActivity) getActivity()).timebase = 875;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 1:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 1;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
+                            axisScale.setXAxisScale(1);
                             ((OscilloscopeActivity) getActivity()).timebase = 1000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 2:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 2;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
+                            axisScale.setXAxisScale(2);
                             ((OscilloscopeActivity) getActivity()).timebase = 2000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 3:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 4;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
+                            axisScale.setXAxisScale(4);
                             ((OscilloscopeActivity) getActivity()).timebase = 4000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 4:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 8;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
+                            axisScale.setXAxisScale(8);
                             ((OscilloscopeActivity) getActivity()).timebase = 8000;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 5:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 25.60;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
+                            axisScale.setXAxisScale(25.60);
                             ((OscilloscopeActivity) getActivity()).timebase = 25600;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 6:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
+                            axisScale.setXAxisScale(38.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 38400;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
@@ -152,72 +144,63 @@ public class TimebaseTriggerFragment extends Fragment {
                     switch (progress) {
                         case 0:
                             textViewTimeBase.setText(getString(R.string.timebase_microsec, 875f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 0.875;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(0.875);
+                            axisScale.setXAxisScale(0.875);
                             ((OscilloscopeActivity) getActivity()).timebase = 875;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 1:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 1f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 1;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(1);
+                            axisScale.setXAxisScale(1);
                             ((OscilloscopeActivity) getActivity()).timebase = 1000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 2:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 2f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 2;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(2);
+                            axisScale.setXAxisScale(2);
                             ((OscilloscopeActivity) getActivity()).timebase = 2000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 3:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 4f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 4;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(4);
+                            axisScale.setXAxisScale(4);
                             ((OscilloscopeActivity) getActivity()).timebase = 4000;
                             ((OscilloscopeActivity) getActivity()).samples = 512;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 4:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 8f));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 8;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(8);
+                            axisScale.setXAxisScale(8);
                             ((OscilloscopeActivity) getActivity()).timebase = 8000;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 5:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 25.60));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 25.60;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(25.60);
+                            axisScale.setXAxisScale(25.60);
                             ((OscilloscopeActivity) getActivity()).timebase = 25600;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 6:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 38.40));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 38.40;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(38.40);
+                            axisScale.setXAxisScale(38.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 38400;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 7:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 51.20));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 51.20;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(51.20);
+                            axisScale.setXAxisScale(51.20);
                             ((OscilloscopeActivity) getActivity()).timebase = 51200;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
                             break;
                         case 8:
                             textViewTimeBase.setText(getString(R.string.timebase_milisec, 102.40));
-                            ((OscilloscopeActivity) getActivity()).xAxisScale = 102.40;
-                            ((OscilloscopeActivity) getActivity()).setXAxisScale(102.40);
+                            axisScale.setXAxisScale(102.40);
                             ((OscilloscopeActivity) getActivity()).timebase = 102400;
                             ((OscilloscopeActivity) getActivity()).samples = 1024;
                             ((OscilloscopeActivity) getActivity()).timeGap = (2 * ((OscilloscopeActivity) getActivity()).timebase) / ((OscilloscopeActivity) getActivity()).samples;
@@ -239,11 +222,11 @@ public class TimebaseTriggerFragment extends Fragment {
             });
             seekBarTimebase.setProgress(0);
         }
-        seekBarTrigger.setters(-1 * ((OscilloscopeActivity) getActivity()).yAxisScale, ((OscilloscopeActivity) getActivity()).yAxisScale);
+        seekBarTrigger.setters(-1 * axisScale.getLeftYAxisScaleUpper(), axisScale.getLeftYAxisScaleUpper());
         seekBarTrigger.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                if (!_ignore) {
+                if (!ignore) {
                     editTextTrigger.setText(String.format("%s V", seekBarTrigger.getValue()));
                     ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
                 }
@@ -322,53 +305,42 @@ public class TimebaseTriggerFragment extends Fragment {
             }
         });
 
-        editTextTrigger.setOnTouchListener(new View.OnTouchListener() {
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-                editTextTrigger.setCursorVisible(true);
-                return false;
-            }
+        editTextTrigger.setOnTouchListener((v1, event) -> {
+            editTextTrigger.setCursorVisible(true);
+            return false;
         });
 
-        editTextTrigger.setOnEditorActionListener(new TextView.OnEditorActionListener() {
-            @Override
-            public boolean onEditorAction(TextView textView, int i, KeyEvent keyEvent) {
-                if (i == EditorInfo.IME_ACTION_DONE) {
-                    String voltageValue = editTextTrigger.getText().toString().replace("V", "");
-                    voltageValue = voltageValue.replace(" ", "");
-                    if (NumberUtils.isCreatable(voltageValue)) {
-                        _ignore = true;
-                        if (Double.parseDouble(voltageValue) > ((OscilloscopeActivity) getActivity()).yAxisScale) {
-                            editTextTrigger.setText(String.format("%s V", ((OscilloscopeActivity) getActivity()).yAxisScale));
-                            seekBarTrigger.setValue(((OscilloscopeActivity) getActivity()).yAxisScale);
-                            ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
-                            _ignore = false;
-                        } else if (Double.parseDouble(voltageValue) < -((OscilloscopeActivity) getActivity()).yAxisScale) {
-                            editTextTrigger.setText(String.format("%s V", -((OscilloscopeActivity) getActivity()).yAxisScale));
-                            seekBarTrigger.setValue(-((OscilloscopeActivity) getActivity()).yAxisScale);
-                            ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
-                            _ignore = false;
-                        } else {
-                            seekBarTrigger.setValue(Double.parseDouble(voltageValue));
-                            editTextTrigger.setText(String.format("%s V", Double.parseDouble(voltageValue)));
-                            ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
-                            _ignore = false;
-                        }
+        editTextTrigger.setOnEditorActionListener((textView, i, keyEvent) -> {
+            if (i == EditorInfo.IME_ACTION_DONE) {
+                String voltageValue = editTextTrigger.getText().toString().replace("V", "");
+                voltageValue = voltageValue.replace(" ", "");
+                if (NumberUtils.isCreatable(voltageValue)) {
+                    ignore = true;
+                    if (Double.parseDouble(voltageValue) > axisScale.getLeftYAxisScaleUpper()) {
+                        editTextTrigger.setText(String.format("%s V", axisScale.getLeftYAxisScaleUpper()));
+                        seekBarTrigger.setValue(axisScale.getLeftYAxisScaleUpper());
+                        ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
+                        ignore = false;
+                    } else if (Double.parseDouble(voltageValue) < -axisScale.getLeftYAxisScaleUpper()) {
+                        editTextTrigger.setText(String.format("%s V", -axisScale.getLeftYAxisScaleUpper()));
+                        seekBarTrigger.setValue(-axisScale.getLeftYAxisScaleUpper());
+                        ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
+                        ignore = false;
                     } else {
-                        seekBarTrigger.setProgress(50);
+                        seekBarTrigger.setValue(Double.parseDouble(voltageValue));
+                        editTextTrigger.setText(String.format("%s V", Double.parseDouble(voltageValue)));
+                        ((OscilloscopeActivity) getActivity()).trigger = seekBarTrigger.getValue();
+                        ignore = false;
                     }
+                } else {
+                    seekBarTrigger.setProgress(50);
                 }
-                editTextTrigger.setCursorVisible(false);
-                return false;
             }
+            editTextTrigger.setCursorVisible(false);
+            return false;
         });
 
-        checkBoxTrigger.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isTriggerSelected = isChecked;
-            }
-        });
+        checkBoxTrigger.setOnCheckedChangeListener((buttonView, isChecked) -> ((OscilloscopeActivity) getActivity()).isTriggerSelected = isChecked);
 
         return v;
     }

--- a/app/src/main/java/io/pslab/fragment/XYPlotFragment.java
+++ b/app/src/main/java/io/pslab/fragment/XYPlotFragment.java
@@ -1,27 +1,27 @@
 package io.pslab.fragment;
 
 import android.os.Bundle;
-import androidx.fragment.app.Fragment;
-
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-
-import io.pslab.R;
-import io.pslab.activity.OscilloscopeActivity;
-import io.pslab.others.ViewGroupUtils;
-
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.Spinner;
+
+import androidx.fragment.app.Fragment;
+
+import io.pslab.R;
+import io.pslab.activity.OscilloscopeActivity;
+import io.pslab.others.OscilloscopeAxisScale;
+import io.pslab.others.ViewGroupUtils;
 
 public class XYPlotFragment extends Fragment {
 
     private Spinner spinnerChannelSelect1;
     private Spinner spinnerChannelSelect2;
     private CheckBox checkBoxXYPlot;
+    private OscilloscopeAxisScale axisScale;
 
     public static XYPlotFragment newInstance() {
         return new XYPlotFragment();
@@ -35,6 +35,9 @@ public class XYPlotFragment extends Fragment {
         spinnerChannelSelect1 = v.findViewById(R.id.spinner_channel_select_xy1);
         spinnerChannelSelect2 = v.findViewById(R.id.spinner_channel_select_xy2);
         checkBoxXYPlot = v.findViewById(R.id.checkBox_enable_xy_xy);
+
+        axisScale = ((OscilloscopeActivity) getActivity()).getAxisScale();
+
         spinnerChannelSelect1.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> adapterView, View view, int position, long l) {
@@ -83,31 +86,28 @@ public class XYPlotFragment extends Fragment {
         spinnerChannelSelect1.setSelection(channelsAdapter.getPosition("CH1"), true);
         spinnerChannelSelect2.setSelection(channelsAdapter.getPosition("CH2"), true);
 
-        checkBoxXYPlot.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                ((OscilloscopeActivity) getActivity()).isXYPlotSelected = isChecked;
-                if (isChecked) {
-                    ViewGroupUtils.replaceView(((OscilloscopeActivity) getActivity()).mChart,
-                            ((OscilloscopeActivity) getActivity()).graph);
-                    ((OscilloscopeActivity) getActivity()).setXAxisLabel(spinnerChannelSelect1.getSelectedItem().toString());
-                    ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect2.getSelectedItem().toString());
-                    ((OscilloscopeActivity) getActivity()).xAxisLabelUnit.setText("(V)");
-                    ((OscilloscopeActivity) getActivity()).rightYAxisLabel.setVisibility(View.INVISIBLE);
-                    ((OscilloscopeActivity) getActivity()).rightYAxisLabelUnit.setVisibility(View.INVISIBLE);
+        checkBoxXYPlot.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            ((OscilloscopeActivity) getActivity()).isXYPlotSelected = isChecked;
+            if (isChecked) {
+                ViewGroupUtils.replaceView(((OscilloscopeActivity) getActivity()).mChart,
+                        ((OscilloscopeActivity) getActivity()).graph);
+                ((OscilloscopeActivity) getActivity()).setXAxisLabel(spinnerChannelSelect1.getSelectedItem().toString());
+                ((OscilloscopeActivity) getActivity()).setLeftYAxisLabel(spinnerChannelSelect2.getSelectedItem().toString());
+                ((OscilloscopeActivity) getActivity()).xAxisLabelUnit.setText("(V)");
+                ((OscilloscopeActivity) getActivity()).rightYAxisLabel.setVisibility(View.INVISIBLE);
+                ((OscilloscopeActivity) getActivity()).rightYAxisLabelUnit.setVisibility(View.INVISIBLE);
 
 
-                } else {
-                    ViewGroupUtils.replaceView(((OscilloscopeActivity) getActivity()).graph,
-                            ((OscilloscopeActivity) getActivity()).mChart);
-                    ((OscilloscopeActivity) getActivity()).rightYAxisLabel.setVisibility(View.VISIBLE);
-                    ((OscilloscopeActivity) getActivity()).rightYAxisLabelUnit.setVisibility(View.VISIBLE);
-                    ((OscilloscopeActivity) getActivity()).setXAxisLabel("time");
-                    ((OscilloscopeActivity) getActivity()).setXAxisScale(((OscilloscopeActivity) getActivity()).timebase);
-
-                }
+            } else {
+                ViewGroupUtils.replaceView(((OscilloscopeActivity) getActivity()).graph,
+                        ((OscilloscopeActivity) getActivity()).mChart);
+                ((OscilloscopeActivity) getActivity()).rightYAxisLabel.setVisibility(View.VISIBLE);
+                ((OscilloscopeActivity) getActivity()).rightYAxisLabelUnit.setVisibility(View.VISIBLE);
+                ((OscilloscopeActivity) getActivity()).setXAxisLabel("time");
+                axisScale.setXAxisScale(((OscilloscopeActivity) getActivity()).timebase);
 
             }
+
         });
 
         return v;

--- a/app/src/main/java/io/pslab/others/OscilloscopeAxisScale.java
+++ b/app/src/main/java/io/pslab/others/OscilloscopeAxisScale.java
@@ -1,0 +1,184 @@
+package io.pslab.others;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Encapsulates axis scale values of the Oscilloscope.
+ */
+public class OscilloscopeAxisScale {
+
+    public static final float DEFAULT_X_AXIS_SCALE = 875f;
+    public static final float DEFAULT_Y_AXIS_SCALE = 16f;
+
+    private final Collection<AxisScaleSetListener> axisScaleSetListeners = new ArrayList<>();
+
+    private double xAxisScale = DEFAULT_X_AXIS_SCALE;
+    private double leftYAxisScaleUpper = DEFAULT_Y_AXIS_SCALE;
+    private double leftYAxisScaleLower = -DEFAULT_Y_AXIS_SCALE;
+    private double rightYAxisScaleUpper = DEFAULT_Y_AXIS_SCALE;
+    private double rightYAxisScaleLower = -DEFAULT_Y_AXIS_SCALE;
+
+    /**
+     * Adds a new listener which will be informed when a range value is changed.
+     *
+     * @param listener the listener to add
+     */
+    public void addAxisScaledListener(AxisScaleSetListener listener) {
+        if (listener != null) {
+            axisScaleSetListeners.add(listener);
+        }
+    }
+
+    /**
+     * Removes a listener which will be informed when a range value is changed.
+     *
+     * @param listener the listener to remove
+     */
+    public void removeAxisScaledListener(AxisScaleSetListener listener) {
+        axisScaleSetListeners.remove(listener);
+    }
+
+    /**
+     * Gets scale of X-axis.
+     *
+     * @return the scale value
+     */
+    public double getXAxisScale() {
+        return xAxisScale;
+    }
+
+    /**
+     * Sets sccale of the X-axis.
+     *
+     * @param timebase the scale value
+     */
+    public void setXAxisScale(double timebase) {
+        this.xAxisScale = timebase;
+
+        for (AxisScaleSetListener listener : axisScaleSetListeners) {
+            listener.onXAxisScaleSet(timebase);
+        }
+    }
+
+    /**
+     * Gets upper value of scale on the left Y-axis.
+     *
+     * @return the scale value
+     */
+    public double getLeftYAxisScaleUpper() {
+        return leftYAxisScaleUpper;
+    }
+
+    /**
+     * Gets lower value of scale on the left Y-axis.
+     *
+     * @return the scale value
+     */
+    public double getLeftYAxisScaleLower() {
+        return leftYAxisScaleLower;
+    }
+
+    /**
+     * Sets upper and lower limit of the left Y-axis. The lower limit is the input value multiplied by -1.
+     *
+     * @param limit new scale value, must be positive
+     */
+    public void setLeftYAxisScale(double limit) {
+        setLeftYAxisScale(limit, -limit);
+    }
+
+    /**
+     * Sets upper and lower limit of the left Y-axis. The lower limit must be smaller than the upper limit.
+     *
+     * @param upperLimit new upper scale value
+     * @param lowerLimit new lower scale value
+     */
+    public void setLeftYAxisScale(double upperLimit, double lowerLimit) {
+        if (upperLimit < lowerLimit) {
+            throw new IllegalArgumentException("Upper limit must be larger than lowe limit.");
+        }
+
+        this.leftYAxisScaleUpper = upperLimit;
+        this.leftYAxisScaleLower = lowerLimit;
+
+        for (AxisScaleSetListener listener : axisScaleSetListeners) {
+            listener.onLeftYAxisScaleSet(upperLimit, lowerLimit);
+        }
+    }
+
+    /**
+     * Gets upper value of scale on the right Y-axis.
+     *
+     * @return the scale value
+     */
+    public double getRightYAxisScaleUpper() {
+        return rightYAxisScaleUpper;
+    }
+
+    /**
+     * Gets lower value of scale on the right Y-axis.
+     *
+     * @return the scale value
+     */
+    public double getRightYAxisScaleLower() {
+        return rightYAxisScaleLower;
+    }
+
+    /**
+     * Sets upper and lower limit of the right Y-axis. The lower limit is the input value multiplied by -1.
+     *
+     * @param limit new scale value, must be positive
+     */
+    public void setRightYAxisScale(double limit) {
+        setRightYAxisScale(limit, -limit);
+    }
+
+    /**
+     * Sets upper and lower limit of the right Y-axis. The lower limit must be smaller than the upper limit.
+     *
+     * @param upperLimit new upper scale value
+     * @param lowerLimit new lower scale value
+     */
+    public void setRightYAxisScale(double upperLimit, double lowerLimit) {
+        if (upperLimit < lowerLimit) {
+            throw new IllegalArgumentException("Upper limit must be larger than lowe limit.");
+        }
+
+        this.rightYAxisScaleUpper = upperLimit;
+        this.rightYAxisScaleLower = lowerLimit;
+
+        for (AxisScaleSetListener listener : axisScaleSetListeners) {
+            listener.onRightYAxisScaleSet(upperLimit, lowerLimit);
+        }
+    }
+
+    /**
+     * Listener which is called when axis scale is set.
+     */
+    public interface AxisScaleSetListener {
+
+        /**
+         * Called when scale of the X-axis is set.
+         *
+         * @param timebase new scale value
+         */
+        void onXAxisScaleSet(double timebase);
+
+        /**
+         * Called when scale of the left Y-axis is set.
+         *
+         * @param upperLimit new upper scale value
+         * @param lowerLimit new lower scale value
+         */
+        void onLeftYAxisScaleSet(double upperLimit, double lowerLimit);
+
+        /**
+         * Called when scale of the right Y-axis is set.
+         *
+         * @param upperLimit new upper scale value
+         * @param lowerLimit new lower scale value
+         */
+        void onRightYAxisScaleSet(double upperLimit, double lowerLimit);
+    }
+}

--- a/app/src/main/java/io/pslab/others/OscilloscopeAxisScale.java
+++ b/app/src/main/java/io/pslab/others/OscilloscopeAxisScale.java
@@ -96,7 +96,8 @@ public class OscilloscopeAxisScale {
      */
     public void setLeftYAxisScale(double upperLimit, double lowerLimit) {
         if (upperLimit < lowerLimit) {
-            throw new IllegalArgumentException("Upper limit must be larger than lowe limit.");
+            throw new IllegalArgumentException(String.format("Upper limit (%f) must be larger than lower limit (%f).",
+                    upperLimit, lowerLimit));
         }
 
         this.leftYAxisScaleUpper = upperLimit;
@@ -142,7 +143,8 @@ public class OscilloscopeAxisScale {
      */
     public void setRightYAxisScale(double upperLimit, double lowerLimit) {
         if (upperLimit < lowerLimit) {
-            throw new IllegalArgumentException("Upper limit must be larger than lowe limit.");
+            throw new IllegalArgumentException(String.format("Upper limit (%f) must be larger than lower limit (%f).",
+                    upperLimit, lowerLimit));
         }
 
         this.rightYAxisScaleUpper = upperLimit;


### PR DESCRIPTION
Fixes #2099

## Changes 
- refactoring of scale handling: moved scale values to extra class
- only set scale when required, not on every new data frame

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the oscilloscope's range selection by encapsulating scale values in a new class and optimizing scale updates to occur only when necessary. This improves code structure and performance.

Enhancements:
- Refactor the oscilloscope's scale handling by moving scale values to a dedicated class, improving code organization and maintainability.
- Introduce a mechanism to set axis scales only when necessary, reducing unnecessary updates and improving performance.
- Replace anonymous inner classes with lambda expressions for cleaner and more concise code.

<!-- Generated by sourcery-ai[bot]: end summary -->