### PR TITLE
chore: supply profile APK for testing

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -47,6 +47,7 @@ runs:
         VERSION_CODE: ${{inputs.VERSION_CODE}}
       run: |
         flutter build apk --debug --build-name $VERSION_NAME --build-number $VERSION_CODE
+        flutter build apk --profile --build-name $VERSION_NAME --build-number $VERSION_CODE
         flutter build apk --build-name $VERSION_NAME --build-number $VERSION_CODE
         flutter build appbundle --build-name $VERSION_NAME --build-number $VERSION_CODE
 
@@ -55,4 +56,4 @@ runs:
       with:
         name: apk-files
         path: |
-          build/app/outputs/flutter-apk/app-debug.apk
+          build/app/outputs/flutter-apk/app-profile.apk


### PR DESCRIPTION
Supply the _profile_, instead of the _debug_ APK for testing through the comment pipeline.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Build a profile APK and use it for testing.

CI:
- Build a profile APK artifact in the Android build workflow

Chores:
- Build and supply a profile APK for testing, in addition to the debug and release APKs.
- Use the profile APK for testing through the comment pipeline instead of the debug APK.