### PR TITLE
fix: app crashes if data is read from sensor which is not connected

### DIFF
--- a/app/src/main/java/io/pslab/sensors/AbstractSensorActivity.java
+++ b/app/src/main/java/io/pslab/sensors/AbstractSensorActivity.java
@@ -333,24 +333,26 @@ abstract class AbstractSensorActivity extends AppCompatActivity {
 
     protected abstract class SensorDataFetch {
 
-        private volatile boolean isSensorDataAcquired;
-
         protected float getTimeElapsed() {
             return (System.currentTimeMillis() - getStartTime()) / 1000f;
         }
 
-        protected boolean isSensorDataAcquired() {
-            return isSensorDataAcquired;
-        }
-
         protected void execute() {
-            getSensorData();
-            isSensorDataAcquired = true;
-            updateUi();
+            if (getSensorData()) {
+                updateUi();
+            }
         }
 
-        abstract void getSensorData();
+        /**
+         * Does whatever is necessary to get data from sensor.
+         *
+         * @return {@code true} if data was fetched successfully, else {@code false}
+         */
+        abstract boolean getSensorData();
 
+        /**
+         * Called whenever new data is read from sensor.
+         */
         abstract void updateUi();
     }
 }

--- a/app/src/main/java/io/pslab/sensors/SensorADS1115.java
+++ b/app/src/main/java/io/pslab/sensors/SensorADS1115.java
@@ -92,10 +92,13 @@ public class SensorADS1115 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorADS1115 != null) {
                     dataADS1115 = sensorADS1115.getRaw();
+                    success = true;
                 }
             } catch (IOException | InterruptedException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
@@ -103,13 +106,13 @@ public class SensorADS1115 extends AbstractSensorActivity {
 
             timeElapsed = getTimeElapsed();
             entries.add(new Entry(timeElapsed, dataADS1115));
+
+            return success;
         }
 
         @Override
         public void updateUi() {
-            if (isSensorDataAcquired()) {
-                tvSensorADS1115.setText(String.valueOf(dataADS1115));
-            }
+            tvSensorADS1115.setText(String.valueOf(dataADS1115));
 
             LineDataSet dataSet = new LineDataSet(entries, getString(R.string.bx));
 

--- a/app/src/main/java/io/pslab/sensors/SensorAPDS9960.java
+++ b/app/src/main/java/io/pslab/sensors/SensorAPDS9960.java
@@ -123,7 +123,9 @@ public class SensorAPDS9960 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorAPDS9960 != null) {
                     if (spinnerMode.getSelectedItemPosition() == 0) {
@@ -139,6 +141,7 @@ public class SensorAPDS9960 extends AbstractSensorActivity {
                         sensorAPDS9960.enableProximity(true);
                         dataAPDS9960Gesture = sensorAPDS9960.getGesture();
                     }
+                    success = true;
                 }
             } catch (IOException | InterruptedException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
@@ -146,18 +149,18 @@ public class SensorAPDS9960 extends AbstractSensorActivity {
             timeElapsed = getTimeElapsed();
             entriesLux.add(new Entry(timeElapsed, (float) dataAPDS9960Lux));
             entriesProximity.add(new Entry(timeElapsed, dataAPDS9960Proximity));
+
+            return success;
         }
 
         public void updateUi() {
             if (spinnerMode.getSelectedItemPosition() == 0) {
 
-                if (isSensorDataAcquired()) {
-                    tvSensorAPDS9960Red.setText(DataFormatter.formatDouble(dataAPDS9960Color[0], DataFormatter.HIGH_PRECISION_FORMAT));
-                    tvSensorAPDS9960Green.setText(DataFormatter.formatDouble(dataAPDS9960Color[1], DataFormatter.HIGH_PRECISION_FORMAT));
-                    tvSensorAPDS9960Blue.setText(DataFormatter.formatDouble(dataAPDS9960Color[2], DataFormatter.HIGH_PRECISION_FORMAT));
-                    tvSensorAPDS9960Clear.setText(DataFormatter.formatDouble(dataAPDS9960Color[3], DataFormatter.HIGH_PRECISION_FORMAT));
-                    tvSensorAPDS9960Proximity.setText(DataFormatter.formatDouble(dataAPDS9960Proximity, DataFormatter.HIGH_PRECISION_FORMAT));
-                }
+                tvSensorAPDS9960Red.setText(DataFormatter.formatDouble(dataAPDS9960Color[0], DataFormatter.HIGH_PRECISION_FORMAT));
+                tvSensorAPDS9960Green.setText(DataFormatter.formatDouble(dataAPDS9960Color[1], DataFormatter.HIGH_PRECISION_FORMAT));
+                tvSensorAPDS9960Blue.setText(DataFormatter.formatDouble(dataAPDS9960Color[2], DataFormatter.HIGH_PRECISION_FORMAT));
+                tvSensorAPDS9960Clear.setText(DataFormatter.formatDouble(dataAPDS9960Color[3], DataFormatter.HIGH_PRECISION_FORMAT));
+                tvSensorAPDS9960Proximity.setText(DataFormatter.formatDouble(dataAPDS9960Proximity, DataFormatter.HIGH_PRECISION_FORMAT));
 
                 LineDataSet dataSetLux = new LineDataSet(entriesLux, getString(R.string.light_lux));
                 LineDataSet dataSetProximity = new LineDataSet(entriesProximity, getString(R.string.proximity));
@@ -165,7 +168,7 @@ public class SensorAPDS9960 extends AbstractSensorActivity {
                 updateChart(mChartLux, timeElapsed, dataSetLux);
                 updateChart(mChartProximity, timeElapsed, dataSetProximity);
 
-            } else if (isSensorDataAcquired()) {
+            } else {
                 switch (dataAPDS9960Gesture) {
                     case 1:
                         tvSensorAPDS9960Gesture.setText(R.string.up);

--- a/app/src/main/java/io/pslab/sensors/SensorBMP180.java
+++ b/app/src/main/java/io/pslab/sensors/SensorBMP180.java
@@ -106,28 +106,34 @@ public class SensorBMP180 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorBMP180 != null && getScienceLab().isConnected()) {
                     dataBMP180 = sensorBMP180.getRaw();
+                    success = dataBMP180 != null;
                 }
             } catch (IOException | InterruptedException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
 
             timeElapsed = getTimeElapsed();
-            entriesTemperature.add(new Entry(timeElapsed, (float) dataBMP180[0]));
-            entriesAltitude.add(new Entry(timeElapsed, (float) dataBMP180[1]));
-            entriesPressure.add(new Entry(timeElapsed, (float) dataBMP180[2]));
+
+            if (success) {
+                entriesTemperature.add(new Entry(timeElapsed, (float) dataBMP180[0]));
+                entriesAltitude.add(new Entry(timeElapsed, (float) dataBMP180[1]));
+                entriesPressure.add(new Entry(timeElapsed, (float) dataBMP180[2]));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorBMP180Temp.setText(DataFormatter.formatDouble(dataBMP180[0], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorBMP180Altitude.setText(DataFormatter.formatDouble(dataBMP180[1], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorBMP180Pressure.setText(DataFormatter.formatDouble(dataBMP180[2], DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorBMP180Temp.setText(DataFormatter.formatDouble(dataBMP180[0], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorBMP180Altitude.setText(DataFormatter.formatDouble(dataBMP180[1], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorBMP180Pressure.setText(DataFormatter.formatDouble(dataBMP180[2], DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSetTemperature = new LineDataSet(entriesTemperature, getString(R.string.temperature));
             LineDataSet dataSetAltitude = new LineDataSet(entriesAltitude, getString(R.string.altitude));

--- a/app/src/main/java/io/pslab/sensors/SensorCCS811.java
+++ b/app/src/main/java/io/pslab/sensors/SensorCCS811.java
@@ -92,27 +92,33 @@ public class SensorCCS811 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorCCS811 != null) {
                     int[] dataCS811 = sensorCCS811.getRaw();
                     dataCCS811eCO2 = dataCS811[0];
                     dataCCS811TVOC = dataCS811[1];
+                    success = true;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
             timeElapsed = getTimeElapsed();
-            entrieseCO2.add(new Entry(timeElapsed, dataCCS811eCO2));
-            entriesTVOC.add(new Entry(timeElapsed, dataCCS811TVOC));
+
+            if (success) {
+                entrieseCO2.add(new Entry(timeElapsed, dataCCS811eCO2));
+                entriesTVOC.add(new Entry(timeElapsed, dataCCS811TVOC));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorCCS811eCO2.setText(DataFormatter.formatDouble(dataCCS811eCO2, DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorCCS811TVOC.setText(DataFormatter.formatDouble(dataCCS811TVOC, DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorCCS811eCO2.setText(DataFormatter.formatDouble(dataCCS811eCO2, DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorCCS811TVOC.setText(DataFormatter.formatDouble(dataCCS811TVOC, DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSeteCO2 = new LineDataSet(entrieseCO2, getString(R.string.eCO2));
             LineDataSet dataSetTVOC = new LineDataSet(entriesTVOC, getString(R.string.eTVOC));

--- a/app/src/main/java/io/pslab/sensors/SensorHMC5883L.java
+++ b/app/src/main/java/io/pslab/sensors/SensorHMC5883L.java
@@ -106,7 +106,7 @@ public class SensorHMC5883L extends AbstractSensorActivity {
             try {
                 if (sensorHMC5883L != null) {
                     dataHMC5883L = sensorHMC5883L.getRaw();
-                    success = true;
+                    success = dataHMC5883L != null;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);

--- a/app/src/main/java/io/pslab/sensors/SensorHMC5883L.java
+++ b/app/src/main/java/io/pslab/sensors/SensorHMC5883L.java
@@ -100,28 +100,34 @@ public class SensorHMC5883L extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorHMC5883L != null) {
                     dataHMC5883L = sensorHMC5883L.getRaw();
+                    success = true;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
 
             timeElapsed = getTimeElapsed();
-            entriesBx.add(new Entry(timeElapsed, dataHMC5883L.get(0).floatValue()));
-            entriesBy.add(new Entry(timeElapsed, dataHMC5883L.get(1).floatValue()));
-            entriesBz.add(new Entry(timeElapsed, dataHMC5883L.get(2).floatValue()));
+
+            if (success) {
+                entriesBx.add(new Entry(timeElapsed, dataHMC5883L.get(0).floatValue()));
+                entriesBy.add(new Entry(timeElapsed, dataHMC5883L.get(1).floatValue()));
+                entriesBz.add(new Entry(timeElapsed, dataHMC5883L.get(2).floatValue()));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorHMC5883Lbx.setText(DataFormatter.formatDouble(dataHMC5883L.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorHMC5883Lby.setText(DataFormatter.formatDouble(dataHMC5883L.get(1), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorHMC5883Lbz.setText(DataFormatter.formatDouble(dataHMC5883L.get(2), DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorHMC5883Lbx.setText(DataFormatter.formatDouble(dataHMC5883L.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorHMC5883Lby.setText(DataFormatter.formatDouble(dataHMC5883L.get(1), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorHMC5883Lbz.setText(DataFormatter.formatDouble(dataHMC5883L.get(2), DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSetBx = new LineDataSet(entriesBx, getString(R.string.bx));
             LineDataSet dataSetBy = new LineDataSet(entriesBy, getString(R.string.by));

--- a/app/src/main/java/io/pslab/sensors/SensorMLX90614.java
+++ b/app/src/main/java/io/pslab/sensors/SensorMLX90614.java
@@ -144,27 +144,33 @@ public class SensorMLX90614 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorMLX90614 != null) {
                     dataMLX90614ObjectTemp = sensorMLX90614.getObjectTemperature();
                     dataMLX90614AmbientTemp = sensorMLX90614.getAmbientTemperature();
+                    success = true;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
 
             timeElapsed = getTimeElapsed();
-            entriesObjectTemperature.add(new Entry(timeElapsed, dataMLX90614ObjectTemp.floatValue()));
-            entriesAmbientTemperature.add(new Entry(timeElapsed, dataMLX90614AmbientTemp.floatValue()));
+
+            if (success) {
+                entriesObjectTemperature.add(new Entry(timeElapsed, dataMLX90614ObjectTemp.floatValue()));
+                entriesAmbientTemperature.add(new Entry(timeElapsed, dataMLX90614AmbientTemp.floatValue()));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorMLX90614ObjectTemp.setText(DataFormatter.formatDouble(dataMLX90614ObjectTemp, DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMLX90614AmbientTemp.setText(DataFormatter.formatDouble(dataMLX90614AmbientTemp, DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorMLX90614ObjectTemp.setText(DataFormatter.formatDouble(dataMLX90614ObjectTemp, DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMLX90614AmbientTemp.setText(DataFormatter.formatDouble(dataMLX90614AmbientTemp, DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSetObjectTemperature = new LineDataSet(entriesObjectTemperature, getString(R.string.object_temp));
             LineDataSet dataSetAmbientTemperature = new LineDataSet(entriesAmbientTemperature, getString(R.string.ambient_temp));

--- a/app/src/main/java/io/pslab/sensors/SensorMLX90614.java
+++ b/app/src/main/java/io/pslab/sensors/SensorMLX90614.java
@@ -151,7 +151,7 @@ public class SensorMLX90614 extends AbstractSensorActivity {
                 if (sensorMLX90614 != null) {
                     dataMLX90614ObjectTemp = sensorMLX90614.getObjectTemperature();
                     dataMLX90614AmbientTemp = sensorMLX90614.getAmbientTemperature();
-                    success = true;
+                    success = dataMLX90614ObjectTemp != null && dataMLX90614AmbientTemp != null;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);

--- a/app/src/main/java/io/pslab/sensors/SensorMPU6050.java
+++ b/app/src/main/java/io/pslab/sensors/SensorMPU6050.java
@@ -179,36 +179,40 @@ public class SensorMPU6050 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
 
             try {
                 dataMPU6050 = sensorMPU6050.getRaw();
+                success = dataMPU6050 != null;
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
 
             timeElapsed = getTimeElapsed();
 
-            entriesAx.add(new Entry(timeElapsed, dataMPU6050.get(0).floatValue()));
-            entriesAy.add(new Entry(timeElapsed, dataMPU6050.get(1).floatValue()));
-            entriesAz.add(new Entry(timeElapsed, dataMPU6050.get(2).floatValue()));
+            if (success) {
+                entriesAx.add(new Entry(timeElapsed, dataMPU6050.get(0).floatValue()));
+                entriesAy.add(new Entry(timeElapsed, dataMPU6050.get(1).floatValue()));
+                entriesAz.add(new Entry(timeElapsed, dataMPU6050.get(2).floatValue()));
 
-            entriesGx.add(new Entry(timeElapsed, dataMPU6050.get(4).floatValue()));
-            entriesGy.add(new Entry(timeElapsed, dataMPU6050.get(5).floatValue()));
-            entriesGz.add(new Entry(timeElapsed, dataMPU6050.get(6).floatValue()));
+                entriesGx.add(new Entry(timeElapsed, dataMPU6050.get(4).floatValue()));
+                entriesGy.add(new Entry(timeElapsed, dataMPU6050.get(5).floatValue()));
+                entriesGz.add(new Entry(timeElapsed, dataMPU6050.get(6).floatValue()));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorMPU6050ax.setText(DataFormatter.formatDouble(dataMPU6050.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU6050ay.setText(DataFormatter.formatDouble(dataMPU6050.get(1), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU6050az.setText(DataFormatter.formatDouble(dataMPU6050.get(2), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU6050gx.setText(DataFormatter.formatDouble(dataMPU6050.get(4), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU6050gy.setText(DataFormatter.formatDouble(dataMPU6050.get(5), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU6050gz.setText(DataFormatter.formatDouble(dataMPU6050.get(6), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU6050temp.setText(DataFormatter.formatDouble(dataMPU6050.get(3), DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorMPU6050ax.setText(DataFormatter.formatDouble(dataMPU6050.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU6050ay.setText(DataFormatter.formatDouble(dataMPU6050.get(1), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU6050az.setText(DataFormatter.formatDouble(dataMPU6050.get(2), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU6050gx.setText(DataFormatter.formatDouble(dataMPU6050.get(4), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU6050gy.setText(DataFormatter.formatDouble(dataMPU6050.get(5), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU6050gz.setText(DataFormatter.formatDouble(dataMPU6050.get(6), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU6050temp.setText(DataFormatter.formatDouble(dataMPU6050.get(3), DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSetAx = new LineDataSet(entriesAx, getString(R.string.ax));
             LineDataSet dataSetAy = new LineDataSet(entriesAy, getString(R.string.ay));

--- a/app/src/main/java/io/pslab/sensors/SensorMPU925X.java
+++ b/app/src/main/java/io/pslab/sensors/SensorMPU925X.java
@@ -179,38 +179,43 @@ public class SensorMPU925X extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
 
             try {
                 dataGyro = sensorMPU925X.getGyroscope();
                 dataAccel = sensorMPU925X.getAcceleration();
                 dataTemp = sensorMPU925X.getTemperature();
+
+                success = dataGyro != null && dataAccel != null;
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
 
             timeElapsed = getTimeElapsed();
 
-            entriesAx.add(new Entry(timeElapsed, (float) dataAccel[0]));
-            entriesAy.add(new Entry(timeElapsed, (float) dataAccel[1]));
-            entriesAz.add(new Entry(timeElapsed, (float) dataAccel[2]));
+            if (success) {
+                entriesAx.add(new Entry(timeElapsed, (float) dataAccel[0]));
+                entriesAy.add(new Entry(timeElapsed, (float) dataAccel[1]));
+                entriesAz.add(new Entry(timeElapsed, (float) dataAccel[2]));
 
-            entriesGx.add(new Entry(timeElapsed, (float) dataGyro[0]));
-            entriesGy.add(new Entry(timeElapsed, (float) dataGyro[1]));
-            entriesGz.add(new Entry(timeElapsed, (float) dataGyro[2]));
+                entriesGx.add(new Entry(timeElapsed, (float) dataGyro[0]));
+                entriesGy.add(new Entry(timeElapsed, (float) dataGyro[1]));
+                entriesGz.add(new Entry(timeElapsed, (float) dataGyro[2]));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorMPU925Xax.setText(DataFormatter.formatDouble(dataAccel[0], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU925Xay.setText(DataFormatter.formatDouble(dataAccel[1], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU925Xaz.setText(DataFormatter.formatDouble(dataAccel[2], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU925Xgx.setText(DataFormatter.formatDouble(dataGyro[0], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU925Xgy.setText(DataFormatter.formatDouble(dataGyro[1], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU925Xgz.setText(DataFormatter.formatDouble(dataGyro[2], DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorMPU925Xtemp.setText(DataFormatter.formatDouble(dataTemp, DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorMPU925Xax.setText(DataFormatter.formatDouble(dataAccel[0], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU925Xay.setText(DataFormatter.formatDouble(dataAccel[1], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU925Xaz.setText(DataFormatter.formatDouble(dataAccel[2], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU925Xgx.setText(DataFormatter.formatDouble(dataGyro[0], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU925Xgy.setText(DataFormatter.formatDouble(dataGyro[1], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU925Xgz.setText(DataFormatter.formatDouble(dataGyro[2], DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorMPU925Xtemp.setText(DataFormatter.formatDouble(dataTemp, DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSetAx = new LineDataSet(entriesAx, getString(R.string.ax));
             LineDataSet dataSetAy = new LineDataSet(entriesAy, getString(R.string.ay));

--- a/app/src/main/java/io/pslab/sensors/SensorSHT21.java
+++ b/app/src/main/java/io/pslab/sensors/SensorSHT21.java
@@ -93,28 +93,35 @@ public class SensorSHT21 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorSHT21 != null) {
                     sensorSHT21.selectParameter("temperature");
                     dataSHT21Temp = sensorSHT21.getRaw();
                     sensorSHT21.selectParameter("humidity");
                     dataSHT21Humidity = sensorSHT21.getRaw();
+
+                    success = dataSHT21Temp != null && dataSHT21Humidity != null;
                 }
             } catch (IOException | InterruptedException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
             timeElapsed = getTimeElapsed();
-            entriesTemperature.add(new Entry(timeElapsed, dataSHT21Temp.get(0).floatValue()));
-            entriesTemperature.add(new Entry(timeElapsed, dataSHT21Humidity.get(0).floatValue()));
+
+            if (success) {
+                entriesTemperature.add(new Entry(timeElapsed, dataSHT21Temp.get(0).floatValue()));
+                entriesTemperature.add(new Entry(timeElapsed, dataSHT21Humidity.get(0).floatValue()));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorSHT21Temp.setText(DataFormatter.formatDouble(dataSHT21Temp.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
-                tvSensorSHT21Humidity.setText(DataFormatter.formatDouble(dataSHT21Humidity.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
-            }
+            tvSensorSHT21Temp.setText(DataFormatter.formatDouble(dataSHT21Temp.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
+            tvSensorSHT21Humidity.setText(DataFormatter.formatDouble(dataSHT21Humidity.get(0), DataFormatter.HIGH_PRECISION_FORMAT));
 
             LineDataSet dataSetTemperature = new LineDataSet(entriesTemperature, getString(R.string.temperature));
             LineDataSet dataSetHumidity = new LineDataSet(entriesHumidity, getString(R.string.humidity));

--- a/app/src/main/java/io/pslab/sensors/SensorTSL2561.java
+++ b/app/src/main/java/io/pslab/sensors/SensorTSL2561.java
@@ -122,27 +122,33 @@ public class SensorTSL2561 extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorTSL2561 != null) {
                     dataTSL2561 = sensorTSL2561.getRaw();
+                    success = dataTSL2561 != null;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
             timeElapsed = getTimeElapsed();
-            entriesFull.add(new Entry(timeElapsed, dataTSL2561[0]));
-            entriesInfrared.add(new Entry(timeElapsed, dataTSL2561[1]));
-            entriesVisible.add(new Entry(timeElapsed, dataTSL2561[2]));
+
+            if (success) {
+                entriesFull.add(new Entry(timeElapsed, dataTSL2561[0]));
+                entriesInfrared.add(new Entry(timeElapsed, dataTSL2561[1]));
+                entriesVisible.add(new Entry(timeElapsed, dataTSL2561[2]));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorTSL2561FullSpectrum.setText(String.valueOf(dataTSL2561[0]));
-                tvSensorTSL2561Infrared.setText(String.valueOf(dataTSL2561[1]));
-                tvSensorTSL2561Visible.setText(String.valueOf(dataTSL2561[2]));
-            }
+            tvSensorTSL2561FullSpectrum.setText(String.valueOf(dataTSL2561[0]));
+            tvSensorTSL2561Infrared.setText(String.valueOf(dataTSL2561[1]));
+            tvSensorTSL2561Visible.setText(String.valueOf(dataTSL2561[2]));
 
             LineDataSet datasetFull = new LineDataSet(entriesFull, getString(R.string.full));
             LineDataSet dataSetInfrared = new LineDataSet(entriesInfrared, getString(R.string.infrared));

--- a/app/src/main/java/io/pslab/sensors/SensorVL53L0X.java
+++ b/app/src/main/java/io/pslab/sensors/SensorVL53L0X.java
@@ -77,24 +77,30 @@ public class SensorVL53L0X extends AbstractSensorActivity {
         private float timeElapsed = getTimeElapsed();
 
         @Override
-        public void getSensorData() {
+        public boolean getSensorData() {
+            boolean success = false;
+
             try {
                 if (sensorVL53L0X != null) {
                     dataVL53L0X = sensorVL53L0X.getRaw();
+                    success = true;
                 }
             } catch (IOException e) {
                 Log.e(TAG, "Error getting sensor data.", e);
             }
 
             timeElapsed = getTimeElapsed();
-            entries.add(new Entry(timeElapsed, (float) dataVL53L0X));
+
+            if (success) {
+                entries.add(new Entry(timeElapsed, (float) dataVL53L0X));
+            }
+
+            return success;
         }
 
         public void updateUi() {
 
-            if (isSensorDataAcquired()) {
-                tvSensorVL53L0X.setText(String.valueOf(dataVL53L0X));
-            }
+            tvSensorVL53L0X.setText(String.valueOf(dataVL53L0X));
 
             LineDataSet dataSet = new LineDataSet(entries, getString(R.string.bx));
 


### PR DESCRIPTION
Fixes #2604

## Changes 
- add return value to method which reads sensor data
- skip UI update if sensor data was not read successfully

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Bug Fixes:
- Prevent UI updates if sensor data reading fails.