### PR TITLE
chore: update screenshots on every push

### DIFF
--- a/.github/actions/screenshot-android/action.yml
+++ b/.github/actions/screenshot-android/action.yml
@@ -82,6 +82,23 @@ runs:
         disable-animations: true
         script: |
           bundle exec fastlane screengrab || exit 1
+    
+    - name: Update Fastlane Metadata
+      if: ${{ github.event_name == 'push' }}
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+        cd fastlane
+
+        # Force push to fastlane branch
+        git checkout --orphan temporary
+        git add --all .
+        git commit -am "[Auto] Update screenshots ($(date +%Y-%m-%d.%H:%M:%S))"
+        git branch -D fastlane-android
+        git branch -m fastlane-android
+        git push --force origin fastlane-android
           
     - name: Upload Screenshots
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,17 +32,12 @@ jobs:
           read -r version_code < versionCode.txt
           echo "VERSION_CODE=$version_code" >> $GITHUB_OUTPUT
 
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Android Screenshot Workflow
-        uses: ./.github/actions/screenshot-android
-        with:
-          ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
-          ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
-
       - name: Add Changelogs to fastlane branch
         run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git clone --branch=fastlane-android --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+
           cd fastlane
           
           echo "${{ github.event.release.body }}" > metadata/android/en-US/changelogs/${{ steps.download-assets.outputs.VERSION_CODE }}.txt


### PR DESCRIPTION
Update screenshots on every _push_ as we do for [badgemagic-app](https://github.com/fossasia/badgemagic-app), instead of capturing them on tagged releases.


## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Update GitHub Actions workflow to capture and update screenshots on every push instead of only during tagged releases

CI:
- Modify screenshot capture workflow to run on every push, adding automatic screenshot updates to the fastlane branch

Chores:
- Reconfigure release workflow to remove screenshot capture from release process