### PR TITLE
chore: bump com.android.application from 8.7.3 to 8.8.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,5 +11,5 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "8.7.3" apply false
+    id("com.android.application") version "8.8.0" apply false
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 13 19:46:35 IST 2024
+#Mon Jan 13 11:07:17 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Superseeds #2609.

## Summary by Sourcery

Upgrade Gradle to version 8.10.2 and the Android Gradle plugin to version 8.8.0.

Build:
- Update Gradle wrapper to version 8.10.2.
- Bump Android Gradle plugin version to 8.8.0.