### PR TITLE
fix: removed unused Google Maps Key

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ org.gradle.jvmargs=-Xmx1536m \
 --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-google_key = "AIzaSyBFvrqI8_J108WntI7surDGqCUcd1RbHPQ"
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true


### PR DESCRIPTION
Fixes #2639<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- Removed Google Maps Key from gradle.properties<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  
<img width="729" alt="Screenshot 2025-03-23 at 2 54 26 AM" src="https://github.com/user-attachments/assets/1f7a4e8e-5a58-42e9-a181-b2e9aad40c68" />
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Chores:
- Remove Google Maps API key from gradle.properties.