### PR TITLE
feat: remove duplicates from 3rd party licenses, add license info of app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,11 @@ android {
     buildFeatures {
         buildConfig = true
     }
+    aboutLibraries {
+        excludeFields = arrayOf("generated")
+        duplicationMode = com.mikepenz.aboutlibraries.plugin.DuplicateMode.MERGE
+        duplicationRule = com.mikepenz.aboutlibraries.plugin.DuplicateRule.SIMPLE
+    }
 }
 
 

--- a/app/src/main/java/io/pslab/activity/MainActivity.java
+++ b/app/src/main/java/io/pslab/activity/MainActivity.java
@@ -335,7 +335,7 @@ public class MainActivity extends AppCompatActivity {
                         break;
                     case R.id.nav_third_party_libs:
                         new LibsBuilder()
-                                .withActivityTitle(getString(R.string.third_party_libs))
+                                .withActivityTitle(getString(R.string.software_licenses))
                                 .start(MainActivity.this);
                         break;
                     default:

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -68,6 +68,6 @@
         <item
             android:id="@+id/nav_third_party_libs"
             android:icon="@drawable/baseline_attribution_24"
-            android:title="@string/third_party_libs" />
+            android:title="@string/software_licenses" />
     </group>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1087,7 +1087,7 @@
     <string name="unit_volts">\u0020V</string>
     <string name="no_playback_data">No data to display</string>
     <string name="privacy_policy">Privacy Policy</string>
-    <string name="third_party_libs">Open Source Licenses</string>
+    <string name="software_licenses">Software Licenses</string>
     <string name="auto_scale_error">No input found</string>
     <string name="auto_scale">Auto</string>
     <string name="control_stop">Stop</string>
@@ -1097,7 +1097,7 @@
 
     <string name="aboutLibraries_description_showIcon">true</string>
     <string name="aboutLibraries_description_showVersion">true</string>
-    <string name="aboutLibraries_description_text">Below is a list of the third-party open source software libraries used in the PSLab app.</string>
+    <string name="aboutLibraries_description_text">The PSLab app is licensed under the Apache License 2.0.&lt;br /&gt;&lt;br /&gt;Below is a list of the third-party open source software libraries used in the PSLab app.</string>
 
     <string name="legacy_title">Legacy Firmware Detected</string>
     <string name="legacy_message">We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.</string>


### PR DESCRIPTION
Fixes #2647

## Changes 
- add AboutLibraries config which filters duplicates and which makes the APK more reproducible
- add license of PSLab app to license screen
- rename license screen from "Open Source Licenses" to "Software Licenses"

## Screenshots / Recordings  
<img src="https://github.com/user-attachments/assets/d26cc717-1410-43d2-b85c-2386050392fb" width="512"/>
<img src="https://github.com/user-attachments/assets/353595d4-a4c1-40db-a264-e90bee799aa7" width="512"/>

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Introduce AboutLibraries configuration to manage duplicate licenses and enhance APK reproducibility. Update the license screen to include the PSLab app's license and rename it to 'Software Licenses'.

New Features:
- Add AboutLibraries configuration to filter duplicate licenses and improve APK reproducibility.

Enhancements:
- Rename the license screen from 'Open Source Licenses' to 'Software Licenses'.

Documentation:
- Add the PSLab app's license information to the license screen.