### PR TITLE
fix: accelerometer screen crash and ui

### DIFF
--- a/app/src/main/java/io/pslab/fragment/AccelerometerDataFragment.java
+++ b/app/src/main/java/io/pslab/fragment/AccelerometerDataFragment.java
@@ -419,6 +419,7 @@ public class AccelerometerDataFragment extends Fragment implements OperationCall
     }
 
     private void visualizeData() {
+        if (!isAdded()) return;
         for (int i = 0; i < accelerometerViewFragments.size(); i++) {
             AccelerometerViewFragment fragment = accelerometerViewFragments.get(i);
             long timeElapsed = (System.currentTimeMillis() - startTime) / 1000;

--- a/app/src/main/res/layout/fragment_accelerometer_data.xml
+++ b/app/src/main/res/layout/fragment_accelerometer_data.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -19,7 +18,7 @@
             android:name="io.pslab.fragment.AccelerometerViewFragment"
             android:layout_width="match_parent"
             android:layout_height="@dimen/accelerometer_fragment_height"
-            android:layout_marginBottom="5dp"
+            android:layout_marginBottom="@dimen/accelerometer_fragment_margint"
             tools:layout="@layout/accelerometer_list_item" />
 
         <fragment
@@ -27,7 +26,7 @@
             android:name="io.pslab.fragment.AccelerometerViewFragment"
             android:layout_width="match_parent"
             android:layout_height="@dimen/accelerometer_fragment_height"
-            android:layout_marginBottom="5dp"
+            android:layout_marginBottom="@dimen/accelerometer_fragment_margint"
             tools:layout="@layout/accelerometer_list_item" />
 
         <fragment
@@ -35,7 +34,7 @@
             android:name="io.pslab.fragment.AccelerometerViewFragment"
             android:layout_width="match_parent"
             android:layout_height="@dimen/accelerometer_fragment_height"
-            android:layout_marginBottom="10dp"
+            android:layout_marginBottom="@dimen/accelerometer_fragment_margint"
             tools:layout="@layout/accelerometer_list_item" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/fragment_accelerometer_data.xml
+++ b/app/src/main/res/layout/fragment_accelerometer_data.xml
@@ -1,40 +1,42 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout android:id="@+id/accelerometer_linearlayout"
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    android:orientation="vertical"
-    tools:context="io.pslab.activity.AccelerometerActivity">
+    android:fitsSystemWindows="true">
 
-    <fragment
-        android:id="@+id/accelerometer_x_axis_fragment"
-        android:name="io.pslab.fragment.AccelerometerViewFragment"
+    <LinearLayout
+        android:id="@+id/accelerometer_linearlayout"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_margin="5dp"
-        tools:layout="@layout/accelerometer_list_item" />
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="5dp"
+        tools:context="io.pslab.activity.AccelerometerActivity">
 
-    <fragment
-        android:id="@+id/accelerometer_y_axis_fragment"
-        android:name="io.pslab.fragment.AccelerometerViewFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_margin="5dp"
-        tools:layout="@layout/accelerometer_list_item" />
+        <fragment
+            android:id="@+id/accelerometer_x_axis_fragment"
+            android:name="io.pslab.fragment.AccelerometerViewFragment"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/accelerometer_fragment_height"
+            android:layout_marginBottom="5dp"
+            tools:layout="@layout/accelerometer_list_item" />
 
-    <fragment
-        android:id="@+id/accelerometer_z_axis_fragment"
-        android:name="io.pslab.fragment.AccelerometerViewFragment"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_marginTop="5dp"
-        android:layout_marginBottom="10dp"
-        android:layout_marginLeft="5dp"
-        android:layout_marginRight="5dp"
-        tools:layout="@layout/accelerometer_list_item" />
-</LinearLayout>
+        <fragment
+            android:id="@+id/accelerometer_y_axis_fragment"
+            android:name="io.pslab.fragment.AccelerometerViewFragment"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/accelerometer_fragment_height"
+            android:layout_marginBottom="5dp"
+            tools:layout="@layout/accelerometer_list_item" />
+
+        <fragment
+            android:id="@+id/accelerometer_z_axis_fragment"
+            android:name="io.pslab.fragment.AccelerometerViewFragment"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/accelerometer_fragment_height"
+            android:layout_marginBottom="10dp"
+            tools:layout="@layout/accelerometer_list_item" />
+
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -422,6 +422,7 @@
     <dimen name="text_size_9sp">9sp</dimen>
 
     <dimen name="accelerometer_fragment_height">200dp</dimen>
+    <dimen name="accelerometer_fragment_margint">5dp</dimen>
 
     <dimen name="gyroscope_fragment_height">300dp</dimen>
     <dimen name="gyroscope_fragment_margin">5dp</dimen>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -421,4 +421,7 @@
     <dimen name="text_size_osc">13sp</dimen>
     <dimen name="text_size_9sp">9sp</dimen>
 
+
+
+    <dimen name="accelerometer_fragment_height">200dp</dimen>
 </resources>


### PR DESCRIPTION
**Bug Fixes**
The accelerometer screen was crashing and not properly visible in landscape mode

**Exception**
java.lang.IllegalStateException: Fragment AccelerometerDataFragment{ddc3faf} (870ce858-bc85-4f8c-83b6-4f50b7359993) not attached to a context.
                                                                                                    	at androidx.fragment.app.Fragment.requireContext(Fragment.java:972)
                                                                                                    	at androidx.fragment.app.Fragment.getResources(Fragment.java:1036)
                                                                                                    	at androidx.fragment.app.Fragment.getString(Fragment.java:1058)
                                                                                                    	at io.pslab.fragment.AccelerometerDataFragment.visualizeData(AccelerometerDataFragment.java:429)
**Changes**
Added if (!isAdded()) return; check at the beginning of the visualizeData() method to ensure that the fragment is properly attached to the activity before attempting to access resources
Used ScrollView to ensure proper UI visibility in landscape mode
## Screenshots / Recordings  
**Before**
![Accelerometer_Before](https://github.com/user-attachments/assets/3c9c8b85-d209-4aad-8ab8-9698e69402fc)

**After**

https://github.com/user-attachments/assets/58b87a69-078a-48c0-b62d-81ba96b368c4



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [ ] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Fixes a crash in the accelerometer screen and improves UI visibility in landscape mode. The crash was due to the fragment not being attached to a context when accessing resources. This is fixed by adding a check to ensure the fragment is attached before accessing resources. The UI visibility is improved by using ScrollView.

Bug Fixes:
- Fixes a crash in the accelerometer screen due to the fragment not being attached to a context when accessing resources.

Enhancements:
- Improves UI visibility in landscape mode by using ScrollView.