### PR TITLE
chore: fix APK signing

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,7 +22,7 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-def KEYSTORE_FILE = rootProject.file('./pslab.jks')
+def KEYSTORE_FILE = rootProject.file('../scripts/pslab.jks')
 def GITHUB_BUILD = System.getenv("GITHUB_ACTIONS") == "true" && KEYSTORE_FILE.exists()
 def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.file(SIGNING_KEY_FILE).exists()
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
-            android:name=".activity.MainActivity"
+            android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
             android:taskAffinity=""

--- a/scripts/prep-key.sh
+++ b/scripts/prep-key.sh
@@ -2,4 +2,4 @@
 set -e
 
 openssl aes-256-cbc -K $ENCRYPTED_F10B5E0E5262_KEY -iv $ENCRYPTED_F10B5E0E5262_IV -in ./scripts/secrets.tar.enc -out ./scripts/secrets.tar -d
-tar xvf ./scripts/secrets.tar -C android/
+tar xvf ./scripts/secrets.tar -C scripts/


### PR DESCRIPTION
Fixes APK signing.

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Fix APK signing by correcting the keystore file path in the build configuration and streamline the AndroidManifest.xml. Additionally, ensure proper formatting in the prep-key.sh script.

Bug Fixes:
- Correct the path to the keystore file in the build.gradle file to ensure proper APK signing.

Enhancements:
- Simplify the AndroidManifest.xml by removing unnecessary activity path specification.

Chores:
- Ensure the prep-key.sh script has a newline at the end of the file.