### PR TITLE
refactor: used existing AudioJack in soundmeter

### DIFF
--- a/lib/providers/soundmeter_state_provider.dart
+++ b/lib/providers/soundmeter_state_provider.dart
@@ -2,17 +2,18 @@ import 'dart:async';
 import 'dart:math';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:pslab/others/logger_service.dart';
-import 'package:flutter_audio_capture/flutter_audio_capture.dart';
 import 'package:flutter/foundation.dart';
 import 'package:pslab/constants.dart';
+import 'package:pslab/others/audio_jack.dart';
 
 class SoundMeterStateProvider extends ChangeNotifier {
   double _currentDb = 0.0;
   Timer? _timeTimer;
+  Timer? _audioTimer;
   final List<double> _dbData = [];
   final List<double> _timeData = [];
   final List<FlSpot> dbChartData = [];
-  FlutterAudioCapture? _audioCapture;
+  AudioJack? _audioJack;
   double _startTime = 0;
   double _currentTime = 0;
   final int _maxLength = 50;
@@ -23,11 +24,12 @@ class SoundMeterStateProvider extends ChangeNotifier {
 
   void initializeSensors() async {
     try {
-      _audioCapture = FlutterAudioCapture();
-
-      await _audioCapture!.init();
+      _audioJack = AudioJack();
+      await _audioJack!.initialize();
+      await _audioJack!.start();
 
       _startTime = DateTime.now().millisecondsSinceEpoch / 1000.0;
+
       _timeTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
         _currentTime =
             (DateTime.now().millisecondsSinceEpoch / 1000.0) - _startTime;
@@ -35,25 +37,21 @@ class SoundMeterStateProvider extends ChangeNotifier {
         notifyListeners();
       });
 
-      await _audioCapture!.start(
-        (Float32List audioData) {
-          _currentDb = _calculateDecibels(audioData);
-          notifyListeners();
-        },
-        (error) {
-          logger.e(
-            "$soundMeterError $error",
-          );
-        },
-        sampleRate: 44100,
-        bufferSize: 4096,
-      );
+      _audioTimer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
+        if (_audioJack!.isListening()) {
+          final audioData = _audioJack!.read();
+          if (audioData.isNotEmpty) {
+            _currentDb = _calculateDecibels(audioData);
+            notifyListeners();
+          }
+        }
+      });
     } catch (e) {
       logger.e("$soundMeterInitialError $e");
     }
   }
 
-  double _calculateDecibels(Float32List audioData) {
+  double _calculateDecibels(List<double> audioData) {
     if (audioData.isEmpty) return 0.0;
 
     double sum = 0;
@@ -71,9 +69,10 @@ class SoundMeterStateProvider extends ChangeNotifier {
     return dbSPL.clamp(20.0, 120.0);
   }
 
-  void disposeSensors() {
-    _audioCapture?.stop();
+  void disposeSensors() async {
+    await _audioJack?.close();
     _timeTimer?.cancel();
+    _audioTimer?.cancel();
   }
 
   @override

--- a/lib/providers/soundmeter_state_provider.dart
+++ b/lib/providers/soundmeter_state_provider.dart
@@ -38,7 +38,7 @@ class SoundMeterStateProvider extends ChangeNotifier {
       });
 
       _audioTimer = Timer.periodic(const Duration(milliseconds: 100), (timer) {
-        if (_audioJack!.isListening()) {
+        if (_audioJack != null && _audioJack!.isListening()) {
           final audioData = _audioJack!.read();
           if (audioData.isNotEmpty) {
             _currentDb = _calculateDecibels(audioData);
@@ -70,9 +70,10 @@ class SoundMeterStateProvider extends ChangeNotifier {
   }
 
   void disposeSensors() async {
-    await _audioJack?.close();
     _timeTimer?.cancel();
     _audioTimer?.cancel();
+    await _audioJack?.close();
+    _audioJack = null;
   }
 
   @override


### PR DESCRIPTION
Part of #2738
   <!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- Just replaced direct FlutterAudioCapture usage with existing AudioJack class.
<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  


<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Refactor SoundMeterStateProvider to leverage the existing AudioJack service for audio capture, replacing direct FlutterAudioCapture usage and streamlining decibel measurement via a polling mechanism.

Enhancements:
- Replace FlutterAudioCapture with the centralized AudioJack class for audio capture in SoundMeterStateProvider
- Start and poll AudioJack on a periodic timer to fetch audio data and update decibel readings
- Change _calculateDecibels to accept a List<double> instead of Float32List
- Introduce a dedicated audio Timer and ensure AudioJack and timers are properly closed in disposeSensors