### PR TITLE
fix: fix invalid values for Vpp and Vp- in Oscilloscope

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -1126,23 +1126,34 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
             if (!isFourierTransformSelected) {
                 for (int i = 0; i < Math.min(entries.size(), paramsChannels.length); i++) {
                     CHANNEL channel = CHANNEL.valueOf(paramsChannels[i]);
-                    double minY = Double.MAX_VALUE;
-                    double maxY = -1 * Double.MIN_VALUE;
+                    double minY;
+                    double maxY;
                     double yRange;
                     double[] voltage = new double[512];
                     ArrayList<Entry> entryArrayList = dataEntries.get(i);
-                    for (int j = 0; j < entryArrayList.size(); j++) {
-                        Entry entry = entryArrayList.get(j);
-                        if (j < voltage.length - 1) {
-                            voltage[j] = entry.getY();
-                        }
-                        if (entry.getY() > maxY) {
-                            maxY = entry.getY();
-                        }
-                        if (entry.getY() < minY) {
-                            minY = entry.getY();
+
+                    if (entryArrayList.isEmpty()) {
+                        minY = 0;
+                        maxY = 0;
+                    } else {
+                        minY = Double.MAX_VALUE;
+                        maxY = -1 * Double.MAX_VALUE;
+
+                        for (int j = 0; j < entryArrayList.size(); j++) {
+                            Entry entry = entryArrayList.get(j);
+                            float y = entry.getY();
+                            if (j < voltage.length - 1) {
+                                voltage[j] = y;
+                            }
+                            if (y > maxY) {
+                                maxY = y;
+                            }
+                            if (y < minY) {
+                                minY = y;
+                            }
                         }
                     }
+
                     final double frequency;
                     if (Objects.equals(dataParamsChannels[i], CHANNEL.MIC.toString())) {
                         frequency = analyticsClass.findFrequency(voltage, ((double) 1 / SAMPLING_RATE));

--- a/app/src/main/java/io/pslab/adapters/OscilloscopeMeasurementsAdapter.java
+++ b/app/src/main/java/io/pslab/adapters/OscilloscopeMeasurementsAdapter.java
@@ -37,7 +37,7 @@ public class OscilloscopeMeasurementsAdapter extends RecyclerView.Adapter<Oscill
             double period = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.PERIOD);
             double positivePeak = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.POSITIVE_PEAK);
             double negativePeak = OscilloscopeMeasurements.channel.get(channel).get(ChannelMeasurements.NEGATIVE_PEAK);
-            DecimalFormat df = new DecimalFormat("#.##");
+            DecimalFormat df = new DecimalFormat("0.00");
             df.setRoundingMode(RoundingMode.CEILING);
             if (frequency >= 1000) {
                 frequency /= 1000;


### PR DESCRIPTION
Fixes #2567

## Changes 
- set values to 0 if we get empty data for a waveform
- force two decimals for numbers in Automatic Measurements

## Screenshots / Recordings 
![Screenshot_20241105-230927](https://github.com/user-attachments/assets/69bc7aeb-a255-4b4e-be96-2860324a1640)
 
**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Fix invalid Vpp and Vp- values in the Oscilloscope by setting values to 0 for empty waveform data and enhance number formatting by forcing two decimal places in Automatic Measurements.

Bug Fixes:
- Set values to 0 for empty waveform data to prevent invalid Vpp and Vp- values in the Oscilloscope.

Enhancements:
- Force two decimal places for numbers in Automatic Measurements to ensure consistent formatting.