### PR TITLE
fix: replace non-FLOSS library for 3rd party library screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("com.android.application")
-    id("com.google.android.gms.oss-licenses-plugin")
+    id("com.mikepenz.aboutlibraries.plugin")
 }
 
 apply(plugin = "realm-android")
@@ -124,6 +124,5 @@ dependencies {
     implementation("com.github.realm:realm-android-adapters:v4.0.0")
 
     // OSS license plugin
-    implementation("com.google.android.gms:play-services-oss-licenses:17.1.0")
-
+    implementation("com.mikepenz:aboutlibraries:11.6.3")
 }

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -130,12 +130,6 @@
         <activity
             android:name=".activity.DustSensorActivity"
             android:screenOrientation="fullSensor" />
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/OssLicenseScreenTheme" />
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:theme="@style/OssLicenseScreenTheme" />
 
         <receiver android:name=".receivers.USBDetachReceiver" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -127,12 +127,6 @@
         <activity
             android:name=".activity.DustSensorActivity"
             android:screenOrientation="fullSensor" />
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
-            android:theme="@style/OssLicenseScreenTheme" />
-        <activity
-            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
-            android:theme="@style/OssLicenseScreenTheme" />
 
         <receiver android:name=".receivers.USBDetachReceiver" />
 

--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -34,9 +34,9 @@ import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
 
-import com.google.android.gms.oss.licenses.OssLicensesMenuActivity;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.snackbar.Snackbar;
+import com.mikepenz.aboutlibraries.LibsBuilder;
 
 import java.io.IOException;
 
@@ -334,8 +334,9 @@ public class MainActivity extends AppCompatActivity {
                         }
                         break;
                     case R.id.nav_third_party_libs:
-                        OssLicensesMenuActivity.setActivityTitle(getString(R.string.third_party_libs));
-                        startActivity(new Intent(MainActivity.this, OssLicensesMenuActivity.class));
+                        new LibsBuilder()
+                                .withActivityTitle(getString(R.string.third_party_libs))
+                                .start(MainActivity.this);
                         break;
                     default:
                         navItemIndex = 0;

--- a/app/src/main/res/values-v21/styles.xml
+++ b/app/src/main/res/values-v21/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1095,6 +1095,10 @@
     <string name="distance">Distance</string>
     <string name="distance_unit">(mm)</string>
 
+    <string name="aboutLibraries_description_showIcon">true</string>
+    <string name="aboutLibraries_description_showVersion">true</string>
+    <string name="aboutLibraries_description_text">Below is a list of the third-party open source software libraries used in the PSLab app.</string>
+
     <string name="legacy_title">Legacy Firmware Detected</string>
     <string name="legacy_message">We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.</string>
     <string name="pin_esp_name" translatable="false">ESP</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -14,11 +14,6 @@
 
     <style name="AppThemeSplash" parent="AppTheme">
         <item name="colorPrimaryDark">@color/darkWhite</item>
-    </style>
-
-    <style name="OssLicenseScreenTheme" parent="AppTheme">
-        <item name="windowActionBar">true</item>
-        <item name="windowNoTitle">false</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,10 @@ buildscript {
     }
     dependencies {
         classpath("io.realm:realm-gradle-plugin:10.19.0")
-        classpath("com.google.android.gms:oss-licenses-plugin:0.10.6")
-
     }
 }
 
 plugins {
     id("com.android.application") version "8.8.2" apply false
+    id("com.mikepenz.aboutlibraries.plugin") version "11.6.3"
 }


### PR DESCRIPTION
Fixes #2644

## Changes 
- removed non-FLOSS library
- added [AboutLibraries](https://github.com/mikepenz/AboutLibraries)
- changed code to replace old 3rd party library screen with new version based on AboutLibraries
- changed app theme since AboutLibraries requires a theme based on `MaterialComponents` (I have not noticed any side effects)

## Screenshots / Recordings  
https://github.com/user-attachments/assets/3ea30fe2-1e1f-41ef-89f8-f7477cb87321

Looks better than the old solution, doesn't it!?

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Replaces the non-FLOSS library used for the 3rd party library screen with the AboutLibraries library. Updates the app theme to be based on MaterialComponents to be compatible with AboutLibraries.

Enhancements:
- Replaces the 3rd party library screen with a new version based on AboutLibraries.
- Updates the app theme to be based on MaterialComponents to be compatible with AboutLibraries.
- Removes the OssLicenseScreenTheme.