### PR TITLE
chore: bump actions/upload-artifact from 3 to 4

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,7 +29,7 @@ jobs:
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/
@@ -39,7 +39,7 @@ jobs:
           bash ./gradlew build --stacktrace
 
       - name: Store APK file
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: apk-files
           path: |


### PR DESCRIPTION
_actions/upload-artifactv3_ has officially been deprecated, leading to failure of our _development_ workflows.
This PR bumps it to v4.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

CI:
- Update the "actions/upload-artifact" action from v3 to v4 to address deprecation warnings and prevent workflow failures.