### PR TITLE
feat: added text input support

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up Java
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: 17
         distribution: 'adopt'

--- a/lib/others/oscilloscope_axes_scale.dart
+++ b/lib/others/oscilloscope_axes_scale.dart
@@ -1,10 +1,10 @@
-class OscillscopeAxesScale {
+class OscilloscopeAxesScale {
   late double _yAxisScale;
   late double _yAxisScaleMin;
   late double _yAxisScaleMax;
   late double _xAxisScale;
 
-  OscillscopeAxesScale() {
+  OscilloscopeAxesScale() {
     _yAxisScale = 16;
     _yAxisScaleMin = -16;
     _yAxisScaleMax = 16;

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -322,14 +322,12 @@ class OscilloscopeStateProvider extends ChangeNotifier {
                   prevY < trigger &&
                   currY >= trigger &&
                   increasing) {
-                logger.d('prevY: $prevY, currY: $currY');
                 isTriggered = true;
               } else if (triggerMode == MODE.falling.toString() &&
                   prevY > trigger &&
                   currY <= trigger &&
                   !increasing) {
                 isTriggered = true;
-                logger.d('prevY: $prevY, currY: $currY');
               } else if (triggerMode == MODE.dual.toString() &&
                       (prevY < trigger && currY >= trigger && increasing) ||
                   (prevY > trigger && currY <= trigger && !increasing)) {

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -84,7 +84,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
 
   late Timer _timer;
 
-  late OscillscopeAxesScale oscillscopeAxesScale;
+  late OscilloscopeAxesScale oscilloscopeAxesScale;
 
   OscilloscopeStateProvider() {
     _audioJack = AudioJack();
@@ -107,7 +107,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     xyPlotAxis1 = 'CH1';
     xyPlotAxis2 = 'CH2';
     dataEntries = [];
-    dataEntriesXYPlot = [[]];
+    dataEntriesXYPlot = [];
     dataEntriesCurveFit = [];
     _timebaseDivisions = 8;
     timebaseSlider = 0;
@@ -144,7 +144,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     curveFittingChannel1 = '';
     curveFittingChannel2 = '';
     _analyticsClass = AnalyticsClass();
-    oscillscopeAxesScale = OscillscopeAxesScale();
+    oscilloscopeAxesScale = OscilloscopeAxesScale();
 
     monitor();
   }
@@ -192,6 +192,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
             if (channels.isNotEmpty) {
               await captureTask(channels);
             } else {
+              resetGraph();
               dataEntries = [];
             }
           }
@@ -308,7 +309,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
             if (isTriggerSelected && triggerChannel == channel) {
               if (currY > prevY) {
                 increasing = true;
-              } else if (currY < prevY && increasing) {
+              } else if ((currY < prevY) && increasing) {
                 increasing = false;
               }
               if (isTriggered) {
@@ -321,12 +322,14 @@ class OscilloscopeStateProvider extends ChangeNotifier {
                   prevY < trigger &&
                   currY >= trigger &&
                   increasing) {
+                logger.d('prevY: $prevY, currY: $currY');
                 isTriggered = true;
               } else if (triggerMode == MODE.falling.toString() &&
                   prevY > trigger &&
                   currY <= trigger &&
                   !increasing) {
                 isTriggered = true;
+                logger.d('prevY: $prevY, currY: $currY');
               } else if (triggerMode == MODE.dual.toString() &&
                       (prevY < trigger && currY >= trigger && increasing) ||
                   (prevY > trigger && currY <= trigger && !increasing)) {
@@ -334,7 +337,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
               }
               prevY = currY;
             } else {
-              entries[i].add(FlSpot(xData[j] + xOffsets[channels[i]]!,
+              entries[i].add(FlSpot(xData[j] - xOffsets[channels[i]]!,
                   yData[j] + yOffsets[channels[i]]!));
             }
           } else {
@@ -363,8 +366,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
           for (int j = 0; j < 500; j++) {
             double x = j * max / 500;
             double y = offset +
-                amp * sin((freq * (2 * pi)).abs()) * x +
-                phase * pi / 180;
+                amp * sin(((freq * (2 * pi)).abs()) * x + phase * pi / 180);
             curveFitEntries[curveFitEntries.length - 1].add(FlSpot(x, y));
           }
         }
@@ -458,13 +460,13 @@ class OscilloscopeStateProvider extends ChangeNotifier {
                 double k = ((xDataPoint / AudioJack.samplingRate) * 1000000.0);
                 k = k / ((timebase == 875) ? 1 : 1000);
                 entries[entries.length - 1].add(FlSpot(
-                    k + xOffsets['MIC']!, audioValue + yOffsets['MIC']!));
+                    k - xOffsets['MIC']!, audioValue + yOffsets['MIC']!));
                 xDataPoint++;
               }
               prevY = currY;
             } else {
               entries[entries.length - 1].add(
-                  FlSpot(j + xOffsets['MIC']!, audioValue + yOffsets['MIC']!));
+                  FlSpot(j - xOffsets['MIC']!, audioValue + yOffsets['MIC']!));
             }
           } else {
             if (i < n / 2) {
@@ -488,13 +490,15 @@ class OscilloscopeStateProvider extends ChangeNotifier {
       dataEntriesCurveFit = List.from(curveFitEntries);
       dataParamsChannels = List.from(paramsChannels);
       if (isFourierTransformSelected) {
-        oscillscopeAxesScale.setYAxisScaleMax(_maxAmp);
-        oscillscopeAxesScale.setYAxisScaleMin(0);
-        oscillscopeAxesScale.setXAxisScale(_maxFreq * 1000);
+        oscilloscopeAxesScale.setYAxisScaleMax(_maxAmp);
+        oscilloscopeAxesScale.setYAxisScaleMin(0);
+        oscilloscopeAxesScale.setXAxisScale(_maxFreq * 1000);
       } else {
-        oscillscopeAxesScale.setYAxisScaleMax(oscillscopeAxesScale.yAxisScale);
-        oscillscopeAxesScale.setYAxisScaleMin(-oscillscopeAxesScale.yAxisScale);
-        oscillscopeAxesScale.setXAxisScale(timebase);
+        oscilloscopeAxesScale
+            .setYAxisScaleMax(oscilloscopeAxesScale.yAxisScale);
+        oscilloscopeAxesScale
+            .setYAxisScaleMin(-oscilloscopeAxesScale.yAxisScale);
+        oscilloscopeAxesScale.setXAxisScale(timebase);
       }
       notifyListeners();
     } catch (e) {
@@ -540,6 +544,12 @@ class OscilloscopeStateProvider extends ChangeNotifier {
         timebase = 875.00;
         break;
     }
+    oscilloscopeAxesScale.setXAxisScale(timebase);
+    notifyListeners();
+  }
+
+  void setYAxisScale(double value) {
+    oscilloscopeAxesScale.setYAxisScale(value);
     notifyListeners();
   }
 
@@ -603,6 +613,15 @@ class OscilloscopeStateProvider extends ChangeNotifier {
         );
       },
     );
+  }
+
+  void resetGraph() {
+    oscilloscopeAxesScale.setYAxisScaleMax(oscilloscopeAxesScale.yAxisScale);
+    oscilloscopeAxesScale.setYAxisScaleMin(-oscilloscopeAxesScale.yAxisScale);
+    oscilloscopeAxesScale.setXAxisScale(timebase);
+    dataEntries = [];
+    dataEntriesXYPlot = [];
+    dataEntriesCurveFit = [];
   }
 
   @override

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -86,44 +86,34 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                         onSelected: (String? value) {
                           switch (yAxisRanges.indexOf(value!)) {
                             case 0:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(16);
+                              oscilloscopeStateProvider.setYAxisScale(16);
                               break;
                             case 1:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(8);
+                              oscilloscopeStateProvider.setYAxisScale(8);
                               break;
                             case 2:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(4);
+                              oscilloscopeStateProvider.setYAxisScale(4);
                               break;
                             case 3:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(3);
+                              oscilloscopeStateProvider.setYAxisScale(3);
                               break;
                             case 4:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(2);
+                              oscilloscopeStateProvider.setYAxisScale(2);
                               break;
                             case 5:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(1.5);
+                              oscilloscopeStateProvider.setYAxisScale(1.5);
                               break;
                             case 6:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(1);
+                              oscilloscopeStateProvider.setYAxisScale(1);
                               break;
                             case 7:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(0.5);
+                              oscilloscopeStateProvider.setYAxisScale(0.5);
                               break;
                             case 8:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(160);
+                              oscilloscopeStateProvider.setYAxisScale(160);
                               break;
                             default:
-                              oscilloscopeStateProvider.oscillscopeAxesScale
-                                  .setYAxisScale(16);
+                              oscilloscopeStateProvider.setYAxisScale(16);
                               break;
                           }
                           oscilloscopeStateProvider.oscillscopeRangeSelection =

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -24,7 +24,7 @@ class _CommonScaffoldState extends State<CommonScaffold> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      resizeToAvoidBottomInset: true,
+      resizeToAvoidBottomInset: false,
       appBar: AppBar(
         systemOverlayStyle:
             const SystemUiOverlayStyle(statusBarColor: Color(0xFFD32F2F)),

--- a/lib/view/widgets/data_analysis_widget.dart
+++ b/lib/view/widgets/data_analysis_widget.dart
@@ -270,17 +270,17 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                               child: Slider(
                                 activeColor: const Color(0xFFCE525F),
                                 min: -oscilloscopeStateProvider
-                                    .oscillscopeAxesScale.yAxisScale,
+                                    .oscilloscopeAxesScale.yAxisScale,
                                 max: oscilloscopeStateProvider
-                                    .oscillscopeAxesScale.yAxisScale,
+                                    .oscilloscopeAxesScale.yAxisScale,
                                 value: oscilloscopeStateProvider.yOffsets[
                                         oscilloscopeStateProvider
                                             .selectedChannelOffset]!
                                     .clamp(
                                         -oscilloscopeStateProvider
-                                            .oscillscopeAxesScale.yAxisScale,
+                                            .oscilloscopeAxesScale.yAxisScale,
                                         oscilloscopeStateProvider
-                                            .oscillscopeAxesScale.yAxisScale),
+                                            .oscilloscopeAxesScale.yAxisScale),
                                 onChanged: (double value) {
                                   setState(
                                     () {
@@ -293,12 +293,43 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                               ),
                             ),
                           ),
-                          Text(
-                            '${oscilloscopeStateProvider.yOffsets[oscilloscopeStateProvider.selectedChannelOffset]!.toStringAsFixed(2)} V',
-                            style: const TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.normal,
-                              fontStyle: FontStyle.normal,
+                          SizedBox(
+                            width: 50,
+                            child: TextField(
+                              controller: TextEditingController(
+                                text:
+                                    '${oscilloscopeStateProvider.yOffsets[oscilloscopeStateProvider.selectedChannelOffset]!.toStringAsFixed(2)} V',
+                              ),
+                              decoration: const InputDecoration(
+                                border: InputBorder.none,
+                              ),
+                              style: const TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.normal,
+                                fontStyle: FontStyle.normal,
+                              ),
+                              onSubmitted: (value) {
+                                String triggerValue =
+                                    value.replaceAll("V", "").trim();
+                                double parsedValue =
+                                    double.tryParse(triggerValue) ?? 0.0;
+                                if (parsedValue >
+                                    oscilloscopeStateProvider
+                                        .oscilloscopeAxesScale.yAxisScaleMax) {
+                                  parsedValue = oscilloscopeStateProvider
+                                      .oscilloscopeAxesScale.yAxisScaleMax;
+                                } else if (parsedValue <
+                                    oscilloscopeStateProvider
+                                        .oscilloscopeAxesScale.yAxisScaleMin) {
+                                  parsedValue = oscilloscopeStateProvider
+                                      .oscilloscopeAxesScale.yAxisScaleMin;
+                                }
+                                setState(() {
+                                  oscilloscopeStateProvider.yOffsets[
+                                      oscilloscopeStateProvider
+                                          .selectedChannelOffset] = parsedValue;
+                                });
+                              },
                             ),
                           ),
                         ],
@@ -322,7 +353,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                                 min: 0,
                                 max: oscilloscopeStateProvider.timebase / 1000,
                                 value: oscilloscopeStateProvider
-                                            .oscillscopeAxesScale.xAxisScale ==
+                                            .oscilloscopeAxesScale.xAxisScale ==
                                         875
                                     ? (oscilloscopeStateProvider.xOffsets[
                                                 oscilloscopeStateProvider
@@ -343,7 +374,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                                   setState(
                                     () {
                                       if (oscilloscopeStateProvider
-                                              .oscillscopeAxesScale
+                                              .oscilloscopeAxesScale
                                               .xAxisScale ==
                                           875) {
                                         oscilloscopeStateProvider.xOffsets[
@@ -361,16 +392,53 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                               ),
                             ),
                           ),
-                          Text(
-                            oscilloscopeStateProvider
-                                        .oscillscopeAxesScale.xAxisScale ==
-                                    875
-                                ? '${(oscilloscopeStateProvider.xOffsets[oscilloscopeStateProvider.selectedChannelOffset]! / 1000).toStringAsFixed(2)} ms'
-                                : '${oscilloscopeStateProvider.xOffsets[oscilloscopeStateProvider.selectedChannelOffset]!.toStringAsFixed(2)} ms',
-                            style: const TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.normal,
-                              fontStyle: FontStyle.normal,
+                          SizedBox(
+                            width: 60,
+                            child: TextField(
+                              controller: TextEditingController(
+                                text: oscilloscopeStateProvider
+                                            .oscilloscopeAxesScale.xAxisScale ==
+                                        875
+                                    ? '${(oscilloscopeStateProvider.xOffsets[oscilloscopeStateProvider.selectedChannelOffset]! / 1000).toStringAsFixed(2)} ms'
+                                    : '${oscilloscopeStateProvider.xOffsets[oscilloscopeStateProvider.selectedChannelOffset]!.toStringAsFixed(2)} ms',
+                              ),
+                              style: const TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.normal,
+                                fontStyle: FontStyle.normal,
+                              ),
+                              onSubmitted: (value) {
+                                String triggerValue = value
+                                    .replaceAll(RegExp(r'[ms]'), "")
+                                    .trim();
+                                double parsedValue =
+                                    double.tryParse(triggerValue) ?? 0.0;
+                                if (parsedValue >
+                                    (oscilloscopeStateProvider
+                                            .oscilloscopeAxesScale.xAxisScale /
+                                        1000)) {
+                                  parsedValue = oscilloscopeStateProvider
+                                          .oscilloscopeAxesScale.xAxisScale /
+                                      1000;
+                                } else if (parsedValue < 0.0) {
+                                  parsedValue = 0.0;
+                                }
+                                setState(() {
+                                  if (oscilloscopeStateProvider
+                                          .oscilloscopeAxesScale.xAxisScale ==
+                                      875) {
+                                    oscilloscopeStateProvider.xOffsets[
+                                            oscilloscopeStateProvider
+                                                .selectedChannelOffset] =
+                                        parsedValue * 1000;
+                                  } else {
+                                    oscilloscopeStateProvider.xOffsets[
+                                            oscilloscopeStateProvider
+                                                .selectedChannelOffset] =
+                                        parsedValue;
+                                  }
+                                });
+                              },
                             ),
                           ),
                         ],

--- a/lib/view/widgets/oscilloscope_graph.dart
+++ b/lib/view/widgets/oscilloscope_graph.dart
@@ -62,7 +62,7 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                   topTitles: AxisTitles(
                     axisNameWidget: Text(
                       oscilloscopeStateProvider
-                                  .oscillscopeAxesScale.xAxisScale ==
+                                  .oscilloscopeAxesScale.xAxisScale ==
                               875
                           ? 'Time (\u00b5s)'
                           : 'Time (ms)',
@@ -74,7 +74,7 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                     ),
                     sideTitles: SideTitles(
                       maxIncluded: false,
-                      interval: oscilloscopeStateProvider.oscillscopeAxesScale
+                      interval: oscilloscopeStateProvider.oscilloscopeAxesScale
                           .getTimebaseInterval(),
                       reservedSize: 20,
                       showTitles: true,
@@ -93,7 +93,8 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                       ),
                     ),
                     sideTitles: SideTitles(
-                      interval: provider.oscillscopeAxesScale.yAxisScaleMax / 4,
+                      interval:
+                          provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
                       reservedSize: 30,
                       showTitles: true,
                       getTitlesWidget: sideTitleWidgets,
@@ -109,7 +110,8 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                       ),
                     ),
                     sideTitles: SideTitles(
-                      interval: provider.oscillscopeAxesScale.yAxisScaleMax / 4,
+                      interval:
+                          provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
                       reservedSize: 30,
                       showTitles: true,
                       getTitlesWidget: sideTitleWidgets,
@@ -121,9 +123,9 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                   drawHorizontalLine: true,
                   drawVerticalLine: true,
                   horizontalInterval:
-                      provider.oscillscopeAxesScale.yAxisScaleMax / 4,
+                      provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
                   verticalInterval: oscilloscopeStateProvider
-                      .oscillscopeAxesScale
+                      .oscilloscopeAxesScale
                       .getTimebaseInterval(),
                 ),
                 borderData: FlBorderData(
@@ -143,14 +145,14 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                     ),
                   ),
                 ),
-                maxY: provider.oscillscopeAxesScale.yAxisScaleMax,
-                minY: provider.oscillscopeAxesScale.yAxisScaleMin,
+                maxY: provider.oscilloscopeAxesScale.yAxisScaleMax,
+                minY: provider.oscilloscopeAxesScale.yAxisScaleMin,
                 maxX: oscilloscopeStateProvider
-                            .oscillscopeAxesScale.xAxisScale ==
+                            .oscilloscopeAxesScale.xAxisScale ==
                         875
-                    ? oscilloscopeStateProvider.oscillscopeAxesScale.xAxisScale
+                    ? oscilloscopeStateProvider.oscilloscopeAxesScale.xAxisScale
                     : oscilloscopeStateProvider
-                            .oscillscopeAxesScale.xAxisScale /
+                            .oscilloscopeAxesScale.xAxisScale /
                         1000,
                 minX: 0,
                 clipData: const FlClipData.all(),

--- a/lib/view/widgets/timebase_trigger_widget.dart
+++ b/lib/view/widgets/timebase_trigger_widget.dart
@@ -86,7 +86,7 @@ class _TimebaseTriggerState extends State<TimebaseTriggerWidget> {
                         ),
                         child: Selector<OscilloscopeStateProvider, double>(
                           selector: (context, provider) =>
-                              provider.oscillscopeAxesScale.yAxisScale,
+                              provider.oscilloscopeAxesScale.yAxisScale,
                           builder: (context, yAxisScale, _) {
                             return Slider(
                               activeColor: const Color(0xFFCE525F),
@@ -106,12 +106,41 @@ class _TimebaseTriggerState extends State<TimebaseTriggerWidget> {
                         ),
                       ),
                     ),
-                    Text(
-                      '${oscilloscopeStateProvider.trigger.toStringAsFixed(1)} V',
-                      style: const TextStyle(
-                        fontSize: 14,
-                        fontWeight: FontWeight.normal,
-                        fontStyle: FontStyle.normal,
+                    SizedBox(
+                      width: 50,
+                      child: TextField(
+                        controller: TextEditingController(
+                          text:
+                              "${oscilloscopeStateProvider.trigger.toStringAsFixed(1)} V",
+                        ),
+                        decoration: const InputDecoration(
+                          border: InputBorder.none,
+                        ),
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.normal,
+                          fontStyle: FontStyle.normal,
+                        ),
+                        onSubmitted: (value) {
+                          String triggerValue =
+                              value.replaceAll("V", "").trim();
+                          double parsedValue =
+                              double.tryParse(triggerValue) ?? 0.0;
+                          if (parsedValue >
+                              oscilloscopeStateProvider
+                                  .oscilloscopeAxesScale.yAxisScaleMax) {
+                            parsedValue = oscilloscopeStateProvider
+                                .oscilloscopeAxesScale.yAxisScaleMax;
+                          } else if (parsedValue <
+                              oscilloscopeStateProvider
+                                  .oscilloscopeAxesScale.yAxisScaleMin) {
+                            parsedValue = oscilloscopeStateProvider
+                                .oscilloscopeAxesScale.yAxisScaleMin;
+                          }
+                          setState(() {
+                            oscilloscopeStateProvider.trigger = parsedValue;
+                          });
+                        },
                       ),
                     ),
                     Padding(


### PR DESCRIPTION
Fixes [errors](https://github.com/fossasia/pslab-android/pull/2630#issuecomment-2661558077) reported by @marcnause in #2630.
Adds text input support for _offset_ and _trigger_ values.

## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Enable direct text input for oscilloscope offsets and trigger values and clean up axes scale management and plotting logic

New Features:
- Add TextField inputs to adjust y-offset, x-offset, and trigger values via typed input

Bug Fixes:
- Fix incorrect addition of x-offsets for channels and microphone by switching to subtraction
- Correct the sine equation for curve fitting to include phase inside the sine argument
- Resolve naming mismatches in axes scale properties to prevent runtime errors

Enhancements:
- Rename OscillscopeAxesScale to OscilloscopeAxesScale and update all references
- Introduce setYAxisScale and resetGraph methods in OscilloscopeStateProvider for consistent state updates
- Refine plotting routines to subtract x-offsets and adjust the curve-fitting formula
- Disable resizeToAvoidBottomInset in the common scaffold to prevent unwanted layout shifts

Chores:
- Reformat code and fix indentation across multiple files