### PR TITLE
fix: don't forget menu state when Fragment is changed in Oscilloscope

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -432,6 +432,8 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
         playMenu = menu.findItem(R.id.play_data);
         menu.findItem(R.id.record_pause_data).setVisible(!isPlayingback);
         menu.findItem(R.id.play_data).setVisible(isPlayingback);
+        menu.findItem(R.id.measurements).setChecked(isMeasurementsChecked);
+        menu.findItem(R.id.run_stop).setTitle(isRunning ? R.string.control_stop : R.string.control_run);
         return super.onPrepareOptionsMenu(menu);
     }
 


### PR DESCRIPTION
Fixes #2569

## Changes 
- set state of STOP/RUN and Automatic Measurement when menu is recreated

## Screenshots / Recordings  
Please ignore the strange waveform, it seems like I damaged one of my boards.

https://github.com/user-attachments/assets/33639a7a-2b69-497b-a45a-52cdee624217

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the menu state of STOP/RUN and Automatic Measurement is not retained when the menu is recreated in the Oscilloscope.