### PR TITLE
fix: small UI bug in robotic arm screen

### DIFF
--- a/lib/providers/robotic_arm_state_provider.dart
+++ b/lib/providers/robotic_arm_state_provider.dart
@@ -235,6 +235,7 @@ class RoboticArmStateProvider extends ChangeNotifier {
     List<FlSpot> spots = [];
     List<double> dutyCycles = [];
     List<double> angleList = [];
+    List<Map<String, dynamic>> dutyLabelPoints = [];
 
     double time = 0;
 
@@ -253,6 +254,12 @@ class RoboticArmStateProvider extends ChangeNotifier {
 
       final duty = (pulseHigh / period) * 100;
       dutyCycles.add(duty);
+
+      final mid = time + highMs / 2;
+      dutyLabelPoints.add({
+        'x': mid,
+        'label': '${duty.toStringAsFixed(1)}$percentage',
+      });
 
       spots.add(FlSpot(time, 0));
       spots.add(FlSpot(time, 1));
@@ -287,6 +294,7 @@ class RoboticArmStateProvider extends ChangeNotifier {
       'avgAngle': avgAngle,
       'minAngle': minAngle,
       'maxAngle': maxAngleVal,
+      'dutyLabelPoints': dutyLabelPoints,
     };
   }
 }

--- a/lib/view/widgets/robotic_arm_summary.dart
+++ b/lib/view/widgets/robotic_arm_summary.dart
@@ -37,6 +37,7 @@ class _PlaybackSummaryDialogState extends State<PlaybackSummaryDialog> {
     final double avg = data['avgAngle'];
     final double max = data['maxAngle'];
     final double min = data['minAngle'];
+    final List<Map<String, dynamic>> labelPoints = data['dutyLabelPoints'];
 
     return Dialog(
       backgroundColor: Colors.white,
@@ -235,23 +236,18 @@ class _PlaybackSummaryDialogState extends State<PlaybackSummaryDialog> {
                                               reservedSize: 12,
                                               interval: 1,
                                               getTitlesWidget: (value, _) {
-                                                final double period =
-                                                    1000 / widget.frequency;
-                                                for (int i = 0;
-                                                    i < data['dutyList'].length;
-                                                    i++) {
-                                                  final double start =
-                                                      i * period;
-                                                  final double high =
-                                                      (data['dutyList'][i] /
-                                                              100) *
-                                                          period;
-                                                  final double mid =
-                                                      start + high / 2;
-                                                  if ((value - mid).abs() <
+                                                if (pwmSpots.isEmpty) {
+                                                  return const SizedBox
+                                                      .shrink();
+                                                }
+
+                                                for (final label
+                                                    in labelPoints) {
+                                                  if ((label['x'] - value)
+                                                          .abs() <
                                                       0.5) {
                                                     return Text(
-                                                      '${data['dutyList'][i].toStringAsFixed(1)}$percentage',
+                                                      label['label'],
                                                       style: const TextStyle(
                                                         color: Colors.white70,
                                                         fontSize: 9,
@@ -261,6 +257,7 @@ class _PlaybackSummaryDialogState extends State<PlaybackSummaryDialog> {
                                                     );
                                                   }
                                                 }
+
                                                 return const SizedBox.shrink();
                                               },
                                             ),


### PR DESCRIPTION
Fixes #2711
## Changes 
Fixed a UI bug where duty cycle (%) was not aligning correctly if null values existed before. Resolved the issue by using a map to track and render percentages only for valid spots

**Before**
![Screenshot_2025-07-03-19-22-09-830_io pslab](https://github.com/user-attachments/assets/d56ff982-83e8-46d6-b8d3-4ce84a5f0093)


**After**
![After_Image](https://github.com/user-attachments/assets/19c2b13f-7a7f-4adf-981a-c4057853ed9d)




**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Bug Fixes:
- Align duty cycle labels correctly by replacing inline dutyList calculations with a precomputed list of valid label points supplied by the state provider.