### PR TITLE
chore: bump gradle

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip


### PR DESCRIPTION
Required by https://github.com/fossasia/pslab-android/pull/2717. It will not compile if Gradle is not updated (see https://github.com/fossasia/pslab-android/actions/runs/15635817852/job/44050573974):


> FAILURE: Build failed with an exception.
> 
> * Where:
> Build file '/home/runner/work/pslab-android/pslab-android/android/app/build.gradle' line: 2
> 
> * What went wrong:
> An exception occurred applying plugin request [id: 'com.android.application']
> \> Failed to apply plugin 'com.android.internal.version-check'.
>    \> Minimum supported Gradle version is 8.11.1. Current version is 8.4. If using the gradle wrapper, try editing the distributionUrl in /home/runner/work/pslab-android/pslab-android/android/gradle/wrapper/gradle-wrapper.properties to gradle-8.11.1-all.zip

## Summary by Sourcery

Build:
- Bump Gradle distribution URL to 8.14.2