### PR TITLE
fix: Rising Edge Triggering

### DIFF
--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -329,8 +329,8 @@ class OscilloscopeStateProvider extends ChangeNotifier {
                   !increasing) {
                 isTriggered = true;
               } else if (triggerMode == MODE.dual.toString() &&
-                      (prevY < trigger && currY >= trigger && increasing) ||
-                  (prevY > trigger && currY <= trigger && !increasing)) {
+                  ((prevY < trigger && currY >= trigger && increasing) ||
+                      (prevY > trigger && currY <= trigger && !increasing))) {
                 isTriggered = true;
               }
               prevY = currY;
@@ -450,8 +450,8 @@ class OscilloscopeStateProvider extends ChangeNotifier {
                   !increasing) {
                 isTriggered = true;
               } else if (triggerMode == MODE.dual.toString() &&
-                      (prevY < trigger && currY >= trigger && increasing) ||
-                  (prevY > trigger && currY <= trigger && !increasing)) {
+                  ((prevY < trigger && currY >= trigger && increasing) ||
+                      (prevY > trigger && currY <= trigger && !increasing))) {
                 isTriggered = true;
               }
               if (isTriggered) {

--- a/lib/view/connect_device_screen.dart
+++ b/lib/view/connect_device_screen.dart
@@ -64,16 +64,18 @@ class _HomeScreenState extends State<ConnectDeviceScreen> {
                         margin: const EdgeInsets.only(
                             left: 40, right: 40, bottom: 20),
                         child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
-                              stepsToConnect[0],
-                              textAlign: TextAlign.center,
-                              style: const TextStyle(
-                                decoration: TextDecoration.underline,
-                                color: Colors.black,
-                                fontSize: 18,
-                                fontWeight: FontWeight.bold,
+                            Center(
+                              child: Text(
+                                stepsToConnect[0],
+                                textAlign: TextAlign.center,
+                                style: const TextStyle(
+                                  decoration: TextDecoration.underline,
+                                  color: Colors.black,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.bold,
+                                ),
                               ),
                             ),
                             const SizedBox(height: 20),


### PR DESCRIPTION
Fixes an issue in _Rising Edge Trigger_ which caused it to trigger on all edges, as reported by @marcnause [here](https://github.com/fossasia/pslab-android/pull/2630#issuecomment-2661558077).


## Screenshots / Recordings  

https://github.com/user-attachments/assets/23440ef7-b647-4772-9748-8342cf00ceba



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

@marcnause Let's now test if all the [issues](https://github.com/fossasia/pslab-android/pull/2630#issuecomment-2661558077) reported by you before have now been solved. Could you please test those and the support for text input through keyboard in the _Trigger_ and _Offset_ values ?

## Summary by Sourcery

Bug Fixes:
- Correct conditional grouping in dual trigger mode to prevent rising edge trigger from firing on all edges