### PR TITLE
fix: gyroscope screen crash and UI

### DIFF
--- a/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
@@ -435,9 +435,7 @@ public class GyroscopeDataFragment extends Fragment implements OperationCallback
                 fragment.setPreviousTimeElapsed(timeElapsed);
                 fragment.addEntry(new Entry((float) timeElapsed, fragment.getCurrentValue()));
 
-                String label = fragment.getContext() != null ? fragment.getContext().getString(R.string.gyroscope) : "Gyroscope";
-
-                LineDataSet dataSet = new LineDataSet(fragment.getEntries(), label);
+                LineDataSet dataSet = new LineDataSet(fragment.getEntries(), getString(R.string.gyroscope));
                 dataSet.setDrawCircles(false);
                 dataSet.setDrawValues(false);
                 dataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);

--- a/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/GyroscopeDataFragment.java
@@ -425,14 +425,19 @@ public class GyroscopeDataFragment extends Fragment implements OperationCallback
     }
 
     private void visualizeData() {
+        if (!isAdded()) return;
         for (int i = 0; i < gyroscopeViewFragments.size(); i++) {
             GyroscopeViewFragment fragment = gyroscopeViewFragments.get(i);
+            if (!fragment.isAdded()) continue;
+
             long timeElapsed = (System.currentTimeMillis() - startTime) / 1000;
             if (timeElapsed != fragment.getPreviousTimeElapsed()) {
                 fragment.setPreviousTimeElapsed(timeElapsed);
                 fragment.addEntry(new Entry((float) timeElapsed, fragment.getCurrentValue()));
 
-                LineDataSet dataSet = new LineDataSet(fragment.getEntries(), getString(R.string.gyroscope));
+                String label = fragment.getContext() != null ? fragment.getContext().getString(R.string.gyroscope) : "Gyroscope";
+
+                LineDataSet dataSet = new LineDataSet(fragment.getEntries(), label);
                 dataSet.setDrawCircles(false);
                 dataSet.setDrawValues(false);
                 dataSet.setMode(LineDataSet.Mode.CUBIC_BEZIER);

--- a/app/src/main/res/layout/fragment_gyroscope_data.xml
+++ b/app/src/main/res/layout/fragment_gyroscope_data.xml
@@ -17,24 +17,24 @@
             android:id="@+id/gyroscope_x_axis_fragment"
             android:name="io.pslab.fragment.GyroscopeViewFragment"
             android:layout_width="match_parent"
-            android:layout_height="300dp"
-            android:layout_margin="5dp"
+            android:layout_height="@dimen/gyroscope_fragment_height"
+            android:layout_margin="@dimen/gyroscope_fragment_margin"
             tools:layout="@layout/gyroscope_list_item" />
 
         <fragment
             android:id="@+id/gyroscope_y_axis_fragment"
             android:name="io.pslab.fragment.GyroscopeViewFragment"
             android:layout_width="match_parent"
-            android:layout_height="300dp"
-            android:layout_margin="5dp"
+            android:layout_height="@dimen/gyroscope_fragment_height"
+            android:layout_margin="@dimen/gyroscope_fragment_margin"
             tools:layout="@layout/gyroscope_list_item" />
 
         <fragment
             android:id="@+id/gyroscope_z_axis_fragment"
             android:name="io.pslab.fragment.GyroscopeViewFragment"
             android:layout_width="match_parent"
-            android:layout_height="300dp"
-            android:layout_margin="5dp"
+            android:layout_height="@dimen/gyroscope_fragment_height"
+            android:layout_margin="@dimen/gyroscope_fragment_margin"
             tools:layout="@layout/gyroscope_list_item" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_gyroscope_data.xml
+++ b/app/src/main/res/layout/fragment_gyroscope_data.xml
@@ -1,40 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:id="@+id/gyro_linearlayout"
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    android:orientation="vertical"
-    tools:context="io.pslab.activity.GyroscopeActivity">
+    android:fitsSystemWindows="true">
 
-    <fragment
-        android:id="@+id/gyroscope_x_axis_fragment"
-        android:name="io.pslab.fragment.GyroscopeViewFragment"
+    <LinearLayout
+        android:id="@+id/gyro_linearlayout"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_margin="5dp"
-        tools:layout="@layout/gyroscope_list_item" />
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        tools:context="io.pslab.activity.GyroscopeActivity">
 
-    <fragment
-        android:id="@+id/gyroscope_y_axis_fragment"
-        android:name="io.pslab.fragment.GyroscopeViewFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_margin="5dp"
-        tools:layout="@layout/gyroscope_list_item" />
+        <fragment
+            android:id="@+id/gyroscope_x_axis_fragment"
+            android:name="io.pslab.fragment.GyroscopeViewFragment"
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:layout_margin="5dp"
+            tools:layout="@layout/gyroscope_list_item" />
 
-    <fragment
-        android:id="@+id/gyroscope_z_axis_fragment"
-        android:name="io.pslab.fragment.GyroscopeViewFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_marginTop="5dp"
-        android:layout_marginLeft="5dp"
-        android:layout_marginRight="5dp"
-        android:layout_marginBottom="10dp"
-        tools:layout="@layout/gyroscope_list_item" />
-</LinearLayout>
+        <fragment
+            android:id="@+id/gyroscope_y_axis_fragment"
+            android:name="io.pslab.fragment.GyroscopeViewFragment"
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:layout_margin="5dp"
+            tools:layout="@layout/gyroscope_list_item" />
+
+        <fragment
+            android:id="@+id/gyroscope_z_axis_fragment"
+            android:name="io.pslab.fragment.GyroscopeViewFragment"
+            android:layout_width="match_parent"
+            android:layout_height="300dp"
+            android:layout_margin="5dp"
+            tools:layout="@layout/gyroscope_list_item" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -421,4 +421,7 @@
     <dimen name="text_size_osc">13sp</dimen>
     <dimen name="text_size_9sp">9sp</dimen>
 
+    <dimen name="gyroscope_fragment_height">300dp</dimen>
+    <dimen name="gyroscope_fragment_margin">5dp</dimen>
+
 </resources>


### PR DESCRIPTION
**Bug Fixes**
The gyroscope screen was crashing and the gyroscope screen ui was not properly visible in landscape mode

**Exception**
java.lang.IllegalStateException: Fragment GyroscopeDataFragment{9c6c7cf} (e25b37d6-0238-4496-aaa5-74f0d1aa9d93) not attached to a context.

## Changes 
Added checks to ensure fragments are properly attached before accessing context (isAdded() and fragment.isAdded() checks)
Used safe context access for string resources with a fallback string
Used ScrollView to ensure proper UI visibility in landscape mode

## Screenshots / Recordings  
**Before**

https://github.com/user-attachments/assets/d4d3be7f-9513-402a-b5a9-2394b324ff4b

**After**

https://github.com/user-attachments/assets/d10fcd51-3dd9-46ee-8d24-b5d58decba42



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Fixes a crash on the gyroscope screen and improves UI visibility in landscape mode. The fragment is now properly attached before accessing the context and a ScrollView is used to ensure proper UI visibility.

Bug Fixes:
- Fixes a crash caused by accessing the context of a fragment that is not attached.
- Fixes UI visibility issues in landscape mode on the gyroscope screen.
- Prevents the IllegalStateException: Fragment GyroscopeDataFragment not attached to a context.

Enhancements:
- Improves UI visibility in landscape mode by using ScrollView.