### PR TITLE
chore: updated pull-request workflow to build debug APK

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -46,6 +46,7 @@ runs:
         VERSION_NAME: ${{inputs.VERSION_NAME}}
         VERSION_CODE: ${{inputs.VERSION_CODE}}
       run: |
+        flutter build apk --debug --build-name $VERSION_NAME --build-number $VERSION_CODE
         flutter build apk --build-name $VERSION_NAME --build-number $VERSION_CODE
         flutter build appbundle --build-name $VERSION_NAME --build-number $VERSION_CODE
 
@@ -54,4 +55,4 @@ runs:
       with:
         name: apk-files
         path: |
-          build/app/outputs/flutter-apk
+          build/app/outputs/flutter-apk/app-debug.apk


### PR DESCRIPTION
I guess we should follow the same procedure that we do for the native app. Build debug APKs on pull requests and release APKs and bundles on push-events.
Currently, we are building release APKs on pull requests, which can't be installed on devices since we aren't signing them, and hence can't be tested by contributors.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Build debug APKs instead of release APKs for pull requests to allow testing on contributor devices.

Enhancements:
- Store only the debug APK as an artifact.

CI:
- Build debug APKs in the Android build workflow.