### PR TITLE
chore: don't use Bundler to execute fastlane

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Push version to production
         run: |
-          bundle exec fastlane promoteToProduction version_code:${{ steps.download-assets.outputs.VERSION_CODE }}
+          fastlane promoteToProduction version_code:${{ steps.download-assets.outputs.VERSION_CODE }}
           if [[ $? -ne 0 ]]; then
               exit 1
           fi


### PR DESCRIPTION
_fastlane_ can now be executed directly from a GitHub Actions Runner. The usage of [Bundler](https://bundler.io/) isn't required.


## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Remove Bundler dependency when executing fastlane in GitHub Actions workflow

CI:
- Updated release workflow to run fastlane command directly instead of using 'bundle exec'

Chores:
- Simplify GitHub Actions workflow by executing fastlane directly without using Bundler