### PR TITLE
feat: added functionality for Multimeter

### DIFF
--- a/lib/communication/analogChannel/analog_input_source.dart
+++ b/lib/communication/analogChannel/analog_input_source.dart
@@ -40,6 +40,7 @@ class AnalogInputSource {
       gainPGA = 2;
       _gain = 0;
     }
+    gainPGA = 1;
     _gain = 0;
     regenerateCalibration();
   }

--- a/lib/communication/analogChannel/analog_input_source.dart
+++ b/lib/communication/analogChannel/analog_input_source.dart
@@ -39,9 +39,10 @@ class AnalogInputSource {
       gainEnabled = true;
       gainPGA = 2;
       _gain = 0;
+    } else {
+      gainPGA = 1;
+      _gain = 0;
     }
-    gainPGA = 1;
-    _gain = 0;
     regenerateCalibration();
   }
 

--- a/lib/communication/digitalChannel/digital_channel.dart
+++ b/lib/communication/digitalChannel/digital_channel.dart
@@ -7,6 +7,7 @@ class DigitalChannel {
   static const int everyFourthRisingEdge = 4;
   static const int everyRisingEdge = 3;
   static const int everyFallingEdge = 2;
+  static const int captureDelay = 2;
   static List<String> digitalChannelNames = [
     'LA1',
     'LA2',
@@ -58,25 +59,22 @@ class DigitalChannel {
       final int s = initialStates[channelName]!;
       initialState = s == 1;
     }
-    this.timestamps.setRange(0, timestamps.length, timestamps);
+    this.timestamps.setRange(0, timestamps.length - 1, timestamps);
     dLength = timestamps.length;
-    double factor;
-    switch (prescaler) {
-      case 0:
-        factor = 64;
-        break;
-      case 1:
-        factor = 8;
-        break;
-      case 2:
-        factor = 4;
-        break;
-      default:
-        factor = 1;
-        break;
+    double factor = 64;
+    List<double> diff = [];
+    for (int i = 0; i < this.timestamps.length - 1; i++) {
+      diff.add(this.timestamps[i + 1] - this.timestamps[i]);
+    }
+    for (int i = 0; i < diff.length; i++) {
+      if (diff[i] < 0) {
+        for (int j = i + 1; j < this.timestamps.length; j++) {
+          this.timestamps[j] += (1 << 16) - 1;
+        }
+      }
     }
     for (int i = 0; i < this.timestamps.length; i++) {
-      this.timestamps[i] /= factor;
+      this.timestamps[i] = (this.timestamps[i] + (i * captureDelay)) / factor;
     }
     if (dLength > 0) {
       maxT = this.timestamps[this.timestamps.length - 1];
@@ -99,11 +97,11 @@ class DigitalChannel {
       plotLength = 1;
     } else if (mode == everyEdge) {
       xAxis[0] = 0;
-      yAxis[0] = state as double;
+      yAxis[0] = state.toDouble();
       int length = 0;
       for (int i = 1, j = 1; i < dLength; i++, j++) {
         xAxis[j] = timestamps[i];
-        yAxis[j] = state as double;
+        yAxis[j] = state.toDouble();
         if (state == high) {
           state = low;
         } else {
@@ -111,23 +109,23 @@ class DigitalChannel {
         }
         j++;
         xAxis[j] = timestamps[i];
-        yAxis[j] = state as double;
+        yAxis[j] = state.toDouble();
         length = j;
       }
       plotLength = length;
     } else if (mode == everyFallingEdge) {
       xAxis[0] = 0;
-      yAxis[0] = high as double;
+      yAxis[0] = high.toDouble();
       int length = 0;
       for (int i = 1, j = 1; i < dLength; i++, j++) {
         xAxis[j] = timestamps[i];
-        yAxis[j] = high as double;
+        yAxis[j] = high.toDouble();
         j++;
         xAxis[j] = timestamps[i];
-        yAxis[j] = low as double;
+        yAxis[j] = low.toDouble();
         j++;
         xAxis[j] = timestamps[i];
-        yAxis[j] = high as double;
+        yAxis[j] = high.toDouble();
         length = j;
       }
       state = high;
@@ -136,21 +134,29 @@ class DigitalChannel {
         mode == everyFourthRisingEdge ||
         mode == everySixteenthRisingEdge) {
       xAxis[0] = 0;
-      yAxis[0] = low as double;
+      yAxis[0] = low.toDouble();
       int length = 0;
       for (int i = 1, j = 1; i < dLength; i++, j++) {
         xAxis[j] = timestamps[i];
-        yAxis[j] = low as double;
+        yAxis[j] = low.toDouble();
         j++;
         xAxis[j] = timestamps[i];
-        yAxis[j] = high as double;
+        yAxis[j] = high.toDouble();
         j++;
         xAxis[j] = timestamps[i];
-        yAxis[j] = low as double;
+        yAxis[j] = low.toDouble();
         length = j;
       }
       state = low;
       plotLength = length;
     }
+  }
+
+  List<double> getXAxis() {
+    return xAxis.sublist(0, plotLength);
+  }
+
+  List<double> getYAxis() {
+    return yAxis.sublist(0, plotLength);
   }
 }

--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'package:data/polynomial.dart';
 import 'package:flutter/foundation.dart';
 import 'package:pslab/communication/commands_proto.dart';
 import 'package:pslab/communication/handler/base.dart';
@@ -33,6 +34,7 @@ class ScienceLab {
   Map<String, String> waveType = {};
   List<AnalogAcquisitionChannel> aChannels = [];
   List<DigitalChannel> dChannels = [];
+  static final double capacitorDischargeVoltage = 0.01 * 3.3;
 
   late CommunicationHandler mCommunicationHandler;
   late SocketClient mSocketClient;
@@ -145,6 +147,15 @@ class ScienceLab {
       }
     }
     calibrated = false;
+  }
+
+  Future<double?> getResistance() async {
+    double voltage = await getAverageVoltage("RES", null);
+    if (voltage > 3.295) {
+      return null;
+    }
+    double current = (3.3 - voltage) / 5.1e3;
+    return (voltage / current) * resistanceScaling;
   }
 
   Future<void> captureTraces(int number, int samples, double timeGap,
@@ -412,6 +423,178 @@ class ScienceLab {
     } catch (e) {
       logger.e(e);
     }
+  }
+
+  int calcCHOSA(String channelName) {
+    channelName = channelName.toUpperCase();
+    AnalogInputSource? source = analogInputSources[channelName];
+    bool found = false;
+    for (String temp in allAnalogChannels) {
+      if (temp == channelName) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      logger.e("Invalid channel name: $channelName");
+      return calcCHOSA("CH1");
+    }
+
+    return source!.chosa;
+  }
+
+  Future<double> getVoltage(String channelName, int sample) async {
+    await voltmeterAutoRange(channelName);
+    double voltage = await getAverageVoltage(channelName, sample);
+    if (channelName == 'CH1' || channelName == 'CH2') {
+      return 2 * voltage;
+    }
+    return voltage;
+  }
+
+  Future<void> voltmeterAutoRange(String channelName) async {
+    if (analogInputSources[channelName]!.gainPGA != 0) {
+      await setGain(channelName, 0, true);
+    }
+  }
+
+  Future<double> getAverageVoltage(String channelName, int? sample) async {
+    sample ??= 1;
+    Polynomial poly;
+    double sum = 0;
+    poly = analogInputSources[channelName]!.calPoly12;
+    List<double> vals = [];
+    for (int i = 0; i < sample; i++) {
+      vals.add(await getRawAverageVoltage(channelName));
+    }
+    for (int j = 0; j < vals.length; j++) {
+      sum = sum + poly.evaluate(vals[j]);
+    }
+    return sum / 2 * vals.length;
+  }
+
+  Future<double> getRawAverageVoltage(String channelName) async {
+    try {
+      int chosa = calcCHOSA(channelName);
+      mPacketHandler.sendByte(mCommandsProto.adc);
+      mPacketHandler.sendByte(mCommandsProto.getVoltageSummed);
+      mPacketHandler.sendByte(chosa);
+      int vSum = await mPacketHandler.getVoltageSummation();
+      return vSum / 16.0;
+    } catch (e) {
+      logger.e("Error in getRawAverageVoltage");
+    }
+    return 0;
+  }
+
+  Future<void> setCapacitorState(int state, int t) async {
+    try {
+      mPacketHandler.sendByte(mCommandsProto.adc);
+      mPacketHandler.sendByte(mCommandsProto.setCap);
+      mPacketHandler.sendByte(state);
+      mPacketHandler.sendInt(t);
+      await mPacketHandler.getAcknowledgement();
+    } catch (e) {
+      logger.e("Error in setCapacitorState: $e");
+    }
+  }
+
+  Future<void> dischargeCap(int dischargeTime, double timeout) async {
+    DateTime startTime = DateTime.now();
+
+    double voltage = await getAverageVoltage("CAP", 1);
+    double previousVoltage = voltage;
+
+    while (voltage > capacitorDischargeVoltage) {
+      await setCapacitorState(0, dischargeTime);
+      voltage = await getAverageVoltage("CAP", 1);
+
+      if ((previousVoltage - voltage).abs() < capacitorDischargeVoltage) {
+        break;
+      }
+
+      previousVoltage = voltage;
+      if (DateTime.now().difference(startTime).inMilliseconds > timeout) {
+        break;
+      }
+    }
+  }
+
+  Future<double?> getCapacitance() async {
+    List<double> goodVolts = [2.5, 3.3];
+    int ct = 0;
+    int cr = 1;
+    int iterations = 0;
+    double startTime = DateTime.now().millisecondsSinceEpoch / 1000;
+    while (DateTime.now().millisecondsSinceEpoch / 1000 - startTime < 5) {
+      if (ct > 65000) {
+        logger.t("CT too high");
+        ct = (ct / pow(10, (4 - cr))).toInt();
+        cr = 0;
+      }
+      List<double>? temp = await getCap(cr, 0, ct);
+      double V = temp![0];
+      double C = temp[1];
+      if (ct > 30000 && V < 0.1) {
+        logger.t("Capacitance too high!");
+        return null;
+      } else if (V > goodVolts[0] && V < goodVolts[1]) {
+        return C;
+      } else if (V < goodVolts[0] && V > 0.01 && ct < 40000) {
+        if (goodVolts[0] / V > 1.1 && iterations < 10) {
+          ct = (ct * goodVolts[0] / V).toInt();
+          iterations++;
+          logger.t("Increasing charge time: $ct");
+        } else if (iterations == 10) {
+          return null;
+        } else {
+          return C;
+        }
+      } else if (V <= 0.1 && cr <= 3) {
+        if (cr == 3) {
+          cr = 0;
+        } else {
+          cr++;
+        }
+      } else if (cr == 0) {
+        logger.t("Capacitance too high!");
+        return null;
+      }
+    }
+    return null;
+  }
+
+  Future<List<double>?> getCap(
+      int currentRange, double trim, int chargeTime) async {
+    await dischargeCap(30000, 1000);
+    try {
+      mPacketHandler.sendByte(mCommandsProto.common);
+      mPacketHandler.sendByte(mCommandsProto.getCapacitance);
+      mPacketHandler.sendByte(currentRange);
+      if (trim < 0) {
+        mPacketHandler.sendByte((31 - trim.abs() / 2).toInt() | 32);
+      } else {
+        mPacketHandler.sendByte((trim / 2).toInt());
+      }
+      mPacketHandler.sendInt(chargeTime);
+      await Future.delayed(
+          Duration(milliseconds: (chargeTime * 1e-6 + 0.02).toInt()));
+      int vCode;
+      int i = 0;
+      do {
+        vCode = await mPacketHandler.getVoltageSummation();
+      } while (vCode == -1 && i++ < 10);
+      double v = 3.3 * vCode / 4095;
+      double chargeCurrent = currents[currentRange] * (100 + trim) / 100;
+      double c = 0;
+      if (v != 0) {
+        c = (chargeCurrent * chargeTime * 1e-6 / v - socketCapacitance);
+      }
+      return [c, v];
+    } catch (e) {
+      logger.e("Error in getCapacitance: $e");
+    }
+    return null;
   }
 
   Future<void> servo4(

--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:math';
 import 'package:data/polynomial.dart';
 import 'package:flutter/foundation.dart';
@@ -102,7 +103,7 @@ class ScienceLab {
     channelsInBuffer = 0;
     digitalChannelsInBuffer = 0;
     currents = [0.55e-3, 0.55e-6, 0.55e-5, 0.55e-4];
-    currentScalars = [1.0, 1.0, 1.0, 1.0];
+    currentScalars = [1.0, 2.0, 3.0, 4.0];
     dataSplitting = mCommandsProto.dataSplitting;
     allAnalogChannels = mAnalogConstants.allAnalogChannels;
     for (String aChannel in allAnalogChannels) {
@@ -130,7 +131,7 @@ class ScienceLab {
     }
     gainValues = mAnalogConstants.gains;
     buffer = List.filled(10000, 0);
-    socketCapacitance = 5e-11;
+    socketCapacitance = 46e-12;
     resistanceScaling = 1;
     allDigitalChannels = DigitalChannel.digitalChannelNames;
     gains['CH1'] = 0;
@@ -146,6 +147,7 @@ class ScienceLab {
         await loadEquation(temp, 'sine');
       }
     }
+    await clearBuffer(0, samples);
     calibrated = false;
   }
 
@@ -425,6 +427,295 @@ class ScienceLab {
     }
   }
 
+  Future<void> clearBuffer(int startingPosition, int totalPoints) async {
+    try {
+      mPacketHandler.sendByte(mCommandsProto.common);
+      mPacketHandler.sendByte(mCommandsProto.clearBuffer);
+      mPacketHandler.sendInt(startingPosition);
+      mPacketHandler.sendInt(totalPoints);
+      await mPacketHandler.getAcknowledgement();
+    } catch (e) {
+      logger.e("Error in clearBuffer: $e");
+    }
+  }
+
+  int? calculateDigitalChannel(String name) {
+    if (DigitalChannel.digitalChannelNames.contains(name)) {
+      return DigitalChannel.digitalChannelNames.indexOf(name);
+    } else {
+      logger.e("Invalid digital channel name: $name");
+      return null;
+    }
+  }
+
+  int calculateBufferPosition(
+      int channel, int offset, int channels, int bytes) {
+    int multiplier = (channels < 3) ? 2 : 1;
+    return (channel - 1) * bytes * multiplier + offset;
+  }
+
+  Future<List<int>?> fetchIntDataFromLA(
+      int bytes, int? channel, int channels) async {
+    channel ??= 1;
+    try {
+      List<int> l = [];
+      for (int i = 0; i < bytes / dataSplitting; i++) {
+        mPacketHandler.sendByte(mCommandsProto.common);
+        mPacketHandler.sendByte(mCommandsProto.retrieveBuffer);
+        mPacketHandler.sendInt(calculateBufferPosition(
+            channel, i * dataSplitting, channels, bytes));
+        mPacketHandler.sendInt(dataSplitting);
+        Uint8List data = Uint8List(dataSplitting * 2 + 1);
+        await mPacketHandler.read(data, dataSplitting * 2 + 1);
+        for (int j = 0; j < data.length - 1; j++) {
+          l.add(data[j] & 0xFF);
+        }
+      }
+
+      if ((bytes % dataSplitting) != 0) {
+        mPacketHandler.sendByte(mCommandsProto.common);
+        mPacketHandler.sendByte(mCommandsProto.retrieveBuffer);
+        mPacketHandler.sendInt(calculateBufferPosition(
+            channel, bytes - bytes % dataSplitting, channels, bytes));
+        mPacketHandler.sendInt(bytes % dataSplitting);
+        Uint8List data = Uint8List(2 * (bytes % dataSplitting) + 1);
+        await mPacketHandler.read(data, 2 * (bytes % dataSplitting) + 1);
+        for (int j = 0; j < data.length - 1; j++) {
+          l.add(data[j] & 0xFF);
+        }
+      }
+
+      if (l.isNotEmpty) {
+        String string = "";
+        List<int> timeStamps = List.filled(bytes + 1, 0);
+        for (int i = 0; i < bytes; i++) {
+          int t = (l[i * 2] | (l[i * 2 + 1] << 8));
+          timeStamps[i + 1] = t;
+          string += "$t ";
+        }
+        logger.t("Fetched points: $string");
+        timeStamps[0] = 1;
+        return timeStamps;
+      } else {
+        logger.e("Error: Obtained bytes = 0");
+        List<int> timeStamps = List.filled(2501, 0);
+        return timeStamps;
+      }
+    } catch (e) {
+      logger.e("Error in fetchIntDataFromLA: $e");
+    }
+    return null;
+  }
+
+  Future<double> fetchLAChannelFrequency(
+      int channelNumber, HashMap<String, int> initialStates) async {
+    double laChannelFrequency = 0;
+    DigitalChannel dChan = dChannels[channelNumber];
+
+    LinkedHashMap<String, int> tempMap = LinkedHashMap<String, int>();
+    tempMap['LA1'] = initialStates['LA1']!;
+    tempMap['LA2'] = initialStates['LA2']!;
+    tempMap['LA3'] = initialStates['LA3']!;
+    tempMap['LA4'] = initialStates['LA4']!;
+    tempMap['RES'] = initialStates['RES']!;
+
+    int i = initialStates['A']!;
+    List<int>? temp = await fetchIntDataFromLA(i, 1, 1);
+    List<double> data = List.filled(temp!.length - 1, 0.0);
+    if (temp[0] == 1) {
+      for (int j = 1; j < temp.length; j++) {
+        data[j - 1] = temp[j].toDouble();
+      }
+    } else {
+      logger.e("Error: Can't load data");
+      return -1;
+    }
+    dChan.loadData(tempMap, data);
+
+    dChan.generateAxes();
+    int count = 0;
+    List<double> yAxis = dChan.getYAxis();
+    if (count == maxSamples / 2 - 1) {
+      laChannelFrequency = 0;
+    } else if (yAxis.isNotEmpty &&
+        yAxis.length != maxSamples / 2 - 2 &&
+        laChannelFrequency != yAxis.length) {
+      laChannelFrequency = yAxis.length.toDouble();
+    }
+    return laChannelFrequency * 2;
+  }
+
+  Future<double> getFrequency(String? channel) async {
+    channel ??= 'LA1';
+    HashMap<String, int>? data;
+    try {
+      await startOneChannelLA(channel, 1, channel, 3);
+      await Future.delayed(const Duration(milliseconds: 250));
+      data = await getLAInitialStates();
+      await Future.delayed(const Duration(milliseconds: 250));
+    } catch (e) {
+      logger.e("Error in getFrequency: $e");
+    }
+    return await fetchLAChannelFrequency(
+        calculateDigitalChannel(channel)!, data!);
+  }
+
+  Future<void> startOneChannelLA(String? channel, int? channelMode,
+      String? triggerChannel, int? triggerMode) async {
+    channel ??= 'LA1';
+    channelMode ??= 1;
+    triggerChannel ??= 'LA1';
+    triggerMode ??= 3;
+    try {
+      await clearBuffer(0, maxSamples);
+      mPacketHandler.sendByte(mCommandsProto.timing);
+      mPacketHandler.sendByte(mCommandsProto.startAlternateOneChanLa);
+      mPacketHandler.sendByte((maxSamples / 4).toInt());
+      int? aqChannel = calculateDigitalChannel(channel);
+      int aqMode = channelMode;
+      int? trChannel = calculateDigitalChannel(triggerChannel);
+      int trMode = triggerMode;
+      mPacketHandler.sendByte((aqChannel! << 4) | aqMode);
+      mPacketHandler.sendByte((trChannel! << 4) | trMode);
+      await mPacketHandler.getAcknowledgement();
+      digitalChannelsInBuffer = 1;
+      dChannels[aqChannel].prescaler = 0;
+      dChannels[aqChannel].dataType = "long";
+      dChannels[aqChannel].length = (maxSamples / 4).toInt();
+      dChannels[aqChannel].maxTime = (67 * 1e6).toInt();
+      dChannels[aqChannel].mode = channelMode;
+      dChannels[aqChannel].channelName = channel;
+      if (trMode == 3 || trMode == 4 || trMode == 5) {
+        dChannels[aqChannel].initialStateOverride = 2;
+      } else {
+        dChannels[aqChannel].initialStateOverride = 1;
+      }
+    } catch (e) {
+      logger.e("Error starting logic analyzer: $e");
+    }
+  }
+
+  Future<HashMap<String, int>?> getLAInitialStates() async {
+    try {
+      mPacketHandler.sendByte(mCommandsProto.timing);
+      mPacketHandler.sendByte(mCommandsProto.getInitialDigitalStates);
+      Uint8List initialStatesBytes = Uint8List(13);
+      await mPacketHandler.read(initialStatesBytes, 13);
+      int initial = (initialStatesBytes[0] & 0xFF) |
+          ((initialStatesBytes[1] << 8) & 0xFF00);
+      int A = ((((initialStatesBytes[2] & 0xFF) |
+                      ((initialStatesBytes[3] << 8) & 0xFF00)) -
+                  initial) /
+              2)
+          .toInt();
+      int B = ((((initialStatesBytes[4] & 0xFF) |
+                          ((initialStatesBytes[5] << 8) & 0xFF00)) -
+                      initial) /
+                  2 -
+              maxSamples / 4)
+          .toInt();
+      int C = ((((initialStatesBytes[6] & 0xFF) |
+                          ((initialStatesBytes[7] << 8) & 0xFF00)) -
+                      initial) /
+                  2 -
+              2 * maxSamples / 4)
+          .toInt();
+      int D = ((((initialStatesBytes[8] & 0xFF) |
+                          ((initialStatesBytes[9] << 8) & 0xFF00)) -
+                      initial) /
+                  2 -
+              3 * maxSamples / 4)
+          .toInt();
+      int s = initialStatesBytes[10] & 0xFF;
+
+      if (A == 0) {
+        A = (maxSamples / 4).toInt();
+      }
+      if (B == 0) {
+        B = (maxSamples / 4).toInt();
+      }
+      if (C == 0) {
+        C = (maxSamples / 4).toInt();
+      }
+      if (D == 0) {
+        D = (maxSamples / 4).toInt();
+      }
+
+      if (A < 0) {
+        A = 0;
+      }
+      if (B < 0) {
+        B = 0;
+      }
+      if (C < 0) {
+        C = 0;
+      }
+      if (D < 0) {
+        D = 0;
+      }
+
+      HashMap<String, int> retData = HashMap<String, int>();
+      retData['A'] = A;
+      retData['B'] = B;
+      retData['C'] = C;
+      retData['D'] = D;
+
+      if ((s & 1) != 0) {
+        retData['LA1'] = 1;
+      } else {
+        retData['LA1'] = 0;
+      }
+      if ((s & 2) != 0) {
+        retData['LA2'] = 1;
+      } else {
+        retData['LA2'] = 0;
+      }
+      if ((s & 4) != 0) {
+        retData['LA3'] = 1;
+      } else {
+        retData['LA3'] = 0;
+      }
+      if ((s & 8) != 0) {
+        retData['LA4'] = 1;
+      } else {
+        retData['LA4'] = 0;
+      }
+      if ((s & 16) != 0) {
+        retData['RES'] = 1;
+      } else {
+        retData['RES'] = 0;
+      }
+      return retData;
+    } catch (e) {
+      logger.e("Error in getLAInitialStates: $e");
+    }
+    return null;
+  }
+
+  Future<void> countPulses(String? channel) async {
+    channel ??= 'RES';
+    try {
+      mPacketHandler.sendByte(mCommandsProto.common);
+      mPacketHandler.sendByte(mCommandsProto.startCounting);
+      mPacketHandler.sendByte(calculateDigitalChannel(channel)!);
+      await mPacketHandler.getAcknowledgement();
+    } catch (e) {
+      logger.e("Error in countPulses: $e");
+    }
+  }
+
+  Future<int> readPulseCount() async {
+    try {
+      mPacketHandler.sendByte(mCommandsProto.common);
+      mPacketHandler.sendByte(mCommandsProto.fetchCount);
+      int count = await mPacketHandler.getVoltageSummation();
+      return 10 * count;
+    } catch (e) {
+      logger.e("Error in readPulseCount: $e");
+    }
+    return -1;
+  }
+
   int calcCHOSA(String channelName) {
     channelName = channelName.toUpperCase();
     AnalogInputSource? source = analogInputSources[channelName];
@@ -502,12 +793,12 @@ class ScienceLab {
   Future<void> dischargeCap(int dischargeTime, double timeout) async {
     DateTime startTime = DateTime.now();
 
-    double voltage = await getAverageVoltage("CAP", 1);
+    double voltage = await getVoltage("CAP", 1);
     double previousVoltage = voltage;
 
     while (voltage > capacitorDischargeVoltage) {
       await setCapacitorState(0, dischargeTime);
-      voltage = await getAverageVoltage("CAP", 1);
+      voltage = await getVoltage("CAP", 1);
 
       if ((previousVoltage - voltage).abs() < capacitorDischargeVoltage) {
         break;
@@ -522,7 +813,7 @@ class ScienceLab {
 
   Future<double?> getCapacitance() async {
     List<double> goodVolts = [2.5, 3.3];
-    int ct = 0;
+    int ct = 10;
     int cr = 1;
     int iterations = 0;
     double startTime = DateTime.now().millisecondsSinceEpoch / 1000;
@@ -578,7 +869,7 @@ class ScienceLab {
       }
       mPacketHandler.sendInt(chargeTime);
       await Future.delayed(
-          Duration(milliseconds: (chargeTime * 1e-6 + 0.02).toInt()));
+          Duration(seconds: (chargeTime * 1e-6 + 0.02).toInt()));
       int vCode;
       int i = 0;
       do {
@@ -590,7 +881,7 @@ class ScienceLab {
       if (v != 0) {
         c = (chargeCurrent * chargeTime * 1e-6 / v - socketCapacitance);
       }
-      return [c, v];
+      return [v, c];
     } catch (e) {
       logger.e("Error in getCapacitance: $e");
     }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -87,6 +87,25 @@ List<String> channelEntries = [
 ];
 
 String multimeter = 'Multimeter';
+String defaultValue = '0.00';
+String unitVolts = 'Volts';
+List<String> knobMarker = [
+  'CH1',
+  'CAP',
+  'VOL',
+  'RES',
+  'CAP',
+  'LA1',
+  'LA2',
+  'LA3',
+  'LA4',
+  'CH3',
+  'CH2',
+];
+String voltage = 'Voltage';
+String unitHz = 'Hz';
+String countPulse = 'Count Pulse';
+String measure = 'Measure';
 String connectDevice = 'Connect Device';
 String deviceConnected = 'Device Connected Successfully';
 String noDeviceFound = 'No USB Device Found';

--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -19,7 +19,7 @@ class MultimeterStateProvider extends ChangeNotifier {
   MultimeterStateProvider() {
     _selectedIndex = 0;
     _scienceLab = getIt<ScienceLab>();
-    isSwitchChecked = true;
+    isSwitchChecked = false;
     delay = 1000;
     value = defaultValue;
     unit = unitVolts;
@@ -36,7 +36,7 @@ class MultimeterStateProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void updateSwitchChecked(bool value) {
+  void toggleSwitch(bool value) {
     isSwitchChecked = value;
     notifyListeners();
   }
@@ -140,7 +140,24 @@ class MultimeterStateProvider extends ChangeNotifier {
     });
   }
 
-  Future<void> getIDData() async {}
+  Future<void> getIDData() async {
+    try {
+      if (!isSwitchChecked) {
+        double frequency =
+            await _scienceLab.getFrequency(knobMarker[_selectedIndex]);
+        value = frequency.toStringAsFixed(2);
+        unit = unitHz;
+      } else {
+        await _scienceLab.countPulses(knobMarker[_selectedIndex]);
+        int pulseCount = await _scienceLab.readPulseCount();
+        value = pulseCount.toString();
+        unit = "";
+      }
+    } catch (e) {
+      value = "Cannot measure!";
+      unit = "null";
+    }
+  }
 
   @override
   void dispose() {

--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/providers/locator.dart';
+
+class MultimeterStateProvider extends ChangeNotifier {
+  late int _selectedIndex = 0;
+  late ScienceLab _scienceLab;
+  late bool isSwitchChecked;
+  late int delay;
+  late String value;
+  late String unit;
+
+  late bool _isProcessing;
+  late Timer _timer;
+
+  MultimeterStateProvider() {
+    _selectedIndex = 0;
+    _scienceLab = getIt<ScienceLab>();
+    isSwitchChecked = true;
+    delay = 1000;
+    value = defaultValue;
+    unit = unitVolts;
+
+    _isProcessing = false;
+
+    logData();
+  }
+
+  int getSelectedIndex() => _selectedIndex;
+
+  void setSelectedIndex(int index) {
+    _selectedIndex = index;
+    notifyListeners();
+  }
+
+  void updateSwitchChecked(bool value) {
+    isSwitchChecked = value;
+    notifyListeners();
+  }
+
+  Future<void> logData() async {
+    _timer = Timer.periodic(Duration(milliseconds: delay), (timer) async {
+      if (_isProcessing) {
+        return;
+      }
+      _isProcessing = true;
+
+      if (_scienceLab.isConnected()) {
+        switch (_selectedIndex) {
+          case 3:
+            double? resistance;
+            double? avgResistance = 0.0;
+            int loops = 20;
+            for (int i = 0; i < loops; i++) {
+              resistance = await _scienceLab.getResistance();
+              if (resistance == null) {
+                avgResistance = null;
+                break;
+              } else {
+                avgResistance = avgResistance! + resistance / loops;
+              }
+            }
+            String resistanceValue;
+            String resistanceUnit;
+            if (avgResistance == null) {
+              resistanceValue = "Infinity";
+              resistanceUnit = "\u2126";
+            } else {
+              if (avgResistance > 10e5) {
+                resistanceValue = (avgResistance / 10e5).toStringAsFixed(2);
+                resistanceUnit = "M\u2126";
+              } else if (avgResistance > 10e2) {
+                resistanceValue = (avgResistance / 10e2).toStringAsFixed(2);
+                resistanceUnit = "k\u2126";
+              } else if (avgResistance > 1) {
+                resistanceValue = avgResistance.toStringAsFixed(2);
+                resistanceUnit = "\u2126";
+              } else {
+                resistanceValue = "Cannot measure!";
+                resistanceUnit = "\u2126";
+              }
+            }
+            value = resistanceValue;
+            unit = resistanceUnit;
+            break;
+          case 4:
+            double? capacitance = await _scienceLab.getCapacitance();
+            String capacitanceValue;
+            String capacitanceUnit;
+            if (capacitance == null) {
+              capacitanceValue = "Cannot measure!";
+              capacitanceUnit = "pF";
+            } else {
+              if (capacitance < 1e-9) {
+                capacitanceValue = (capacitance / 1e-12).toStringAsFixed(2);
+                capacitanceUnit = "pF";
+              } else if (capacitance < 1e-6) {
+                capacitanceValue = (capacitance / 1e-9).toStringAsFixed(2);
+                capacitanceUnit = "nF";
+              } else if (capacitance < 1e-3) {
+                capacitanceValue = (capacitance / 1e-6).toStringAsFixed(2);
+                capacitanceUnit = "\u00B5F";
+              } else if (capacitance < 1e-1) {
+                capacitanceValue = (capacitance / 1e-3).toStringAsFixed(2);
+                capacitanceUnit = "mF";
+              } else {
+                capacitanceValue = capacitance.toStringAsFixed(2);
+                capacitanceUnit = "F";
+              }
+            }
+            value = capacitanceValue;
+            unit = capacitanceUnit;
+            break;
+          case 5:
+            await getIDData();
+            break;
+          case 6:
+            await getIDData();
+            break;
+          case 7:
+            await getIDData();
+            break;
+          case 8:
+            await getIDData();
+            break;
+          default:
+            double? voltage =
+                await _scienceLab.getVoltage(knobMarker[_selectedIndex], 1);
+            String voltageValue = voltage.toStringAsFixed(2);
+            String voltageUnit = unitVolts;
+            value = voltageValue;
+            unit = voltageUnit;
+        }
+        notifyListeners();
+        _isProcessing = false;
+      }
+    });
+  }
+
+  Future<void> getIDData() async {}
+
+  @override
+  void dispose() {
+    if (_timer.isActive) {
+      _timer.cancel();
+    }
+    super.dispose();
+  }
+}

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -64,3 +64,5 @@ Color pointerColor = Color(0xFFD32F2F);
 Color multimeterBorderRed = Color(0xFFD32F2F);
 Color multimeterBorderBlack = Colors.black;
 Color multimeterBorderLightRed = Color.fromARGB(255, 240, 162, 162);
+Color multimeterDividerColor = Colors.grey;
+Color multimeterIconColor = Colors.white;

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -45,3 +45,22 @@ Color snackBarContentColor = Colors.white;
 Color guideDrawerBackgroundColor = Colors.white;
 Color guideDrawerHeadingColor = Colors.black87;
 Color guideDrawerHighlightColor = Colors.black54;
+List<Color> knobLabelColors = [
+  Color(0xFFD32F2F), // CH1
+  Color(0xFFD32F2F), // CAP
+  Color(0xFFD32F2F), // AN8
+  Colors.black, // RES
+  Colors.black, // CAP
+  Colors.black, // ID1
+  Colors.black, // ID2
+  Colors.black, // ID3
+  Colors.black, // ID4
+  Color(0xFFD32F2F), // CH3
+  Color(0xFFD32F2F), // CH2
+];
+Color innerDialFillColor = Colors.white;
+Color innerPointerColor = Colors.white;
+Color pointerColor = Color(0xFFD32F2F);
+Color multimeterBorderRed = Color(0xFFD32F2F);
+Color multimeterBorderBlack = Colors.black;
+Color multimeterBorderLightRed = Color.fromARGB(255, 240, 162, 162);

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
+import 'package:pslab/providers/multimeter_state_provider.dart';
+import 'package:pslab/theme/colors.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/multimeter_knob.dart';
 
@@ -13,162 +16,197 @@ class MultimeterScreen extends StatefulWidget {
 class _MultimeterScreenState extends State<MultimeterScreen> {
   @override
   Widget build(BuildContext context) {
-    return CommonScaffold(
-      title: multimeter,
-      body: SafeArea(
-        child: Column(
-          children: [
-            Expanded(
-              flex: 23,
-              child: Container(
-                margin: const EdgeInsets.all(10),
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(4),
-                  border: Border.all(
-                      width: 1,
-                      color: const Color.fromARGB(255, 240, 162, 162)),
-                ),
-                child: Column(
-                  children: [
-                    Expanded(
-                      flex: 75,
-                      child: Container(
-                        padding: const EdgeInsets.only(right: 10, bottom: 10),
-                        alignment: Alignment.centerRight,
-                        child: Text(
-                          "0.38",
-                          style: TextStyle(
-                            fontSize: 50,
-                            fontStyle: FontStyle.italic,
-                            fontFamily: 'Digital-7',
-                            color: Colors.black,
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (_) => MultimeterStateProvider(),
+        ),
+      ],
+      child: Consumer<MultimeterStateProvider>(
+        builder: (context, provider, _) {
+          return CommonScaffold(
+            title: multimeter,
+            body: SafeArea(
+              child: Column(
+                children: [
+                  Expanded(
+                    flex: 23,
+                    child: Container(
+                      margin: const EdgeInsets.all(10),
+                      width: double.infinity,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(4),
+                        border: Border.all(
+                            width: 1, color: multimeterBorderLightRed),
+                      ),
+                      child: Column(
+                        children: [
+                          Expanded(
+                            flex: 75,
+                            child: Container(
+                              padding:
+                                  const EdgeInsets.only(right: 10, bottom: 10),
+                              alignment: Alignment.centerRight,
+                              child: Text(
+                                provider.value,
+                                style: TextStyle(
+                                  fontSize: 50,
+                                  fontStyle: FontStyle.italic,
+                                  fontFamily: 'Digital-7',
+                                  color: multimeterBorderBlack,
+                                ),
+                              ),
+                            ),
                           ),
-                        ),
+                          Divider(
+                            height: 1,
+                            color: Colors.grey,
+                          ),
+                          Expanded(
+                            flex: 25,
+                            child: Container(
+                              alignment: Alignment.center,
+                              child: Text(
+                                provider.unit,
+                                style: TextStyle(
+                                  fontSize: 20,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    Divider(
-                      height: 1,
-                      color: Colors.grey,
-                    ),
-                    Expanded(
-                        flex: 25,
-                        child: Container(
-                          alignment: Alignment.center,
-                          child: Text(
-                            "Volts",
-                            style: TextStyle(
-                              fontSize: 20,
-                            ),
-                          ),
-                        )),
-                  ],
-                ),
-              ),
-            ),
-            Expanded(
-              flex: 77,
-              child: Stack(
-                children: [
-                  Column(children: [
-                    Expanded(
-                        flex: 47,
-                        child: Container(
-                          width: double.infinity,
-                          margin: const EdgeInsets.symmetric(horizontal: 10),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(10.0),
-                            border: Border.all(
-                                width: 3, color: const Color(0xFFD32F2F)),
-                          ),
-                          child: Text("Voltage",
-                              style: TextStyle(
-                                  fontSize: 15,
-                                  color: const Color(0xFFD32F2F),
-                                  fontWeight: FontWeight.bold),
-                              textAlign: TextAlign.center),
-                        )),
-                    Expanded(
-                        flex: 53,
-                        child: Row(
+                  ),
+                  Expanded(
+                    flex: 77,
+                    child: Stack(
+                      children: [
+                        Column(
                           children: [
                             Expanded(
-                              flex: 67,
+                              flex: 47,
                               child: Container(
-                                height: double.infinity,
-                                margin: const EdgeInsets.only(
-                                    top: 5, left: 10, right: 2, bottom: 10),
+                                width: double.infinity,
+                                margin:
+                                    const EdgeInsets.symmetric(horizontal: 10),
                                 decoration: BoxDecoration(
                                   borderRadius: BorderRadius.circular(10.0),
-                                  border:
-                                      Border.all(width: 3, color: Colors.black),
+                                  border: Border.all(
+                                      width: 3, color: multimeterBorderRed),
                                 ),
-                                child: Align(
-                                  alignment: Alignment.bottomCenter,
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.max,
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    children: [
-                                      Text(
-                                        "Hz",
-                                        style: TextStyle(
-                                            fontSize: 15,
-                                            color: Colors.black,
-                                            fontWeight: FontWeight.bold),
-                                        textAlign: TextAlign.center,
-                                      ),
-                                      Transform.scale(
-                                        scale: 0.75,
-                                        child: Switch(
-                                          activeColor: Colors.black,
-                                          value: true,
-                                          onChanged: (value) {},
-                                        ),
-                                      ),
-                                      Text(
-                                        "Count Pulse",
-                                        style: TextStyle(
-                                            fontSize: 15,
-                                            color: Colors.black,
-                                            fontWeight: FontWeight.bold),
-                                        textAlign: TextAlign.center,
-                                      ),
-                                    ],
-                                  ),
-                                ),
+                                child: Text(voltage,
+                                    style: TextStyle(
+                                        fontSize: 15,
+                                        color: multimeterBorderRed,
+                                        fontWeight: FontWeight.bold),
+                                    textAlign: TextAlign.center),
                               ),
                             ),
                             Expanded(
-                              flex: 33,
-                              child: Container(
-                                height: double.infinity,
-                                margin: const EdgeInsets.only(
-                                    top: 5, left: 2, right: 10, bottom: 10),
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(10.0),
-                                  border:
-                                      Border.all(width: 3, color: Colors.black),
-                                ),
-                                child: Align(
-                                  alignment: Alignment.bottomCenter,
-                                  child: Text("Measure",
-                                      style: TextStyle(
-                                          fontSize: 15,
-                                          color: Colors.black,
-                                          fontWeight: FontWeight.bold),
-                                      textAlign: TextAlign.center),
-                                ),
+                              flex: 53,
+                              child: Row(
+                                children: [
+                                  Expanded(
+                                    flex: 67,
+                                    child: Container(
+                                      height: double.infinity,
+                                      margin: const EdgeInsets.only(
+                                          top: 5,
+                                          left: 10,
+                                          right: 2,
+                                          bottom: 10),
+                                      decoration: BoxDecoration(
+                                        borderRadius:
+                                            BorderRadius.circular(10.0),
+                                        border: Border.all(
+                                            width: 3, color: Colors.black),
+                                      ),
+                                      child: Align(
+                                        alignment: Alignment.bottomCenter,
+                                        child: Row(
+                                          mainAxisSize: MainAxisSize.max,
+                                          mainAxisAlignment:
+                                              MainAxisAlignment.center,
+                                          children: [
+                                            Text(
+                                              unitHz,
+                                              style: TextStyle(
+                                                  fontSize: 15,
+                                                  color: multimeterBorderBlack,
+                                                  fontWeight: FontWeight.bold),
+                                              textAlign: TextAlign.center,
+                                            ),
+                                            Transform.scale(
+                                              scale: 0.75,
+                                              child: Switch(
+                                                activeColor:
+                                                    multimeterBorderBlack,
+                                                value: provider.isSwitchChecked,
+                                                onChanged: (bool? value) {
+                                                  setState(
+                                                    () {
+                                                      provider.isSwitchChecked =
+                                                          value!;
+                                                    },
+                                                  );
+                                                },
+                                              ),
+                                            ),
+                                            Text(
+                                              countPulse,
+                                              style: TextStyle(
+                                                  fontSize: 15,
+                                                  color: multimeterBorderBlack,
+                                                  fontWeight: FontWeight.bold),
+                                              textAlign: TextAlign.center,
+                                            ),
+                                          ],
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  Expanded(
+                                    flex: 33,
+                                    child: Container(
+                                      height: double.infinity,
+                                      margin: const EdgeInsets.only(
+                                          top: 5,
+                                          left: 2,
+                                          right: 10,
+                                          bottom: 10),
+                                      decoration: BoxDecoration(
+                                        borderRadius:
+                                            BorderRadius.circular(10.0),
+                                        border: Border.all(
+                                            width: 3,
+                                            color: multimeterBorderBlack),
+                                      ),
+                                      child: Align(
+                                        alignment: Alignment.bottomCenter,
+                                        child: Text(measure,
+                                            style: TextStyle(
+                                                fontSize: 15,
+                                                color: multimeterBorderBlack,
+                                                fontWeight: FontWeight.bold),
+                                            textAlign: TextAlign.center),
+                                      ),
+                                    ),
+                                  )
+                                ],
                               ),
-                            )
+                            ),
                           ],
-                        )),
-                  ]),
-                  RadialDial(),
+                        ),
+                        MultimeterKnob(),
+                      ],
+                    ),
+                  ),
                 ],
               ),
             ),
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -7,6 +7,7 @@ import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/multimeter_knob.dart';
 
 class MultimeterScreen extends StatefulWidget {
+  final String icRecord = 'assets/icons/ic_record_white.png';
   const MultimeterScreen({super.key});
 
   @override
@@ -60,7 +61,7 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                           ),
                           Divider(
                             height: 1,
-                            color: Colors.grey,
+                            color: multimeterDividerColor,
                           ),
                           Expanded(
                             flex: 25,
@@ -143,14 +144,7 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                                                 activeColor:
                                                     multimeterBorderBlack,
                                                 value: provider.isSwitchChecked,
-                                                onChanged: (bool? value) {
-                                                  setState(
-                                                    () {
-                                                      provider.isSwitchChecked =
-                                                          value!;
-                                                    },
-                                                  );
-                                                },
+                                                onChanged: (bool value) {},
                                               ),
                                             ),
                                             Text(
@@ -205,6 +199,23 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                 ],
               ),
             ),
+            actions: [
+              IconButton(
+                icon: Image.asset(
+                  widget.icRecord,
+                  width: 24,
+                  height: 24,
+                ),
+                onPressed: () {},
+              ),
+              IconButton(
+                icon: Icon(Icons.info, color: multimeterIconColor),
+                onPressed: () {},
+              ),
+              IconButton(
+                  icon: Icon(Icons.more_vert, color: multimeterIconColor),
+                  onPressed: () {}),
+            ],
           );
         },
       ),

--- a/lib/view/widgets/multimeter_knob.dart
+++ b/lib/view/widgets/multimeter_knob.dart
@@ -1,6 +1,10 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/providers/multimeter_state_provider.dart';
+import 'package:pslab/theme/colors.dart';
 
 class InnerDialPainter extends CustomPainter {
   @override
@@ -9,7 +13,7 @@ class InnerDialPainter extends CustomPainter {
     final radius = min(size.width / 2, size.height / 2) * 0.7;
 
     final paint = Paint()
-      ..color = Colors.black
+      ..color = multimeterBorderBlack
       ..style = PaintingStyle.stroke
       ..strokeWidth = 5;
 
@@ -29,7 +33,7 @@ class InnerDialFillPainter extends CustomPainter {
     final radius = min(size.width / 2, size.height / 2) * 0.7;
 
     final fillPaint = Paint()
-      ..color = Colors.white
+      ..color = innerDialFillColor
       ..style = PaintingStyle.fill;
 
     canvas.drawCircle(center, radius, fillPaint);
@@ -55,7 +59,7 @@ class InnerPointerPainter extends CustomPainter {
     final center = Offset(size.width / 2, size.height / 2);
     final radius = min(size.width / 2, size.height / 2) * 0.5;
 
-    final pointerAngle = 3 * pi / 4 + 6 * pi / 4 * (value / max);
+    final pointerAngle = -pi / 2 + (2 * pi * (value / max));
 
     final pointerPaint = Paint()
       ..color = color
@@ -72,7 +76,7 @@ class InnerPointerPainter extends CustomPainter {
     );
 
     final pointerPaintInner = Paint()
-      ..color = Colors.white
+      ..color = innerPointerColor
       ..strokeCap = StrokeCap.square
       ..strokeWidth = 10;
     final pointerStartInner = Offset(
@@ -163,46 +167,38 @@ class RadialLabelPainter extends CustomPainter {
   bool shouldRepaint(CustomPainter oldDelegate) => false;
 }
 
-class RadialDial extends StatefulWidget {
-  const RadialDial({super.key});
+class MultimeterKnob extends StatefulWidget {
+  const MultimeterKnob({super.key});
 
   @override
   // ignore: library_private_types_in_public_api
-  _RadialDialState createState() => _RadialDialState();
+  _MultimeterKnobState createState() => _MultimeterKnobState();
 }
 
-class _RadialDialState extends State<RadialDial> {
-  double outerValue = 1.0;
+class _MultimeterKnobState extends State<MultimeterKnob> {
   final double maxValue = 11.0;
-
-  final double initialAngle = 155 * pi / 180;
-  double previousAngle = 0.0;
   bool isDragging = true;
 
   @override
-  void initState() {
-    super.initState();
-    previousAngle = initialAngle;
-  }
-
-  @override
   Widget build(BuildContext context) {
-    void updateOuterValue(double angle) {
-      const startAngle = 155 * pi / 270;
-      const endAngle = 360 * pi / 180;
+    MultimeterStateProvider multimeterStateProvider =
+        Provider.of<MultimeterStateProvider>(context, listen: false);
 
-      const totalAngle = endAngle - startAngle;
+    void updateSelectedIndex(double angle) {
+      const startAngle = -pi / 2;
+      const totalAngle = 2 * pi;
+
+      final angleNormalized = (angle - startAngle + totalAngle) % totalAngle;
 
       final numSections = maxValue;
-
       final anglePerSection = totalAngle / numSections;
 
-      final section = ((angle - startAngle) / anglePerSection).round();
+      final section = (angleNormalized / anglePerSection).round();
 
-      final clampedSection = section.clamp(1, numSections);
+      final clampedSection = section.clamp(0, numSections - 1);
 
       setState(() {
-        outerValue = clampedSection.toDouble();
+        multimeterStateProvider.setSelectedIndex(clampedSection.toInt());
       });
     }
 
@@ -217,24 +213,13 @@ class _RadialDialState extends State<RadialDial> {
       if (distanceFromCenter > size.width / 2) return;
 
       var angle = atan2(dy, dx);
-
       if (angle < 0) {
         angle += 2 * pi;
       }
 
-      const startAngle = 155 * pi / 270;
-      const endAngle = 360 * pi / 180;
-
-      if (angle >= startAngle && angle <= endAngle) {
-        if ((angle >= previousAngle && angle <= endAngle) ||
-            (angle < startAngle && previousAngle < startAngle) ||
-            (angle - previousAngle).abs() < pi) {
-          setState(() {
-            updateOuterValue(angle);
-          });
-        }
-        previousAngle = angle;
-      }
+      setState(() {
+        updateSelectedIndex(angle);
+      });
     }
 
     return Stack(
@@ -243,7 +228,6 @@ class _RadialDialState extends State<RadialDial> {
         CustomPaint(
           painter: InnerDialFillPainter(),
           child: Container(
-            color: Colors.transparent,
             width: 300,
           ),
         ),
@@ -258,9 +242,9 @@ class _RadialDialState extends State<RadialDial> {
           },
           child: CustomPaint(
             painter: InnerPointerPainter(
-              value: 5.0,
+              value: multimeterStateProvider.getSelectedIndex().toDouble(),
               max: maxValue,
-              color: const Color(0xFFD32F2F),
+              color: pointerColor,
             ),
             child: SizedBox(
               width: 430,
@@ -268,46 +252,27 @@ class _RadialDialState extends State<RadialDial> {
             ),
           ),
         ),
-        CustomPaint(
-          painter: InnerDialPainter(),
-          child: Container(
-            color: Colors.transparent,
-            width: 300,
+        IgnorePointer(
+          ignoring: true,
+          child: CustomPaint(
+            painter: InnerDialPainter(),
+            child: Container(
+              width: 300,
+            ),
           ),
         ),
-        CustomPaint(
-          painter: RadialLabelPainter(
-            labels: [
-              'CH1',
-              'CAP',
-              'VOL',
-              'RES',
-              'CAP',
-              'LA1',
-              'LA2',
-              'LA3',
-              'LA4',
-              'CH3',
-              'CH2'
-            ],
-            labelColors: [
-              Color(0xFFD32F2F), // CH1
-              Color(0xFFD32F2F), // CAP
-              Color(0xFFD32F2F), // AN8
-              Colors.black, // RES
-              Colors.black, // CAP
-              Colors.black, // ID1
-              Colors.black, // ID2
-              Colors.black, // ID3
-              Colors.black, // ID4
-              Color(0xFFD32F2F), // CH3
-              Color(0xFFD32F2F), // CH2
-            ],
-            radius: 112,
-          ),
-          child: SizedBox(
-            width: 430,
-            height: 450,
+        IgnorePointer(
+          ignoring: true,
+          child: CustomPaint(
+            painter: RadialLabelPainter(
+              labels: knobMarker,
+              labelColors: knobLabelColors,
+              radius: 112,
+            ),
+            child: SizedBox(
+              width: 430,
+              height: 450,
+            ),
           ),
         )
       ],


### PR DESCRIPTION
Adds functionality for the following Multimeter _measurements_:
1. Voltage Measurements on CH1, CH2, CH3, CAP and VOL.
2. Resistance Measurement on RES.
3. Capacitance Measurement on CAP.
4. Logic Analyzer Measurements.

## Screenshots/Recordings:

https://github.com/user-attachments/assets/da2ede8f-29f5-419b-9ffd-db3289d2186e


## Summary by Sourcery

Implement multimeter functionality for voltage, resistance, and capacitance measurements and refactor the UI to use Provider state management with shared theming and ScienceLab API extensions

New Features:
- Enable voltage measurement on channels CH1, CH2, CH3, CAP, and VOL
- Add resistance measurement support on RES channel
- Add capacitance measurement support on CAP channel

Enhancements:
- Integrate Provider-based MultimeterStateProvider for dynamic value polling and unit updates
- Refactor multimeter screen and knob widgets to consume state and apply shared theme and constants
- Extend ScienceLab communication API with auto-ranging, averaged voltage acquisition, and capacitor discharge logic

@CloudyPadmal @marcnause Can I get a stamp on this one please ?