### PR TITLE
chore: bump androidx.recyclerview:recyclerview from 1.3.2 to 1.4.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,12 +10,12 @@ val GITHUB_BUILD = System.getenv("GITHUB_ACTIONS") == "true" && KEYSTORE_FILE.ex
 
 android {
     namespace = "io.pslab"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "io.pslab"
         minSdk = 24
-        targetSdk = 34
+        targetSdk = 35
         versionCode = System.getenv("VERSION_CODE")?.toInt() ?: 1
         versionName = System.getenv("VERSION_NAME") ?: "1.0.0"
         resourceConfigurations += setOf("en", "ru", "ar", "si", "pl")
@@ -66,7 +66,7 @@ dependencies {
     // Android stock libraries
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("androidx.cardview:cardview:1.0.0")
-    implementation("androidx.recyclerview:recyclerview:1.3.2")
+    implementation("androidx.recyclerview:recyclerview:1.4.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.preference:preference:1.2.1")
     implementation("androidx.browser:browser:1.8.0")


### PR DESCRIPTION
Superseeds #2616.

## Changes 
- Bumps _androidx.recyclerview:recyclerview_ from 1.3.2 to 1.4.0.
- Changes the _compileSdk_ to 35.
- Also, changes the _targetSdk_ to 35. We were targeting 34 before, which has now been declared as the minimum API level that an app should target, to stay on the PlayStore.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause API level 34 -> 35 introduces many changes. I tested the app once but couldn't find anything that breaks our app.  It'd be great if you could test the whole app once before merging this PR.

## Summary by Sourcery

Update Android compile and target SDK versions to 35 and bump androidx.recyclerview library to 1.4.0.

Build:
- Bump androidx.recyclerview from 1.3.2 to 1.4.0.
- Change compileSdk to 35.
- Change targetSdk to 35.