### PR TITLE
chore: use latest SDK to build IPAs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,6 +39,11 @@ jobs:
     needs: common
     runs-on: macos-latest
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest
+          
       - uses: actions/checkout@v4
 
       - name: iOS Workflow

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -141,6 +141,11 @@ jobs:
     needs: common
     runs-on: macos-latest
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest
+          
       - uses: actions/checkout@v4
 
       - name: Prepare Build Keys


### PR DESCRIPTION
Sets up the _macos-latest_ runner with the latest version of Xcode, to use the latest iOS SDK to build IPAs.


## Screenshots / Recordings  
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

CI:
- Set up the latest Xcode version in pull-request and push-event workflows to leverage the newest iOS SDK