### PR TITLE
fix: unnecessary issue of commands in the Oscilloscope

### DIFF
--- a/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
+++ b/app/src/main/java/io/pslab/activity/OscilloscopeActivity.java
@@ -372,13 +372,15 @@ public class OscilloscopeActivity extends GuideActivity implements View.OnClickL
                             if (isAudioInputSelected && isInBuiltMicSelected || (scienceLab.isConnected() && isMICSelected)) {
                                 channels.add(CHANNEL.MIC.toString());
                             }
-                            captureTask = new CaptureTask();
-                            captureTask.execute(channels.toArray(new String[0]));
-                            synchronized (lock) {
-                                try {
-                                    lock.wait();
-                                } catch (InterruptedException e) {
-                                    e.printStackTrace();
+                            if (!channels.isEmpty()) {
+                                captureTask = new CaptureTask();
+                                captureTask.execute(channels.toArray(new String[0]));
+                                synchronized (lock) {
+                                    try {
+                                        lock.wait();
+                                    } catch (InterruptedException e) {
+                                        e.printStackTrace();
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes #2592 

## Changes 
- #2592 arose because of 6d1398586b479301ec4859e9d506d4bd9a612aa1 merged in #2465.
- A small check is added to prevent `CaptureTask` from executing when no channel is selected.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause This small PR fixes that issue and has been tested by me. Could you please test and confirm that the unnecessary commands are being sent no more and that the _Oscilloscope_ is working fine now ?

## Summary by Sourcery

Bug Fixes:
- Fix an issue where unnecessary commands were sent to the Oscilloscope when no channel was selected.