### PR TITLE
fix: double indication of the time units in the sensor screens

### DIFF
--- a/app/src/main/res/layout/activity_sensor_graph_view.xml
+++ b/app/src/main/res/layout/activity_sensor_graph_view.xml
@@ -66,20 +66,6 @@
                         tools:layout_editor_absoluteX="288dp"
                         tools:layout_editor_absoluteY="0dp" />
 
-                    <TextView
-                        android:id="@+id/tv_unit_xaxis_hmc"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_alignParentTop="true"
-                        android:layout_toEndOf="@+id/tv_graph_label_xaxis_hmc"
-                        android:layout_toRightOf="@+id/tv_graph_label_xaxis_hmc"
-                        android:text="@string/seconds"
-                        android:textColor="#ffff"
-                        android:textSize="@dimen/lux_chart_axis_text"
-                        android:textStyle="normal|bold"
-                        app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_hmc"
-                        tools:layout_editor_absoluteY="0dp" />
-
                 </RelativeLayout>
 
                 <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/sensor_ads1115.xml
+++ b/app/src/main/res/layout/sensor_ads1115.xml
@@ -150,18 +150,6 @@
                             tools:layout_editor_absoluteX="288dp"
                             tools:layout_editor_absoluteY="0dp" />
 
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_ads"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_ads"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_ads"
-                            tools:layout_editor_absoluteY="0dp" />
                     </RelativeLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/sensor_apds9960.xml
+++ b/app/src/main/res/layout/sensor_apds9960.xml
@@ -638,24 +638,11 @@
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
                             android:gravity="center_vertical|center_horizontal|center"
-                            android:text="@string/time_space"
+                            android:text="@string/time"
                             android:textColor="#ffff"
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_apds"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_lux_apds"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_lux_apds"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>
@@ -769,19 +756,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_prox_apds"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_prox_apds"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_prox_apds"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_bmp180.xml
+++ b/app/src/main/res/layout/sensor_bmp180.xml
@@ -194,19 +194,6 @@
                             tools:layout_editor_absoluteX="288dp"
                             tools:layout_editor_absoluteY="0dp" />
 
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_temp_bmp"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_temp_bmp"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_temp_bmp"
-                            tools:layout_editor_absoluteY="0dp" />
-
                     </RelativeLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
@@ -314,19 +301,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_alt_bmp"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_alt_bmp"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_alt_bmp"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>
@@ -438,19 +412,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_pre_bmp"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_pre_bmp"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_pre_bmp"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_ccs811.xml
+++ b/app/src/main/res/layout/sensor_ccs811.xml
@@ -177,19 +177,6 @@
                             tools:layout_editor_absoluteX="288dp"
                             tools:layout_editor_absoluteY="0dp" />
 
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_eCO2_ccs811"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_eCO2_ccs811"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_eCO2_ccs811"
-                            tools:layout_editor_absoluteY="0dp" />
-
                     </RelativeLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout
@@ -298,19 +285,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_TVOC_ccs811"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_TVOC_ccs811"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_TVOC_ccs811"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_hmc5883l.xml
+++ b/app/src/main/res/layout/sensor_hmc5883l.xml
@@ -188,24 +188,11 @@
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
                             android:gravity="center_vertical|center_horizontal|center"
-                            android:text="@string/time_space"
+                            android:text="@string/time"
                             android:textColor="#ffff"
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_hmc"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_hmc"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_hmc"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_mlx90614.xml
+++ b/app/src/main/res/layout/sensor_mlx90614.xml
@@ -170,24 +170,11 @@
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
                             android:gravity="center_vertical|center_horizontal|center"
-                            android:text="@string/time_space"
+                            android:text="@string/time"
                             android:textColor="#ffff"
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_objtemp_mlx"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_objtemp_mlx"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_objtemp_mlx"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>
@@ -293,24 +280,11 @@
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
                             android:gravity="center_vertical|center_horizontal|center"
-                            android:text="@string/time_space"
+                            android:text="@string/time"
                             android:textColor="#ffff"
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_ambtemp_mlx"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_ambtemp_mlx"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_ambtemp_mlx"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_mpu6050.xml
+++ b/app/src/main/res/layout/sensor_mpu6050.xml
@@ -84,24 +84,11 @@
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
                             android:gravity="center_vertical|center_horizontal|center"
-                            android:text="@string/time_space"
+                            android:text="@string/time"
                             android:textColor="#ffff"
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_hmc"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_acc_mpu"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_acc_mpu"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>
@@ -214,19 +201,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_gy_mpu"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_gy_mpu"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_gy_mpu"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_mpu925x.xml
+++ b/app/src/main/res/layout/sensor_mpu925x.xml
@@ -278,24 +278,11 @@
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
                             android:gravity="center_vertical|center_horizontal|center"
-                            android:text="@string/time_space"
+                            android:text="@string/time"
                             android:textColor="#ffff"
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_hmc"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_acc_mpu"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_acc_mpu"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>
@@ -408,19 +395,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_gy_mpu"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_gy_mpu"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_gy_mpu"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_sht21.xml
+++ b/app/src/main/res/layout/sensor_sht21.xml
@@ -165,7 +165,6 @@
                             android:id="@+id/tv_graph_label_xaxis_temperature_sht21"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
                             android:layout_centerHorizontal="true"
                             android:layout_gravity="center_vertical|center_horizontal|center"
                             android:foregroundGravity="center_vertical"
@@ -175,19 +174,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_temperature_sht21"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_temperature_sht21"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_temperature_sht21"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>
@@ -298,19 +284,6 @@
                             android:textSize="@dimen/text_size_9sp"
                             android:textStyle="normal|bold"
                             tools:layout_editor_absoluteX="288dp"
-                            tools:layout_editor_absoluteY="0dp" />
-
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_humidity_sht21"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_humidity_sht21"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_humidity_sht21"
                             tools:layout_editor_absoluteY="0dp" />
 
                     </RelativeLayout>

--- a/app/src/main/res/layout/sensor_tsl2561.xml
+++ b/app/src/main/res/layout/sensor_tsl2561.xml
@@ -194,19 +194,6 @@
                             tools:layout_editor_absoluteX="288dp"
                             tools:layout_editor_absoluteY="0dp" />
 
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_tsl"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_tsl"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_tsl"
-                            tools:layout_editor_absoluteY="0dp" />
-
                     </RelativeLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/layout/sensor_vl53l0x.xml
+++ b/app/src/main/res/layout/sensor_vl53l0x.xml
@@ -151,18 +151,6 @@
                             tools:layout_editor_absoluteX="288dp"
                             tools:layout_editor_absoluteY="0dp" />
 
-                        <TextView
-                            android:id="@+id/tv_unit_xaxis_ads"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_alignParentTop="true"
-                            android:layout_toEndOf="@+id/tv_graph_label_xaxis_ads"
-                            android:text="@string/seconds"
-                            android:textColor="#ffff"
-                            android:textSize="@dimen/text_size_9sp"
-                            android:textStyle="normal|bold"
-                            app:layout_constraintLeft_toRightOf="@+id/tv_graph_label_xaxis_ads"
-                            tools:layout_editor_absoluteY="0dp" />
                     </RelativeLayout>
 
                     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -445,7 +445,6 @@
 
     <string name="voltage_unit">(V)</string>
     <string name="volts">فولت</string>
-    <string name="seconds">(س)</string>
     <string name="lux">LX</string>
     <string name="pressure2">صحافة.</string>
     <string name="plot_altitude">المؤامرة - الارتفاع</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -449,7 +449,6 @@
 
     <string name="voltage_unit">(V)</string>
     <string name="volts">wolty</string>
-    <string name="seconds">(s)</string>
     <string name="lux">Lx</string>
     <string name="pressure2">Kliknij.</string>
     <string name="plot_altitude">Wykres - Wysokość</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -452,7 +452,6 @@
 
     <string name="voltage_unit">(V)</string>
     <string name="volts">Вольт</string>
-    <string name="seconds">(с)</string>
     <string name="lux">Lx</string>
     <string name="pressure2">Нажмите.</string>
         <string name="plot_altitude">Участко - высота над уровнем моря</string>

--- a/app/src/main/res/values-si/string.xml
+++ b/app/src/main/res/values-si/string.xml
@@ -449,7 +449,7 @@
 
     <string name="voltage_unit">(V)</string>
     <string name="volts">වෝල්ට්</string>
-    <string name="seconds">(s)</string>
+
     <string name="lux">Lx</string>
     <string name="pressure2">පීඩන.</string>
     <string name="plot_altitude">සලකුණ - අක්ෂාංශ</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,7 +480,6 @@
 
     <string name="voltage_unit">(V)</string>
     <string name="volts">Volts</string>
-    <string name="seconds">(s)</string>
     <string name="lux">Lx</string>
     <string name="pressure2">Press.</string>
     <string name="plot_altitude">Plot - Altitude</string>


### PR DESCRIPTION
Fixes #2591

## Changes 
- remove redundant textviews with text "(s)"
- remove unused string resource ("strings/seconds")
- replaced `time_space` string with `time`

## Screenshots / Recordings
<img src="https://github.com/user-attachments/assets/7b2402ec-d075-4c07-9f99-853c2a268dac" height="500" />

**Checklist**:
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Fixes a bug where the time units were displayed twice in the sensor screens by removing the redundant text views and the unused string resource.

Bug Fixes:
- Removes the redundant indication of time units in the sensor screens.

Chores:
- Removes the unused string resource "seconds".