### PR TITLE
fix: fix build problems

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,7 @@ dependencies {
     implementation("com.github.mirrajabi:search-dialog:1.2.4")
     implementation(files("../libs/croller-release.aar"))
     implementation("com.github.BeppiMenozzi:Knob:1.9.0")
-    implementation("com.github.warkiz:IndicatorSeekBar:v2.1.1")
+    implementation("com.github.warkiz:IndicatorSeekBar:2.1.1")
     implementation("com.github.Vatican-Cameos:CarouselPicker:1.2")
     implementation("com.github.anastr:speedviewlib:1.6.1")
     implementation("com.github.GoodieBag:ProtractorView:v1.2")


### PR DESCRIPTION
IndicatorSeekBar could not be resolved. The reason is that Gradle tries to download https://jitpack.io/com/github/warkiz/IndicatorSeekBar/v2.1.1/IndicatorSeekBar-v2.1.1.pom which does not work. Instead https://jitpack.io/com/github/warkiz/IndicatorSeekBar/2.1.1/IndicatorSeekBar-2.1.1.pom should be used.

For some reason the version was v2.1.1 and is 2.1.1 now.

## Changes 
- Changed version string of dependency in the Gradle file

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Build:
- Update the `build.gradle.kts` file to use the correct version of the IndicatorSeekBar library.