### PR TITLE
fix: add red border to TextViews of screen for MPU925X

### DIFF
--- a/app/src/main/res/layout/sensor_ads1115.xml
+++ b/app/src/main/res/layout/sensor_ads1115.xml
@@ -81,8 +81,8 @@
 
                     <TextView
                         android:id="@+id/tv_sensor_ads1115"
-                        android:layout_width="120dp"
-                        android:layout_height="40dp"
+                        android:layout_width="@dimen/tv_sensor_width"
+                        android:layout_height="@dimen/tv_sensor_height"
                         android:layout_gravity="center_vertical"
                         android:background="@drawable/tv_border"
                         android:textColor="@color/black"

--- a/app/src/main/res/layout/sensor_bmp180.xml
+++ b/app/src/main/res/layout/sensor_bmp180.xml
@@ -71,7 +71,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/temperature"
                             android:textColor="@color/black"
@@ -80,7 +80,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/altitude"
                             android:textColor="@color/black"
@@ -89,7 +89,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/pressure"
                             android:textColor="@color/black"
@@ -106,8 +106,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_bmp180_temp"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -116,8 +116,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_bmp180_altitude"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -126,8 +126,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_bmp180_pressure"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"

--- a/app/src/main/res/layout/sensor_ccs811.xml
+++ b/app/src/main/res/layout/sensor_ccs811.xml
@@ -72,7 +72,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/eCO2"
                             android:textColor="@color/black"
@@ -81,7 +81,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/eTVOC"
                             android:textColor="@color/black"
@@ -99,8 +99,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_ccs811_eCO2"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -109,8 +109,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_ccs811_TVOC"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"

--- a/app/src/main/res/layout/sensor_hmc5883l.xml
+++ b/app/src/main/res/layout/sensor_hmc5883l.xml
@@ -71,7 +71,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/bx"
                             android:textColor="@color/black"
@@ -80,7 +80,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/by"
                             android:textColor="@color/black"
@@ -89,7 +89,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/bz"
                             android:textColor="@color/black"
@@ -106,8 +106,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_hmc5883l_bx"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -116,8 +116,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_hmc5883l_by"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -126,8 +126,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_hmc5883l_bz"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"

--- a/app/src/main/res/layout/sensor_mlx90614.xml
+++ b/app/src/main/res/layout/sensor_mlx90614.xml
@@ -72,7 +72,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/object_temp"
                             android:textColor="@color/black"
@@ -81,7 +81,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/ambient_temp"
                             android:textColor="@color/black"
@@ -99,8 +99,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mlx90614_object_temp"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -109,8 +109,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mlx90614_ambient_temp"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"

--- a/app/src/main/res/layout/sensor_mpu925x.xml
+++ b/app/src/main/res/layout/sensor_mpu925x.xml
@@ -121,7 +121,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_ax"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -132,7 +132,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_ay"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -143,7 +143,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_az"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -154,7 +154,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_temp"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -211,7 +211,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_gx"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -222,7 +222,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_gy"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -233,7 +233,7 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_gz"
-                            android:layout_width="wrap_content"
+                            android:layout_width="80dp"
                             android:layout_height="30dp"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
@@ -636,8 +636,8 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:background="@null"
-            app:srcCompat="@drawable/circle_play_button"
-            android:scaleType="fitCenter" />
+            android:scaleType="fitCenter"
+            app:srcCompat="@drawable/circle_play_button" />
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/editBox_samples_sensors"

--- a/app/src/main/res/layout/sensor_mpu925x.xml
+++ b/app/src/main/res/layout/sensor_mpu925x.xml
@@ -73,7 +73,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/ax"
                             android:textAlignment="textStart"
@@ -83,7 +83,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/ay"
                             android:textAlignment="textStart"
@@ -93,7 +93,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/az"
                             android:textAlignment="textStart"
@@ -103,7 +103,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/temp"
                             android:textAlignment="textStart"
@@ -121,8 +121,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_ax"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"
@@ -132,8 +132,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_ay"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"
@@ -143,8 +143,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_az"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"
@@ -154,8 +154,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_temp"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"
@@ -173,7 +173,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/gx"
                             android:textAlignment="textStart"
@@ -183,7 +183,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/gy"
                             android:textAlignment="textStart"
@@ -193,7 +193,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:text="@string/gz"
                             android:textAlignment="textStart"
@@ -211,8 +211,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_gx"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"
@@ -222,8 +222,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_gy"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"
@@ -233,8 +233,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_mpu925x_gz"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:layout_gravity="start"
                             android:background="@drawable/tv_border"
                             android:textAlignment="textStart"

--- a/app/src/main/res/layout/sensor_sht21.xml
+++ b/app/src/main/res/layout/sensor_sht21.xml
@@ -72,7 +72,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/temp"
                             android:textColor="@color/black"
@@ -81,7 +81,7 @@
 
                         <TextView
                             android:layout_width="wrap_content"
-                            android:layout_height="30dp"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:gravity="center_vertical"
                             android:text="@string/humidity"
                             android:textColor="@color/black"
@@ -99,8 +99,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_sht21_temp"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -109,8 +109,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_sht21_humidity"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"

--- a/app/src/main/res/layout/sensor_tsl2561.xml
+++ b/app/src/main/res/layout/sensor_tsl2561.xml
@@ -28,24 +28,24 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/sensor_control_dock_layout"
+        android:layout_below="@id/app_bar"
         android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:layout_below="@id/app_bar">
+        android:layout_alignParentTop="true">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginTop="@dimen/margin_50dp">
+            android:layout_marginTop="@dimen/margin_50dp"
+            android:orientation="vertical">
 
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="180dp"
-                android:layout_marginEnd="@dimen/card_margin"
-                android:layout_marginLeft="@dimen/card_margin"
-                android:layout_marginRight="@dimen/card_margin"
                 android:layout_marginStart="@dimen/card_margin"
-                android:layout_marginTop="20dp">
+                android:layout_marginLeft="@dimen/card_margin"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="@dimen/card_margin"
+                android:layout_marginRight="@dimen/card_margin">
 
                 <TextView
                     android:layout_width="match_parent"
@@ -106,8 +106,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_tsl2561_full"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -116,8 +116,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_tsl2561_infrared"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -126,8 +126,8 @@
 
                         <TextView
                             android:id="@+id/tv_sensor_tsl2561_visible"
-                            android:layout_width="80dp"
-                            android:layout_height="30dp"
+                            android:layout_width="@dimen/tv_sensor_width"
+                            android:layout_height="@dimen/tv_sensor_height"
                             android:background="@drawable/tv_border"
                             android:gravity="center"
                             android:textColor="@color/black"
@@ -148,11 +148,11 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="200dp"
-                android:layout_marginEnd="@dimen/card_margin"
-                android:layout_marginLeft="@dimen/card_margin"
-                android:layout_marginRight="@dimen/card_margin"
                 android:layout_marginStart="@dimen/card_margin"
-                android:layout_marginTop="20dp">
+                android:layout_marginLeft="@dimen/card_margin"
+                android:layout_marginTop="20dp"
+                android:layout_marginEnd="@dimen/card_margin"
+                android:layout_marginRight="@dimen/card_margin">
 
                 <TextView
                     android:layout_width="match_parent"
@@ -271,11 +271,11 @@
             <androidx.cardview.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="240dp"
-                android:layout_marginEnd="@dimen/card_margin"
-                android:layout_marginLeft="@dimen/card_margin"
-                android:layout_marginRight="@dimen/card_margin"
                 android:layout_marginStart="@dimen/card_margin"
+                android:layout_marginLeft="@dimen/card_margin"
                 android:layout_marginTop="20dp"
+                android:layout_marginEnd="@dimen/card_margin"
+                android:layout_marginRight="@dimen/card_margin"
                 android:layout_marginBottom="@dimen/card_margin_bottom">
 
                 <TextView
@@ -306,8 +306,8 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="40dp"
-                            android:layout_marginBottom="5dp"
                             android:layout_marginTop="5dp"
+                            android:layout_marginBottom="5dp"
                             android:gravity="center_vertical"
                             android:text="@string/set_gain"
                             android:textColor="@color/black"
@@ -317,8 +317,8 @@
                         <TextView
                             android:layout_width="wrap_content"
                             android:layout_height="40dp"
-                            android:layout_marginBottom="5dp"
                             android:layout_marginTop="5dp"
+                            android:layout_marginBottom="5dp"
                             android:gravity="center_vertical"
                             android:text="@string/set_timing"
                             android:textColor="@color/black"
@@ -338,15 +338,15 @@
                             android:id="@+id/spinner_sensor_tsl2561_gain"
                             android:layout_width="160dp"
                             android:layout_height="40dp"
-                            android:layout_marginBottom="5dp"
                             android:layout_marginTop="5dp"
+                            android:layout_marginBottom="5dp"
                             android:entries="@array/tsl2561_gain_spinner" />
 
                         <LinearLayout
                             android:layout_width="160dp"
                             android:layout_height="40dp"
-                            android:layout_marginBottom="5dp"
                             android:layout_marginTop="5dp"
+                            android:layout_marginBottom="5dp"
                             android:orientation="horizontal">
 
                             <EditText
@@ -382,8 +382,8 @@
         android:id="@+id/sensor_control_dock_layout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/sensor_control_doc_height"
-        android:layout_alignParentBottom="true"
         android:layout_alignParentStart="true"
+        android:layout_alignParentBottom="true"
         android:layout_margin="@dimen/margin_5dp"
         android:background="@drawable/la_custom_border"
         android:gravity="top">
@@ -395,8 +395,8 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:background="@null"
-            app:srcCompat="@drawable/circle_play_button"
-            android:scaleType="fitCenter" />
+            android:scaleType="fitCenter"
+            app:srcCompat="@drawable/circle_play_button" />
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/editBox_samples_sensors"
@@ -404,8 +404,8 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:layout_marginStart="@dimen/control_margin_small"
-            android:layout_toEndOf="@+id/imageButton_play_pause_sensor"
             android:layout_toStartOf="@+id/tv_timegap_label"
+            android:layout_toEndOf="@+id/imageButton_play_pause_sensor"
             android:hint="@string/no_of_samples"
             android:inputType="numberSigned|numberDecimal"
             android:maxLines="1"
@@ -423,26 +423,26 @@
             android:id="@+id/textView4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/imageButton_play_pause_sensor"
             android:layout_alignStart="@+id/editBox_samples_sensors"
+            android:layout_alignBottom="@+id/imageButton_play_pause_sensor"
             android:text="@string/timegap" />
 
         <SeekBar
             android:id="@+id/seekBar_timegap_sensor"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignBottom="@+id/textView4"
             android:layout_alignTop="@+id/textView4"
-            android:layout_toEndOf="@+id/textView4"
-            android:layout_toStartOf="@+id/tv_timegap_label" />
+            android:layout_alignBottom="@+id/textView4"
+            android:layout_toStartOf="@+id/tv_timegap_label"
+            android:layout_toEndOf="@+id/textView4" />
 
         <TextView
             android:id="@+id/tv_timegap_label"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_alignStart="@+id/checkBox_samples_sensor"
             android:layout_alignBottom="@+id/seekBar_timegap_sensor"
             android:layout_alignParentEnd="true"
-            android:layout_alignStart="@+id/checkBox_samples_sensor"
             android:text="@string/hundred_ms"
             android:textSize="@dimen/textsize_edittext" />
 

--- a/app/src/main/res/layout/sensor_vl53l0x.xml
+++ b/app/src/main/res/layout/sensor_vl53l0x.xml
@@ -82,8 +82,8 @@
 
                     <TextView
                         android:id="@+id/tv_sensor_vl53l0x"
-                        android:layout_width="120dp"
-                        android:layout_height="40dp"
+                        android:layout_width="@dimen/tv_sensor_width"
+                        android:layout_height="@dimen/tv_sensor_height"
                         android:layout_gravity="center|center_vertical"
                         android:background="@drawable/tv_border"
                         android:padding="@dimen/card_margin"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -55,6 +55,8 @@
 
     <dimen name="sensor_title_font">16sp</dimen>
     <dimen name="sensor_body_font">14sp</dimen>
+    <dimen name="tv_sensor_width">80dp</dimen>
+    <dimen name="tv_sensor_height">30dp</dimen>
 
     <dimen name="accel_textsize_large">15sp</dimen>
     <dimen name="accel_textsize_small">9sp</dimen>


### PR DESCRIPTION
Fixes https://github.com/fossasia/pslab-android/issues/

Fixes #2585

## Changes 
- changed width of TextViews to make red borders visible
- introduce uniform width and height for TextViews in sensor screens and use i where possible

## Screenshots / Recordings  

<img src="https://github.com/user-attachments/assets/8ada2818-5f82-4014-9a15-c641f51acc44" width=400/>

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Bug Fixes:
- Adjust the width of TextViews in the MPU925X sensor screen layout to ensure red borders are visible.