### PR TITLE
fix: initialization of ScienceLab

### DIFF
--- a/lib/others/science_lab_common.dart
+++ b/lib/others/science_lab_common.dart
@@ -6,8 +6,8 @@ class ScienceLabCommon {
   static late ScienceLab _scienceLab;
   static late CommunicationHandler communicationHandler;
 
-  ScienceLabCommon(CommunicationHandler communicationHandler) {
-    communicationHandler = communicationHandler;
+  ScienceLabCommon(CommunicationHandler mCommunicationHandler) {
+    communicationHandler = mCommunicationHandler;
     _scienceLab = ScienceLab(communicationHandler);
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the initialization of ScienceLab by correctly assigning the communicationHandler.