### PR TITLE
chore: configure Fastfile to add lane to push to closed testers

### DIFF
--- a/Fastfile
+++ b/Fastfile
@@ -4,6 +4,10 @@ platform :android do
     upload_to_play_store(track: "beta",aab:"app/build/outputs/bundle/release/app-release.aab")
   end
 
+  lane :uploadToClosedTesting do
+    upload_to_play_store(track: "alpha",aab:"build/app/outputs/bundle/release/app-release.aab")
+  end
+
   lane :promoteToProduction do | options |
     if options[:version_code]
       supply(track: "beta",track_promote_to: "production",skip_upload_apk: true, version_code: options[:version_code])


### PR DESCRIPTION
Updates our _Fastfile_ in the `fastlane` branch to add a lane to push to closed testers. 
This would be used to test the flutter APKs.

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Build:
- Add a new lane in the Fastfile to push APKs to closed testers using the alpha track.