### PR TITLE
fix: different font sizes for diagram headlines in sensor screens

### DIFF
--- a/app/src/main/res/layout/sensor_bmp180.xml
+++ b/app/src/main/res/layout/sensor_bmp180.xml
@@ -283,7 +283,7 @@
                     android:padding="@dimen/title_padding"
                     android:text="@string/plot_altitude"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/title_font_size"
+                    android:textSize="@dimen/sensor_title_font"
                     android:textStyle="bold" />
 
                 <RelativeLayout
@@ -406,7 +406,7 @@
                     android:padding="@dimen/title_padding"
                     android:text="@string/plot_hyphen_pressure"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/title_font_size"
+                    android:textSize="@dimen/sensor_title_font"
                     android:textStyle="bold" />
 
                 <RelativeLayout

--- a/app/src/main/res/layout/sensor_ccs811.xml
+++ b/app/src/main/res/layout/sensor_ccs811.xml
@@ -267,7 +267,7 @@
                     android:padding="@dimen/title_padding"
                     android:text="@string/plot_eTVOC"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/title_font_size"
+                    android:textSize="@dimen/sensor_title_font"
                     android:textStyle="bold" />
 
                 <RelativeLayout

--- a/app/src/main/res/layout/sensor_sht21.xml
+++ b/app/src/main/res/layout/sensor_sht21.xml
@@ -267,7 +267,7 @@
                     android:padding="@dimen/title_padding"
                     android:text="@string/plot_humidity"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/title_font_size"
+                    android:textSize="@dimen/sensor_title_font"
                     android:textStyle="bold" />
 
                 <RelativeLayout

--- a/app/src/main/res/layout/sensor_tsl2561.xml
+++ b/app/src/main/res/layout/sensor_tsl2561.xml
@@ -161,7 +161,7 @@
                     android:padding="@dimen/title_padding"
                     android:text="@string/plot"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/title_font_size"
+                    android:textSize="@dimen/sensor_title_font"
                     android:textStyle="bold" />
 
                 <RelativeLayout

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -25,8 +25,6 @@
     <dimen name="instrument_tile_icon_size">100dp</dimen>
     <dimen name="instrument_card_margin">10dp</dimen>
 
-    <dimen name="title_font_size">14sp</dimen>
-
     <dimen name="control_margin">10dp</dimen>
     <dimen name="control_margin_small">5dp</dimen>
     <dimen name="control_margin_medium">15dp</dimen>


### PR DESCRIPTION
Fixes #2600

## Changes 
- removed font size which was only used for wrong title sizes
- replaced wrong font sizes with correct font size

## Screenshots / Recordings  

<img src="https://github.com/user-attachments/assets/bde6546f-a6a2-4ccb-b70e-fda22ee01548" width=400 />

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Use the correct font size for diagram headlines in sensor screens.

Bug Fixes:
- Fixed inconsistent font sizes for diagram titles in sensor screens.

Enhancements:
- Removed an unused font size dimension.