### PR TITLE
feat: added Logic Analyzer

### DIFF
--- a/lib/communication/digitalChannel/digital_channel.dart
+++ b/lib/communication/digitalChannel/digital_channel.dart
@@ -7,7 +7,6 @@ class DigitalChannel {
   static const int everyFourthRisingEdge = 4;
   static const int everyRisingEdge = 3;
   static const int everyFallingEdge = 2;
-  static const int captureDelay = 2;
   static List<String> digitalChannelNames = [
     'LA1',
     'LA2',
@@ -59,7 +58,7 @@ class DigitalChannel {
       final int s = initialStates[channelName]!;
       initialState = s == 1;
     }
-    this.timestamps.setRange(0, timestamps.length - 1, timestamps);
+    this.timestamps.setRange(0, timestamps.length, timestamps);
     dLength = timestamps.length;
     double factor = 64;
     List<double> diff = [];
@@ -69,12 +68,12 @@ class DigitalChannel {
     for (int i = 0; i < diff.length; i++) {
       if (diff[i] < 0) {
         for (int j = i + 1; j < this.timestamps.length; j++) {
-          this.timestamps[j] += (1 << 16) - 1;
+          this.timestamps[j] += ((1 << 16) - 1);
         }
       }
     }
     for (int i = 0; i < this.timestamps.length; i++) {
-      this.timestamps[i] = (this.timestamps[i] + (i * captureDelay)) / factor;
+      this.timestamps[i] = (this.timestamps[i]) / factor;
     }
     if (dLength > 0) {
       maxT = this.timestamps[this.timestamps.length - 1];
@@ -98,8 +97,8 @@ class DigitalChannel {
     } else if (mode == everyEdge) {
       xAxis[0] = 0;
       yAxis[0] = state.toDouble();
-      int length = 0;
-      for (int i = 1, j = 1; i < dLength; i++, j++) {
+      int j = 1;
+      for (int i = 1; i < dLength; i++, j++) {
         xAxis[j] = timestamps[i];
         yAxis[j] = state.toDouble();
         if (state == high) {
@@ -110,14 +109,13 @@ class DigitalChannel {
         j++;
         xAxis[j] = timestamps[i];
         yAxis[j] = state.toDouble();
-        length = j;
       }
-      plotLength = length;
+      plotLength = j;
     } else if (mode == everyFallingEdge) {
       xAxis[0] = 0;
       yAxis[0] = high.toDouble();
-      int length = 0;
-      for (int i = 1, j = 1; i < dLength; i++, j++) {
+      int j = 1;
+      for (int i = 1; i < dLength; i++, j++) {
         xAxis[j] = timestamps[i];
         yAxis[j] = high.toDouble();
         j++;
@@ -126,16 +124,15 @@ class DigitalChannel {
         j++;
         xAxis[j] = timestamps[i];
         yAxis[j] = high.toDouble();
-        length = j;
       }
       state = high;
-      plotLength = length;
+      plotLength = j;
     } else if (mode == everyRisingEdge ||
         mode == everyFourthRisingEdge ||
         mode == everySixteenthRisingEdge) {
       xAxis[0] = 0;
       yAxis[0] = low.toDouble();
-      int length = 0;
+      int j = 1;
       for (int i = 1, j = 1; i < dLength; i++, j++) {
         xAxis[j] = timestamps[i];
         yAxis[j] = low.toDouble();
@@ -145,10 +142,9 @@ class DigitalChannel {
         j++;
         xAxis[j] = timestamps[i];
         yAxis[j] = low.toDouble();
-        length = j;
       }
       state = low;
-      plotLength = length;
+      plotLength = j;
     }
   }
 

--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -512,7 +512,7 @@ class ScienceLab {
   }
 
   Future<bool> fetchLAChannel(int channelNumber,
-      HashMap<String, int> initialStates, int channels) async {
+      LinkedHashMap<String, int> initialStates, int channels) async {
     DigitalChannel dChan = dChannels[channelNumber];
 
     LinkedHashMap<String, int> tempMap = LinkedHashMap<String, int>();
@@ -548,7 +548,7 @@ class ScienceLab {
   }
 
   Future<double> fetchLAChannelFrequency(
-      int channelNumber, HashMap<String, int> initialStates) async {
+      int channelNumber, LinkedHashMap<String, int> initialStates) async {
     double laChannelFrequency = 0;
     DigitalChannel dChan = dChannels[channelNumber];
 
@@ -578,7 +578,7 @@ class ScienceLab {
     if (count == maxSamples / 2 - 1) {
       laChannelFrequency = 0;
     } else if (yAxis.isNotEmpty &&
-        yAxis.length != maxSamples / 2 - 2 &&
+        yAxis.length != maxSamples / 2 - 1 &&
         laChannelFrequency != yAxis.length) {
       laChannelFrequency = yAxis.length.toDouble();
     }
@@ -587,7 +587,7 @@ class ScienceLab {
 
   Future<double> getFrequency(String? channel) async {
     channel ??= 'LA1';
-    HashMap<String, int>? data;
+    LinkedHashMap<String, int>? data;
     try {
       await startOneChannelLA(channel, 1, channel, 3);
       await Future.delayed(const Duration(milliseconds: 250));
@@ -627,7 +627,7 @@ class ScienceLab {
       dChannels[aqChannel].channelName = channel;
       if (trMode == 3 || trMode == 4 || trMode == 5) {
         dChannels[aqChannel].initialStateOverride = 2;
-      } else {
+      } else if (trMode == 2) {
         dChannels[aqChannel].initialStateOverride = 1;
       }
     } catch (e) {
@@ -735,7 +735,7 @@ class ScienceLab {
     }
   }
 
-  Future<HashMap<String, int>?> getLAInitialStates() async {
+  Future<LinkedHashMap<String, int>?> getLAInitialStates() async {
     try {
       mPacketHandler.sendByte(mCommandsProto.timing);
       mPacketHandler.sendByte(mCommandsProto.getInitialDigitalStates);
@@ -794,7 +794,7 @@ class ScienceLab {
         D = 0;
       }
 
-      HashMap<String, int> retData = HashMap<String, int>();
+      LinkedHashMap<String, int> retData = LinkedHashMap<String, int>();
       retData['A'] = A;
       retData['B'] = B;
       retData['C'] = C;

--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -701,14 +701,10 @@ class ScienceLab {
           modes[0] | (modes[1] << 4) | (modes[2] << 8) | (modes[3] << 12));
       mPacketHandler.sendByte(prescale);
       int triggerOptions = 0;
-      if (triggerChannel![0]) {
-        triggerOptions |= 4;
-      }
-      if (triggerChannel[1]) {
-        triggerOptions |= 8;
-      }
-      if (triggerChannel[2]) {
-        triggerOptions |= 16;
+      for (int i = 0; i < 3; i++) {
+        if (triggerChannel![i]) {
+          triggerOptions |= (4 << i);
+        }
       }
       if (triggerOptions == 0) {
         triggerOptions |= 4;

--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -439,6 +439,10 @@ class ScienceLab {
     }
   }
 
+  DigitalChannel getDigitalChannel(int i) {
+    return dChannels[i];
+  }
+
   int? calculateDigitalChannel(String name) {
     if (DigitalChannel.digitalChannelNames.contains(name)) {
       return DigitalChannel.digitalChannelNames.indexOf(name);
@@ -505,6 +509,42 @@ class ScienceLab {
       logger.e("Error in fetchIntDataFromLA: $e");
     }
     return null;
+  }
+
+  Future<bool> fetchLAChannel(int channelNumber,
+      HashMap<String, int> initialStates, int channels) async {
+    DigitalChannel dChan = dChannels[channelNumber];
+
+    LinkedHashMap<String, int> tempMap = LinkedHashMap<String, int>();
+    tempMap['LA1'] = initialStates['LA1']!;
+    tempMap['LA2'] = initialStates['LA2']!;
+    tempMap['LA3'] = initialStates['LA3']!;
+    tempMap['LA4'] = initialStates['LA4']!;
+    tempMap['RES'] = initialStates['RES']!;
+
+    int i = 0;
+    for (MapEntry<String, int> entry in initialStates.entries) {
+      if (dChan.channelNumber == i) {
+        i = entry.value;
+        break;
+      }
+      i++;
+    }
+    List<int>? temp =
+        await fetchIntDataFromLA(i, dChan.channelNumber + 1, channels);
+    List<double> data = List.filled(temp!.length - 1, 0.0);
+    if (temp[0] == 1) {
+      for (int j = 1; j < temp.length; j++) {
+        data[j - 1] = temp[j].toDouble();
+      }
+    } else {
+      logger.e("Error: Can't load data");
+      return false;
+    }
+    dChan.loadData(tempMap, data);
+
+    dChan.generateAxes();
+    return true;
   }
 
   Future<double> fetchLAChannelFrequency(
@@ -589,6 +629,106 @@ class ScienceLab {
         dChannels[aqChannel].initialStateOverride = 2;
       } else {
         dChannels[aqChannel].initialStateOverride = 1;
+      }
+    } catch (e) {
+      logger.e("Error starting logic analyzer: $e");
+    }
+  }
+
+  Future<void> startTwoChannelLA(
+      List<String>? channels,
+      List<int>? modes,
+      int? maximumTime,
+      int? trigger,
+      String? edge,
+      String? triggerChannel) async {
+    maximumTime ??= 67;
+    trigger ??= 0;
+    edge ??= 'rising';
+    channels ??= ['LA1', 'LA2'];
+    modes ??= [1, 1];
+    List<int> chans = [
+      calculateDigitalChannel(channels[0])!,
+      calculateDigitalChannel(channels[1])!
+    ];
+    triggerChannel ??= channels[0];
+    if (trigger != 0) {
+      trigger = 1;
+      if (edge == 'falling') {
+        trigger |= 2;
+      }
+      trigger |= (calculateDigitalChannel(triggerChannel)! << 4);
+    }
+
+    try {
+      await clearBuffer(0, maxSamples);
+      mPacketHandler.sendByte(mCommandsProto.timing);
+      mPacketHandler.sendByte(mCommandsProto.startTwoChanLa);
+      mPacketHandler.sendInt((maxSamples / 4).toInt());
+      mPacketHandler.sendByte(trigger);
+      mPacketHandler.sendByte(modes[0] | (modes[1] << 4));
+      mPacketHandler.sendByte(chans[0] | (chans[1] << 4));
+      await mPacketHandler.getAcknowledgement();
+      for (int i = 0; i < 2; i++) {
+        DigitalChannel temp = dChannels[chans[i]];
+        temp.prescaler = 0;
+        temp.length = (maxSamples / 4).toInt();
+        temp.dataType = "long";
+        temp.maxTime = (maximumTime * 1e6).toInt();
+        temp.mode = modes[i];
+        temp.channelNumber = chans[i];
+        temp.channelName = channels[i];
+      }
+      digitalChannelsInBuffer = 2;
+    } catch (e) {
+      logger.e("Error starting logic analyzer: $e");
+    }
+  }
+
+  Future<void> startFourChannelLA(int? trigger, double? maximumTime,
+      List<int>? modes, String? edge, List<bool>? triggerChannel) async {
+    trigger ??= 1;
+    maximumTime ??= 0.001;
+    modes ??= [1, 1, 1, 1];
+    edge ??= '0';
+    await clearBuffer(0, maxSamples);
+    int prescale = 0;
+    try {
+      mPacketHandler.sendByte(mCommandsProto.timing);
+      mPacketHandler.sendByte(mCommandsProto.startFourChanLa);
+      mPacketHandler.sendInt((maxSamples / 4).toInt());
+      mPacketHandler.sendInt(
+          modes[0] | (modes[1] << 4) | (modes[2] << 8) | (modes[3] << 12));
+      mPacketHandler.sendByte(prescale);
+      int triggerOptions = 0;
+      if (triggerChannel![0]) {
+        triggerOptions |= 4;
+      }
+      if (triggerChannel[1]) {
+        triggerOptions |= 8;
+      }
+      if (triggerChannel[2]) {
+        triggerOptions |= 16;
+      }
+      if (triggerOptions == 0) {
+        triggerOptions |= 4;
+      }
+      if (edge == 'rising') {
+        triggerOptions |= 2;
+      }
+      trigger |= triggerOptions;
+      mPacketHandler.sendByte(trigger);
+      await mPacketHandler.getAcknowledgement();
+      digitalChannelsInBuffer = 4;
+      int i = 0;
+      for (DigitalChannel dChan in dChannels) {
+        dChan.prescaler = prescale;
+        dChan.dataType = "int";
+        dChan.length = (maxSamples / 4).toInt();
+        dChan.maxTime = (maximumTime * 1e6).toInt();
+        dChan.mode = modes[i];
+        dChan.channelName = DigitalChannel.digitalChannelNames[i];
+        i++;
       }
     } catch (e) {
       logger.e("Error starting logic analyzer: $e");

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -123,7 +123,8 @@ String pslabUrl = 'https://pslab.io';
 
 String logicAnalyzer = 'Logic Analyzer';
 String channelSelection = 'Channel Selection';
-String logicAnalyzerAxisTitle = 'Time (ms)';
+String logicAnalyzerAxisTitle = 'Time (\u00B5s)';
+String noChartDataAvailable = 'No chart data available';
 String noOfChannelsOne = '1';
 String noOfChannelsTwo = '2';
 String noOfChannelsThree = '3';

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -132,6 +132,12 @@ String channelLA1 = 'LA1';
 String channelLA2 = 'LA2';
 String channelLA3 = 'LA3';
 String channelLA4 = 'LA4';
+List<String> channelNames = [
+  channelLA1,
+  channelLA2,
+  channelLA3,
+  channelLA4,
+];
 List<String> analysisOptions = [
   'EVERY EDGE',
   'EVERY FALLING EDGE',

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -121,6 +121,26 @@ String wifi = 'WIFI';
 String whatisPslab = 'What is PSLab Device?';
 String pslabUrl = 'https://pslab.io';
 
+String logicAnalyzer = 'Logic Analyzer';
+String channelSelection = 'Channel Selection';
+String logicAnalyzerAxisTitle = 'Time (ms)';
+String noOfChannelsOne = '1';
+String noOfChannelsTwo = '2';
+String noOfChannelsThree = '3';
+String noOfChannelsFour = '4';
+String channelLA1 = 'LA1';
+String channelLA2 = 'LA2';
+String channelLA3 = 'LA3';
+String channelLA4 = 'LA4';
+List<String> analysisOptions = [
+  'EVERY EDGE',
+  'EVERY FALLING EDGE',
+  'EVERY RISING EDGE',
+  'EVERY FOURTH RISING EDGE',
+  'DISABLED'
+];
+String analyze = 'ANALYZE';
+
 String settings = 'Settings';
 String start = 'Auto Start';
 String autoStartText = 'Auto start app when PSLab device is connected';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,6 +8,7 @@ import 'package:pslab/view/connect_device_screen.dart';
 import 'package:pslab/view/faq_screen.dart';
 import 'package:pslab/view/gyroscope_screen.dart';
 import 'package:pslab/view/instruments_screen.dart';
+import 'package:pslab/view/logic_analyzer_screen.dart';
 import 'package:pslab/view/luxmeter_screen.dart';
 import 'package:pslab/view/multimeter_screen.dart';
 import 'package:pslab/view/oscilloscope_screen.dart';
@@ -51,6 +52,7 @@ class MyApp extends StatelessWidget {
         '/': (context) => const InstrumentsScreen(),
         '/oscilloscope': (context) => const OscilloscopeScreen(),
         '/multimeter': (context) => const MultimeterScreen(),
+        '/logicAnalyzer': (context) => const LogicAnalyzerScreen(),
         '/connectDevice': (context) => const ConnectDeviceScreen(),
         '/faq': (context) => const FAQScreen(),
         '/settings': (context) => const SettingsScreen(),

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -131,33 +131,34 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
         break;
     }
 
-    switch (channelMode) {
-      case 1:
-        await captureOne(analysisChannelNames[0], analysisEdgesNames[0]);
-        maxY = singleChannelAxisMax;
-        minY = singleChannelAxisMin;
-        break;
-      case 2:
-        await captureTwo(analysisChannelNames, analysisEdgesNames);
-        maxY = twoChannelAxisMax;
-        minY = twoChannelAxisMin;
-        break;
-      case 3:
-        await captureThree(analysisChannelNames, analysisEdgesNames);
-        maxY = threeChannelAxisMax;
-        minY = threeChannelAxisMin;
-        break;
-      case 4:
-        await captureFour(analysisChannelNames, analysisEdgesNames);
-        maxY = fourChannelAxisMax;
-        minY = fourChannelAxisMin;
-        break;
-      default:
-        break;
+    if (_scienceLab.isConnected()) {
+      switch (channelMode) {
+        case 1:
+          await captureOne(analysisChannelNames[0], analysisEdgesNames[0]);
+          maxY = singleChannelAxisMax;
+          minY = singleChannelAxisMin;
+          break;
+        case 2:
+          await captureTwo(analysisChannelNames, analysisEdgesNames);
+          maxY = twoChannelAxisMax;
+          minY = twoChannelAxisMin;
+          break;
+        case 3:
+          await captureThree(analysisChannelNames, analysisEdgesNames);
+          maxY = threeChannelAxisMax;
+          minY = threeChannelAxisMin;
+          break;
+        case 4:
+          await captureFour(analysisChannelNames, analysisEdgesNames);
+          maxY = fourChannelAxisMax;
+          minY = fourChannelAxisMin;
+          break;
+        default:
+          break;
+      }
+      isData = true;
     }
-
     isProcessing = false;
-    isData = true;
     notifyListeners();
   }
 

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -1,0 +1,9 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class LogicAnalyzerStateProvider extends ChangeNotifier {
+  late List<List<FlSpot>> dataSets;
+  LogicAnalyzerStateProvider() {
+    dataSets = [];
+  }
+}

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -1,9 +1,716 @@
+import 'dart:collection';
+
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:pslab/communication/digitalChannel/digital_channel.dart';
+import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/others/logger_service.dart';
+import 'package:pslab/providers/locator.dart';
+import 'package:pslab/theme/colors.dart';
 
 class LogicAnalyzerStateProvider extends ChangeNotifier {
+  static const int everyEdge = 1;
+  static const int disabled = 0;
+  static const int everyFourthRisingEdge = 4;
+  static const int everyRisingEdge = 3;
+  static const int everyFallingEdge = 2;
+
+  late int channelMode;
+  late int currentChannel;
+  late List<String> channels;
+  late List<String> analysisChannelNames;
+  late List<String> analysisEdgesNames;
+  late Map<String, int> channelMap;
+  late List<FlSpot> tempInput;
+  late DigitalChannel digitalChannel;
+  late List<DigitalChannel> digitalChannels;
   late List<List<FlSpot>> dataSets;
+
+  late String channelSelectSpinner1;
+  late String channelSelectSpinner2;
+  late String channelSelectSpinner3;
+  late String channelSelectSpinner4;
+  late String edgeSelectSpinner1;
+  late String edgeSelectSpinner2;
+  late String edgeSelectSpinner3;
+  late String edgeSelectSpinner4;
+
+  late double maxY;
+  late double minY;
+
+  late ScienceLab _scienceLab;
+  late bool isProcessing;
+
   LogicAnalyzerStateProvider() {
+    channelMode = 1;
+    channels = channelNames;
+    channelMap = {};
+    channelMap[channelNames[0]] = 0;
+    channelMap[channelNames[1]] = 1;
+    channelMap[channelNames[2]] = 2;
+    channelMap[channelNames[3]] = 3;
+    analysisChannelNames = [];
+    analysisEdgesNames = [];
+    tempInput = [];
+    digitalChannels = [];
     dataSets = [];
+
+    channelSelectSpinner1 = channelNames[0];
+    channelSelectSpinner2 = channelNames[1];
+    channelSelectSpinner3 = channelNames[2];
+    channelSelectSpinner4 = channelNames[3];
+    edgeSelectSpinner1 = analysisOptions[0];
+    edgeSelectSpinner2 = analysisOptions[0];
+    edgeSelectSpinner3 = analysisOptions[0];
+    edgeSelectSpinner4 = analysisOptions[0];
+
+    maxY = 1.1;
+    minY = -0.1;
+
+    _scienceLab = getIt<ScienceLab>();
+    isProcessing = false;
+  }
+
+  Future<void> analyze() async {
+    isProcessing = true;
+    notifyListeners();
+
+    currentChannel = 0;
+    dataSets.clear();
+    analysisChannelNames.clear();
+    analysisEdgesNames.clear();
+    digitalChannels.clear();
+
+    switch (channelMode) {
+      case 1:
+        analysisChannelNames.add(channelSelectSpinner1);
+        analysisEdgesNames.add(edgeSelectSpinner1);
+        break;
+      case 2:
+        analysisChannelNames
+            .addAll([channelSelectSpinner1, channelSelectSpinner2]);
+        analysisEdgesNames.addAll([edgeSelectSpinner1, edgeSelectSpinner2]);
+        break;
+      case 3:
+        analysisChannelNames.addAll([
+          channelSelectSpinner1,
+          channelSelectSpinner2,
+          channelSelectSpinner3
+        ]);
+        analysisEdgesNames.addAll(
+            [edgeSelectSpinner1, edgeSelectSpinner2, edgeSelectSpinner3]);
+        break;
+      case 4:
+        analysisChannelNames.addAll([
+          channelSelectSpinner1,
+          channelSelectSpinner2,
+          channelSelectSpinner3,
+          channelSelectSpinner4
+        ]);
+        analysisEdgesNames.addAll([
+          edgeSelectSpinner1,
+          edgeSelectSpinner2,
+          edgeSelectSpinner3,
+          edgeSelectSpinner4
+        ]);
+        break;
+      default:
+        analysisChannelNames.add(channelSelectSpinner1);
+        analysisEdgesNames.add(edgeSelectSpinner1);
+        break;
+    }
+
+    switch (channelMode) {
+      case 1:
+        await captureOne(analysisChannelNames[0], analysisEdgesNames[0]);
+        maxY = 1.1;
+        minY = -0.1;
+        break;
+      case 2:
+        await captureTwo(analysisChannelNames, analysisEdgesNames);
+        maxY = 3.3;
+        minY = -0.3;
+        break;
+      case 3:
+        await captureThree(analysisChannelNames, analysisEdgesNames);
+        maxY = 5.5;
+        minY = -0.5;
+        break;
+      case 4:
+        await captureFour(analysisChannelNames, analysisEdgesNames);
+        maxY = 7.7;
+        minY = -0.7;
+        break;
+      default:
+        break;
+    }
+
+    isProcessing = false;
+    notifyListeners();
+  }
+
+  double getMaxY() {
+    return maxY;
+  }
+
+  double getMinY() {
+    return minY;
+  }
+
+  void setDataSet() {
+    dataSets.add(tempInput);
+  }
+
+  void singleChannelEveryEdge(List<double> xData, List<double> yData) {
+    tempInput = [];
+    List<int> temp = List.filled(xData.length, 0);
+    List<int> yAxis = List.filled(yData.length, 0);
+
+    for (int i = 0; i < xData.length; i++) {
+      temp[i] = xData[i].toInt();
+      yAxis[i] = yData[i].toInt();
+    }
+
+    List<int> xaxis = [];
+    List<int> yaxis = [];
+    xaxis.add(temp[0]);
+    yaxis.add(yAxis[0]);
+
+    for (int i = 1; i < xData.length; i++) {
+      if (temp[i] != temp[i - 1]) {
+        xaxis.add(temp[i]);
+        yaxis.add(yAxis[i]);
+      }
+    }
+
+    if (yaxis.length > 1) {
+      if (yaxis[1] == yaxis[0]) {
+        tempInput.add(FlSpot(
+            xaxis[0].toDouble(), (yaxis[0] + 2 * currentChannel).toDouble()));
+      } else {
+        tempInput.add(FlSpot(
+            xaxis[0].toDouble(), (yaxis[0] + 2 * currentChannel).toDouble()));
+        tempInput.add(FlSpot(
+            xaxis[0].toDouble(), (yaxis[1] + 2 * currentChannel).toDouble()));
+      }
+      for (int i = 1; i < xaxis.length - 1; i++) {
+        if (yaxis[i] == yaxis[i + 1]) {
+          tempInput.add(FlSpot(
+              xaxis[i].toDouble(), (yaxis[i] + 2 * currentChannel).toDouble()));
+        } else {
+          tempInput.add(FlSpot(
+              xaxis[i].toDouble(), (yaxis[i] + 2 * currentChannel).toDouble()));
+          tempInput.add(FlSpot(xaxis[i].toDouble(),
+              (yaxis[i + 1] + 2 * currentChannel).toDouble()));
+        }
+      }
+      tempInput.add(FlSpot(xaxis[xaxis.length - 1].toDouble(),
+          (yaxis[yaxis.length - 1] + 2 * currentChannel).toDouble()));
+    } else {
+      tempInput.add(FlSpot(
+          xaxis[0].toDouble(), (yaxis[0] + 2 * currentChannel).toDouble()));
+    }
+
+    setDataSet();
+  }
+
+  void singleChannelFourthRisingEdge(List<double> xData) {
+    tempInput = [];
+    int xaxis = xData[0].toInt();
+    tempInput
+        .add(FlSpot(xaxis.toDouble(), (0 + 2 * currentChannel).toDouble()));
+    tempInput
+        .add(FlSpot(xaxis.toDouble(), (1 + 2 * currentChannel).toDouble()));
+    tempInput
+        .add(FlSpot(xaxis.toDouble(), (0 + 2 * currentChannel).toDouble()));
+    int check = xaxis;
+    int count = 0;
+
+    if (xData.length > 1) {
+      for (int i = 1; i < xData.length; i++) {
+        xaxis = xData[i].toInt();
+        if (xaxis != check) {
+          if (count == 3) {
+            tempInput.add(
+                FlSpot(xaxis.toDouble(), (0 + 2 * currentChannel).toDouble()));
+            tempInput.add(
+                FlSpot(xaxis.toDouble(), (1 + 2 * currentChannel).toDouble()));
+            tempInput.add(
+                FlSpot(xaxis.toDouble(), (0 + 2 * currentChannel).toDouble()));
+            count = 0;
+          } else {
+            count++;
+          }
+          check = xaxis;
+        }
+      }
+    }
+
+    setDataSet();
+  }
+
+  void singleChannelRisingEdges(List<double> xData, List<double> yData) {
+    tempInput = [];
+
+    for (int i = 1; i < xData.length; i += 6) {
+      tempInput.add(FlSpot(
+          xData[i].toDouble(), (yData[i] + 2 * currentChannel).toDouble()));
+      tempInput.add(FlSpot(xData[i + 1].toDouble(),
+          (yData[i + 1] + 2 * currentChannel).toDouble()));
+      tempInput.add(FlSpot(xData[i + 2].toDouble(),
+          (yData[i + 2] + 2 * currentChannel).toDouble()));
+    }
+
+    setDataSet();
+  }
+
+  void singleChannelFallingEdges(List<double> xData, List<double> yData) {
+    tempInput = [];
+
+    for (int i = 4; i < xData.length; i += 6) {
+      tempInput.add(FlSpot(
+          xData[i].toDouble(), (yData[i] + 2 * currentChannel).toDouble()));
+      tempInput.add(FlSpot(xData[i + 1].toDouble(),
+          (yData[i + 1] + 2 * currentChannel).toDouble()));
+      tempInput.add(FlSpot(xData[i + 2].toDouble(),
+          (yData[i + 2] + 2 * currentChannel).toDouble()));
+    }
+
+    setDataSet();
+  }
+
+  void singleChannelOtherEdges(List<double> xData, List<double> yData) {
+    tempInput = [];
+
+    for (int i = 0; i < xData.length; i++) {
+      int xaxis = xData[i].toInt();
+      int yaxis = yData[i].toInt();
+      tempInput.add(
+          FlSpot(xaxis.toDouble(), (yaxis + 2 * currentChannel).toDouble()));
+    }
+
+    setDataSet();
+  }
+
+  Future<void> captureOne(String channelName, String edgeName) async {
+    String edgeOption = "";
+    bool holder;
+
+    try {
+      channels[0] = channelName;
+
+      int? channelNumber = _scienceLab.calculateDigitalChannel(channelName);
+      digitalChannel = _scienceLab.getDigitalChannel(channelNumber!);
+      edgeOption = edgeName;
+
+      switch (edgeOption) {
+        case "EVERY EDGE":
+          digitalChannel.mode = everyEdge;
+          break;
+        case "EVERY FALLING EDGE":
+          digitalChannel.mode = everyFallingEdge;
+          break;
+        case "EVERY RISING EDGE":
+          digitalChannel.mode = everyRisingEdge;
+          break;
+        case "EVERY FOURTH RISING EDGE":
+          digitalChannel.mode = everyFourthRisingEdge;
+          break;
+        case "DISABLED":
+          digitalChannel.mode = disabled;
+          break;
+        default:
+          digitalChannel.mode = everyEdge;
+          break;
+      }
+
+      _scienceLab.startOneChannelLA(
+          channelName, digitalChannel.mode, channelName, 3);
+      await Future.delayed(const Duration(seconds: 1));
+      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      await Future.delayed(const Duration(seconds: 1));
+      holder = await _scienceLab.fetchLAChannel(channelNumber, data!, 3);
+    } catch (e) {
+      logger.e("Error in captureOne: $e");
+      holder = false;
+    }
+
+    if (holder) {
+      List<double> xAxis = digitalChannel.getXAxis();
+      List<double> yAxis = digitalChannel.getYAxis();
+
+      String string1 = "";
+      String string2 = "";
+      for (int i = 0; i < xAxis.length; i++) {
+        string1 += "${xAxis[i].toStringAsFixed(2)},";
+        string2 += "${yAxis[i].toStringAsFixed(2)},";
+      }
+      logger.t("X-Axis: $string1");
+      logger.t("Y-Axis: $string2");
+
+      switch (edgeOption) {
+        case "EVERY EDGE":
+          singleChannelEveryEdge(xAxis, yAxis);
+          break;
+        case "EVERY FALLING EDGE":
+          singleChannelFourthRisingEdge(xAxis);
+          break;
+        case "EVERY RISING EDGE":
+          singleChannelRisingEdges(xAxis, yAxis);
+          break;
+        case "EVERY FOURTH RISING EDGE":
+          singleChannelFallingEdges(xAxis, yAxis);
+          break;
+        default:
+          singleChannelOtherEdges(xAxis, yAxis);
+          break;
+      }
+    }
+  }
+
+  Future<void> captureTwo(
+      List<String> channelNames, List<String> edgeNames) async {
+    List<String> edgeOption = List.filled(channelMode, "");
+    bool holder1, holder2;
+
+    try {
+      channels[0] = channelNames[0];
+      channels[1] = channelNames[1];
+
+      int channelNumber1 =
+          _scienceLab.calculateDigitalChannel(channelNames[0])!;
+      int channelNumber2 =
+          _scienceLab.calculateDigitalChannel(channelNames[1])!;
+
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber1));
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber2));
+      edgeOption[0] = edgeNames[0];
+      edgeOption[1] = edgeNames[1];
+
+      List<int> modes = [];
+      for (int i = 0; i < channelMode; i++) {
+        switch (edgeOption[i]) {
+          case "EVERY EDGE":
+            digitalChannels[i].mode = everyEdge;
+            modes.add(everyEdge);
+            break;
+          case "EVERY FALLING EDGE":
+            digitalChannels[i].mode = everyFallingEdge;
+            modes.add(everyFallingEdge);
+            break;
+          case "EVERY RISING EDGE":
+            digitalChannels[i].mode = everyRisingEdge;
+            modes.add(everyRisingEdge);
+            break;
+          case "EVERY FOURTH RISING EDGE":
+            digitalChannels[i].mode = everyFourthRisingEdge;
+            modes.add(everyFourthRisingEdge);
+            break;
+          case "DISABLED":
+            digitalChannels[i].mode = disabled;
+            modes.add(disabled);
+            break;
+          default:
+            digitalChannels[i].mode = everyEdge;
+            modes.add(everyEdge);
+            break;
+        }
+      }
+
+      await _scienceLab.startTwoChannelLA(
+          channelNames, modes, 67, null, null, null);
+      await Future.delayed(const Duration(seconds: 1));
+      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      await Future.delayed(const Duration(seconds: 1));
+      holder1 = await _scienceLab.fetchLAChannel(channelNumber1, data!, 2);
+      await Future.delayed(const Duration(seconds: 1));
+      holder2 = await _scienceLab.fetchLAChannel(channelNumber2, data, 2);
+    } catch (e) {
+      logger.e("Error in captureTwo: $e");
+      holder1 = false;
+      holder2 = false;
+    }
+
+    if (holder1 && holder2) {
+      List<List<double>> xaxis = [];
+      xaxis.add(digitalChannels[0].getXAxis());
+      xaxis.add(digitalChannels[1].getXAxis());
+
+      List<List<double>> yaxis = [];
+      yaxis.add(digitalChannels[0].getYAxis());
+      yaxis.add(digitalChannels[1].getYAxis());
+
+      for (int i = 0; i < channelMode; i++) {
+        switch (edgeOption[i]) {
+          case "EVERY EDGE":
+            singleChannelEveryEdge(xaxis[i], yaxis[i]);
+            break;
+          case "EVERY FALLING EDGE":
+            singleChannelFourthRisingEdge(xaxis[i]);
+            break;
+          case "EVERY RISING EDGE":
+            singleChannelRisingEdges(xaxis[i], yaxis[i]);
+            break;
+          case "EVERY FOURTH RISING EDGE":
+            singleChannelFallingEdges(xaxis[i], yaxis[i]);
+            break;
+          default:
+            singleChannelOtherEdges(xaxis[i], yaxis[i]);
+            break;
+        }
+        currentChannel++;
+      }
+    }
+  }
+
+  Future<void> captureThree(
+      List<String> channelNames, List<String> edgeNames) async {
+    List<String> edgeOption = List.filled(channelMode, "");
+    bool holder1, holder2, holder3;
+
+    try {
+      channels[0] = channelNames[0];
+      channels[1] = channelNames[1];
+      channels[2] = channelNames[2];
+
+      int channelNumber1 =
+          _scienceLab.calculateDigitalChannel(channelNames[0])!;
+      int channelNumber2 =
+          _scienceLab.calculateDigitalChannel(channelNames[1])!;
+      int channelNumber3 =
+          _scienceLab.calculateDigitalChannel(channelNames[2])!;
+
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber1));
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber2));
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber3));
+      edgeOption[0] = edgeNames[0];
+      edgeOption[1] = edgeNames[1];
+      edgeOption[2] = edgeNames[2];
+
+      List<int> modes = [];
+      for (int i = 0; i < channelMode; i++) {
+        switch (edgeOption[i]) {
+          case "EVERY EDGE":
+            digitalChannels[i].mode = everyEdge;
+            modes.add(everyEdge);
+            break;
+          case "EVERY FALLING EDGE":
+            digitalChannels[i].mode = everyFallingEdge;
+            modes.add(everyFallingEdge);
+            break;
+          case "EVERY RISING EDGE":
+            digitalChannels[i].mode = everyRisingEdge;
+            modes.add(everyRisingEdge);
+            break;
+          case "EVERY FOURTH RISING EDGE":
+            digitalChannels[i].mode = everyFourthRisingEdge;
+            modes.add(everyFourthRisingEdge);
+            break;
+          case "DISABLED":
+            digitalChannels[i].mode = disabled;
+            modes.add(disabled);
+            break;
+          default:
+            digitalChannels[i].mode = everyEdge;
+            modes.add(everyEdge);
+            break;
+        }
+      }
+      modes.add(everyEdge);
+      List<bool> triggerChannel = [];
+      triggerChannel.add(true);
+      triggerChannel.add(true);
+      triggerChannel.add(true);
+      await _scienceLab.startFourChannelLA(
+          null, null, modes, null, triggerChannel);
+      await Future.delayed(const Duration(seconds: 1));
+      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      await Future.delayed(const Duration(seconds: 1));
+      holder1 = await _scienceLab.fetchLAChannel(channelNumber1, data!, 3);
+      await Future.delayed(const Duration(seconds: 1));
+      holder2 = await _scienceLab.fetchLAChannel(channelNumber2, data, 3);
+      await Future.delayed(const Duration(seconds: 1));
+      holder3 = await _scienceLab.fetchLAChannel(channelNumber3, data, 3);
+    } catch (e) {
+      holder1 = false;
+      holder2 = false;
+      holder3 = false;
+      logger.e("Error in captureThree: $e");
+    }
+
+    if (holder1 && holder2 && holder3) {
+      List<List<double>> xaxis = [];
+      xaxis.add(digitalChannels[0].getXAxis());
+      xaxis.add(digitalChannels[1].getXAxis());
+      xaxis.add(digitalChannels[2].getXAxis());
+
+      List<List<double>> yaxis = [];
+      yaxis.add(digitalChannels[0].getYAxis());
+      yaxis.add(digitalChannels[1].getYAxis());
+      yaxis.add(digitalChannels[2].getYAxis());
+
+      for (int i = 0; i < channelMode; i++) {
+        switch (edgeOption[i]) {
+          case "EVERY EDGE":
+            singleChannelEveryEdge(xaxis[i], yaxis[i]);
+            break;
+          case "EVERY FALLING EDGE":
+            singleChannelFourthRisingEdge(xaxis[i]);
+            break;
+          case "EVERY RISING EDGE":
+            singleChannelRisingEdges(xaxis[i], yaxis[i]);
+            break;
+          case "EVERY FOURTH RISING EDGE":
+            singleChannelFallingEdges(xaxis[i], yaxis[i]);
+            break;
+          default:
+            singleChannelOtherEdges(xaxis[i], yaxis[i]);
+            break;
+        }
+        currentChannel++;
+      }
+    }
+  }
+
+  Future<void> captureFour(
+      List<String> channelNames, List<String> edgeNames) async {
+    List<String> edgeOption = List.filled(channelMode, "");
+    bool holder1, holder2, holder3, holder4;
+
+    try {
+      channels[0] = channelNames[0];
+      channels[1] = channelNames[1];
+      channels[2] = channelNames[2];
+      channels[3] = channelNames[3];
+
+      int channelNumber1 =
+          _scienceLab.calculateDigitalChannel(channelNames[0])!;
+      int channelNumber2 =
+          _scienceLab.calculateDigitalChannel(channelNames[1])!;
+      int channelNumber3 =
+          _scienceLab.calculateDigitalChannel(channelNames[2])!;
+      int channelNumber4 =
+          _scienceLab.calculateDigitalChannel(channelNames[3])!;
+
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber1));
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber2));
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber3));
+      digitalChannels.add(_scienceLab.getDigitalChannel(channelNumber4));
+      edgeOption[0] = edgeNames[0];
+      edgeOption[1] = edgeNames[1];
+      edgeOption[2] = edgeNames[2];
+      edgeOption[3] = edgeNames[3];
+
+      List<int> modes = [];
+      for (int i = 0; i < channelMode; i++) {
+        switch (edgeOption[i]) {
+          case "EVERY EDGE":
+            digitalChannels[i].mode = everyEdge;
+            modes.add(everyEdge);
+            break;
+          case "EVERY FALLING EDGE":
+            digitalChannels[i].mode = everyFallingEdge;
+            modes.add(everyFallingEdge);
+            break;
+          case "EVERY RISING EDGE":
+            digitalChannels[i].mode = everyRisingEdge;
+            modes.add(everyRisingEdge);
+            break;
+          case "EVERY FOURTH RISING EDGE":
+            digitalChannels[i].mode = everyFourthRisingEdge;
+            modes.add(everyFourthRisingEdge);
+            break;
+          case "DISABLED":
+            digitalChannels[i].mode = disabled;
+            modes.add(disabled);
+            break;
+          default:
+            digitalChannels[i].mode = everyEdge;
+            modes.add(everyEdge);
+            break;
+        }
+      }
+      List<bool> triggerChannel = [];
+      triggerChannel.add(true);
+      triggerChannel.add(true);
+      triggerChannel.add(true);
+
+      await _scienceLab.startFourChannelLA(
+          null, null, modes, null, triggerChannel);
+      await Future.delayed(const Duration(seconds: 1));
+      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      await Future.delayed(const Duration(seconds: 1));
+      holder1 = await _scienceLab.fetchLAChannel(channelNumber1, data!, 4);
+      await Future.delayed(const Duration(seconds: 1));
+      holder2 = await _scienceLab.fetchLAChannel(channelNumber2, data, 4);
+      await Future.delayed(const Duration(seconds: 1));
+      holder3 = await _scienceLab.fetchLAChannel(channelNumber3, data, 4);
+      await Future.delayed(const Duration(seconds: 1));
+      holder4 = await _scienceLab.fetchLAChannel(channelNumber4, data, 4);
+    } catch (e) {
+      holder1 = false;
+      holder2 = false;
+      holder3 = false;
+      holder4 = false;
+      logger.e("Error in captureFour: $e");
+    }
+
+    if (holder1 && holder2 && holder3 && holder4) {
+      List<List<double>> xaxis = [];
+      xaxis.add(digitalChannels[0].getXAxis());
+      xaxis.add(digitalChannels[1].getXAxis());
+      xaxis.add(digitalChannels[2].getXAxis());
+      xaxis.add(digitalChannels[3].getXAxis());
+
+      List<List<double>> yaxis = [];
+      yaxis.add(digitalChannels[0].getYAxis());
+      yaxis.add(digitalChannels[1].getYAxis());
+      yaxis.add(digitalChannels[2].getYAxis());
+      yaxis.add(digitalChannels[3].getYAxis());
+
+      for (int i = 0; i < channelMode; i++) {
+        switch (edgeOption[i]) {
+          case "EVERY EDGE":
+            singleChannelEveryEdge(xaxis[i], yaxis[i]);
+            break;
+          case "EVERY FALLING EDGE":
+            singleChannelFourthRisingEdge(xaxis[i]);
+            break;
+          case "EVERY RISING EDGE":
+            singleChannelRisingEdges(xaxis[i], yaxis[i]);
+            break;
+          case "EVERY FOURTH RISING EDGE":
+            singleChannelFallingEdges(xaxis[i], yaxis[i]);
+            break;
+          default:
+            singleChannelOtherEdges(xaxis[i], yaxis[i]);
+            break;
+        }
+        currentChannel++;
+      }
+    }
+  }
+
+  List<LineChartBarData> createPlots() {
+    List<LineChartBarData> plots = [];
+    plots.addAll(
+      List<LineChartBarData>.generate(
+        dataSets.length,
+        (index) {
+          return LineChartBarData(
+            spots: dataSets[index],
+            isCurved: true,
+            color: logicAnalyzerChannelColors[
+                index % logicAnalyzerChannelColors.length],
+            barWidth: 2,
+            dotData: const FlDotData(
+              show: false,
+            ),
+          );
+        },
+      ),
+    );
+    return plots;
   }
 }

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -10,6 +10,14 @@ import 'package:pslab/providers/locator.dart';
 import 'package:pslab/theme/colors.dart';
 
 class LogicAnalyzerStateProvider extends ChangeNotifier {
+  static const singleChannelAxisMin = -0.1;
+  static const singleChannelAxisMax = 1.1;
+  static const double twoChannelAxisMin = -0.3;
+  static const double twoChannelAxisMax = 3.3;
+  static const double threeChannelAxisMin = -0.5;
+  static const double threeChannelAxisMax = 5.5;
+  static const double fourChannelAxisMin = -0.7;
+  static const double fourChannelAxisMax = 7.7;
   static const int everyEdge = 1;
   static const int disabled = 0;
   static const int everyFourthRisingEdge = 4;
@@ -41,6 +49,7 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
 
   late ScienceLab _scienceLab;
   late bool isProcessing;
+  late bool isData;
 
   LogicAnalyzerStateProvider() {
     channelMode = 1;
@@ -65,11 +74,12 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     edgeSelectSpinner3 = analysisOptions[0];
     edgeSelectSpinner4 = analysisOptions[0];
 
-    maxY = 1.1;
-    minY = -0.1;
+    maxY = singleChannelAxisMax;
+    minY = singleChannelAxisMin;
 
     _scienceLab = getIt<ScienceLab>();
     isProcessing = false;
+    isData = false;
   }
 
   Future<void> analyze() async {
@@ -124,29 +134,30 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     switch (channelMode) {
       case 1:
         await captureOne(analysisChannelNames[0], analysisEdgesNames[0]);
-        maxY = 1.1;
-        minY = -0.1;
+        maxY = singleChannelAxisMax;
+        minY = singleChannelAxisMin;
         break;
       case 2:
         await captureTwo(analysisChannelNames, analysisEdgesNames);
-        maxY = 3.3;
-        minY = -0.3;
+        maxY = twoChannelAxisMax;
+        minY = twoChannelAxisMin;
         break;
       case 3:
         await captureThree(analysisChannelNames, analysisEdgesNames);
-        maxY = 5.5;
-        minY = -0.5;
+        maxY = threeChannelAxisMax;
+        minY = threeChannelAxisMin;
         break;
       case 4:
         await captureFour(analysisChannelNames, analysisEdgesNames);
-        maxY = 7.7;
-        minY = -0.7;
+        maxY = fourChannelAxisMax;
+        minY = fourChannelAxisMin;
         break;
       default:
         break;
     }
 
     isProcessing = false;
+    isData = true;
     notifyListeners();
   }
 
@@ -164,16 +175,16 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
 
   void singleChannelEveryEdge(List<double> xData, List<double> yData) {
     tempInput = [];
-    List<int> temp = List.filled(xData.length, 0);
-    List<int> yAxis = List.filled(yData.length, 0);
+    List<double> temp = List.filled(xData.length, 0);
+    List<double> yAxis = List.filled(yData.length, 0);
 
     for (int i = 0; i < xData.length; i++) {
-      temp[i] = xData[i].toInt();
-      yAxis[i] = yData[i].toInt();
+      temp[i] = xData[i];
+      yAxis[i] = yData[i];
     }
 
-    List<int> xaxis = [];
-    List<int> yaxis = [];
+    List<double> xaxis = [];
+    List<double> yaxis = [];
     xaxis.add(temp[0]);
     yaxis.add(yAxis[0]);
 
@@ -186,30 +197,23 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
 
     if (yaxis.length > 1) {
       if (yaxis[1] == yaxis[0]) {
-        tempInput.add(FlSpot(
-            xaxis[0].toDouble(), (yaxis[0] + 2 * currentChannel).toDouble()));
+        tempInput.add(FlSpot(xaxis[0], (yaxis[0] + 2 * currentChannel)));
       } else {
-        tempInput.add(FlSpot(
-            xaxis[0].toDouble(), (yaxis[0] + 2 * currentChannel).toDouble()));
-        tempInput.add(FlSpot(
-            xaxis[0].toDouble(), (yaxis[1] + 2 * currentChannel).toDouble()));
+        tempInput.add(FlSpot(xaxis[0], (yaxis[0] + 2 * currentChannel)));
+        tempInput.add(FlSpot(xaxis[0], (yaxis[1] + 2 * currentChannel)));
       }
       for (int i = 1; i < xaxis.length - 1; i++) {
         if (yaxis[i] == yaxis[i + 1]) {
-          tempInput.add(FlSpot(
-              xaxis[i].toDouble(), (yaxis[i] + 2 * currentChannel).toDouble()));
+          tempInput.add(FlSpot(xaxis[i], (yaxis[i] + 2 * currentChannel)));
         } else {
-          tempInput.add(FlSpot(
-              xaxis[i].toDouble(), (yaxis[i] + 2 * currentChannel).toDouble()));
-          tempInput.add(FlSpot(xaxis[i].toDouble(),
-              (yaxis[i + 1] + 2 * currentChannel).toDouble()));
+          tempInput.add(FlSpot(xaxis[i], (yaxis[i] + 2 * currentChannel)));
+          tempInput.add(FlSpot(xaxis[i], (yaxis[i + 1] + 2 * currentChannel)));
         }
       }
-      tempInput.add(FlSpot(xaxis[xaxis.length - 1].toDouble(),
-          (yaxis[yaxis.length - 1] + 2 * currentChannel).toDouble()));
+      tempInput.add(FlSpot(xaxis[xaxis.length - 1],
+          (yaxis[xaxis.length - 1] + 2 * currentChannel)));
     } else {
-      tempInput.add(FlSpot(
-          xaxis[0].toDouble(), (yaxis[0] + 2 * currentChannel).toDouble()));
+      tempInput.add(FlSpot(xaxis[0], (yaxis[0] + 2 * currentChannel)));
     }
 
     setDataSet();
@@ -217,19 +221,19 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
 
   void singleChannelFourthRisingEdge(List<double> xData) {
     tempInput = [];
-    int xaxis = xData[0].toInt();
+    double xaxis = xData[0];
     tempInput
         .add(FlSpot(xaxis.toDouble(), (0 + 2 * currentChannel).toDouble()));
     tempInput
         .add(FlSpot(xaxis.toDouble(), (1 + 2 * currentChannel).toDouble()));
     tempInput
         .add(FlSpot(xaxis.toDouble(), (0 + 2 * currentChannel).toDouble()));
-    int check = xaxis;
+    double check = xaxis;
     int count = 0;
 
     if (xData.length > 1) {
       for (int i = 1; i < xData.length; i++) {
-        xaxis = xData[i].toInt();
+        xaxis = xData[i];
         if (xaxis != check) {
           if (count == 3) {
             tempInput.add(
@@ -284,8 +288,8 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     tempInput = [];
 
     for (int i = 0; i < xData.length; i++) {
-      int xaxis = xData[i].toInt();
-      int yaxis = yData[i].toInt();
+      double xaxis = xData[i];
+      double yaxis = yData[i];
       tempInput.add(
           FlSpot(xaxis.toDouble(), (yaxis + 2 * currentChannel).toDouble()));
     }
@@ -325,12 +329,11 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
           break;
       }
 
-      _scienceLab.startOneChannelLA(
-          channelName, digitalChannel.mode, channelName, 3);
+      _scienceLab.startTwoChannelLA(null, null, 67, null, null, null);
       await Future.delayed(const Duration(seconds: 1));
-      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      LinkedHashMap<String, int>? data = await _scienceLab.getLAInitialStates();
       await Future.delayed(const Duration(seconds: 1));
-      holder = await _scienceLab.fetchLAChannel(channelNumber, data!, 3);
+      holder = await _scienceLab.fetchLAChannel(channelNumber, data!, 1);
     } catch (e) {
       logger.e("Error in captureOne: $e");
       holder = false;
@@ -421,7 +424,7 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
       await _scienceLab.startTwoChannelLA(
           channelNames, modes, 67, null, null, null);
       await Future.delayed(const Duration(seconds: 1));
-      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      LinkedHashMap<String, int>? data = await _scienceLab.getLAInitialStates();
       await Future.delayed(const Duration(seconds: 1));
       holder1 = await _scienceLab.fetchLAChannel(channelNumber1, data!, 2);
       await Future.delayed(const Duration(seconds: 1));
@@ -525,7 +528,7 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
       await _scienceLab.startFourChannelLA(
           null, null, modes, null, triggerChannel);
       await Future.delayed(const Duration(seconds: 1));
-      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      LinkedHashMap<String, int>? data = await _scienceLab.getLAInitialStates();
       await Future.delayed(const Duration(seconds: 1));
       holder1 = await _scienceLab.fetchLAChannel(channelNumber1, data!, 3);
       await Future.delayed(const Duration(seconds: 1));
@@ -639,7 +642,7 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
       await _scienceLab.startFourChannelLA(
           null, null, modes, null, triggerChannel);
       await Future.delayed(const Duration(seconds: 1));
-      HashMap<String, int>? data = await _scienceLab.getLAInitialStates();
+      LinkedHashMap<String, int>? data = await _scienceLab.getLAInitialStates();
       await Future.delayed(const Duration(seconds: 1));
       holder1 = await _scienceLab.fetchLAChannel(channelNumber1, data!, 4);
       await Future.delayed(const Duration(seconds: 1));
@@ -700,7 +703,6 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
         (index) {
           return LineChartBarData(
             spots: dataSets[index],
-            isCurved: true,
             color: logicAnalyzerChannelColors[
                 index % logicAnalyzerChannelColors.length],
             barWidth: 2,

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -329,7 +329,7 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
           break;
       }
 
-      _scienceLab.startTwoChannelLA(null, null, 67, null, null, null);
+      await _scienceLab.startTwoChannelLA(null, null, 67, null, null, null);
       await Future.delayed(const Duration(seconds: 1));
       LinkedHashMap<String, int>? data = await _scienceLab.getLAInitialStates();
       await Future.delayed(const Duration(seconds: 1));

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -73,3 +73,6 @@ List<Color> logicAnalyzerChannelColors = [
   Colors.cyan,
   Colors.yellow,
 ];
+Color logicAnalyzerChannelsTextColor = Colors.black;
+Color logicAnalyzerTextColor = Colors.white;
+Color logicAnalyzerGraphTextColor = Colors.amber;

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -67,3 +67,9 @@ Color multimeterBorderBlack = Colors.black;
 Color multimeterBorderLightRed = Color.fromARGB(255, 240, 162, 162);
 Color multimeterDividerColor = Colors.grey;
 Color multimeterIconColor = Colors.white;
+List<Color> logicAnalyzerChannelColors = [
+  Color(0xFFFF00FF),
+  Colors.green,
+  Colors.cyan,
+  Colors.yellow,
+];

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -40,6 +40,18 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
           );
         }
         break;
+      case 2:
+        if (Navigator.canPop(context) &&
+            ModalRoute.of(context)?.settings.name == '/logicAnalyzer') {
+          Navigator.popUntil(context, ModalRoute.withName('/logicAnalyzer'));
+        } else {
+          Navigator.pushNamedAndRemoveUntil(
+            context,
+            '/logicAnalyzer',
+            (route) => route.isFirst,
+          );
+        }
+        break;
       case 6:
         if (Navigator.canPop(context) &&
             ModalRoute.of(context)?.settings.name == '/luxmeter') {

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/providers/logic_analyzer_state_provider.dart';
+import 'package:pslab/theme/colors.dart';
+import 'package:pslab/view/widgets/common_scaffold_widget.dart';
+import 'package:pslab/view/widgets/logic_analyzer_channel_selection.dart';
+import 'package:pslab/view/widgets/logic_analyzer_graph.dart';
+
+class LogicAnalyzerScreen extends StatefulWidget {
+  const LogicAnalyzerScreen({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _LogicAnalyzerScreenState();
+}
+
+class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
+  @override
+  void initState() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _setLandscapeOrientation();
+      SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    });
+    super.initState();
+  }
+
+  void _setPortraitOrientation() {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+  }
+
+  void _setLandscapeOrientation() {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
+  }
+
+  @override
+  void dispose() {
+    _setPortraitOrientation();
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider(
+          create: (context) => LogicAnalyzerStateProvider(),
+        ),
+      ],
+      child: Consumer<LogicAnalyzerStateProvider>(
+        builder: (context, provider, _) {
+          return CommonScaffold(
+            title: logicAnalyzer,
+            body: SafeArea(
+              minimum: const EdgeInsets.only(right: 0, bottom: 0),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: chartBackgroundColor,
+                ),
+                padding: const EdgeInsets.only(bottom: 5, top: 5),
+                child: Row(
+                  children: [
+                    Expanded(
+                      flex: 73,
+                      child: LogicAnalyzerGraph(),
+                    ),
+                    Expanded(
+                      flex: 27,
+                      child: LogicAnalyzerChannelSelection(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -1,6 +1,8 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
+import 'package:pslab/providers/logic_analyzer_state_provider.dart';
 import 'package:pslab/theme/colors.dart';
 
 class LogicAnalyzerChannelSelection extends StatefulWidget {
@@ -14,359 +16,433 @@ class _LogicAnalyzerChannelSelectionState
     extends State<LogicAnalyzerChannelSelection> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.only(
-        left: 15,
-      ),
-      child: Column(
-        children: [
-          Text(
-            channelSelection,
-            style: TextStyle(
-              fontSize: 14,
-              color: chartTextColor,
-              fontWeight: FontWeight.bold,
-            ),
+    return Consumer<LogicAnalyzerStateProvider>(
+      builder: (context, provider, _) {
+        return Container(
+          margin: const EdgeInsets.only(
+            left: 15,
           ),
-          Container(
-            margin: EdgeInsets.only(top: 10),
-            width: double.infinity,
-            decoration: BoxDecoration(
-              color: Colors.white,
-              borderRadius: BorderRadius.circular(6),
-            ),
-            child: CarouselSlider(
-              items: [
-                Text(
-                  noOfChannelsOne,
-                  style: TextStyle(
-                    fontSize: 25,
-                    color: Colors.black,
-                  ),
+          child: Column(
+            children: [
+              Text(
+                channelSelection,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: chartTextColor,
+                  fontWeight: FontWeight.bold,
                 ),
-                Text(
-                  noOfChannelsTwo,
-                  style: TextStyle(
-                    fontSize: 25,
-                    color: Colors.black,
-                  ),
-                ),
-                Text(
-                  noOfChannelsThree,
-                  style: TextStyle(
-                    fontSize: 25,
-                    color: Colors.black,
-                  ),
-                ),
-                Text(
-                  noOfChannelsFour,
-                  style: TextStyle(
-                    fontSize: 25,
-                    color: Colors.black,
-                  ),
-                ),
-              ],
-              options: CarouselOptions(
-                height: 40,
-                enableInfiniteScroll: false,
-                initialPage: 0,
-                viewportFraction: 0.4,
-                enlargeCenterPage: true,
-                enlargeFactor: 0.4,
               ),
-            ),
-          ),
-          Expanded(
-            child: Container(
-              margin: const EdgeInsets.only(top: 10, right: 5),
-              child: ScrollConfiguration(
-                behavior: ScrollBehavior(),
-                child: ListView(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 10),
-                      decoration: BoxDecoration(
-                        color: primaryRed,
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: channelLA1,
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: [channelLA1].map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                          Divider(
-                            height: 1,
-                            color: Colors.white,
-                          ),
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: analysisOptions[0],
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: analysisOptions.map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                        ],
+              Container(
+                margin: EdgeInsets.only(top: 10),
+                width: double.infinity,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: CarouselSlider(
+                  items: [
+                    Text(
+                      noOfChannelsOne,
+                      style: TextStyle(
+                        fontSize: 25,
+                        color: Colors.black,
                       ),
                     ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 10),
-                      padding: const EdgeInsets.symmetric(horizontal: 10),
-                      decoration: BoxDecoration(
-                        color: primaryRed,
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: channelLA2,
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: [channelLA2].map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                          Divider(
-                            height: 1,
-                            color: Colors.white,
-                          ),
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: analysisOptions[0],
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: analysisOptions.map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                        ],
+                    Text(
+                      noOfChannelsTwo,
+                      style: TextStyle(
+                        fontSize: 25,
+                        color: Colors.black,
                       ),
                     ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 10),
-                      padding: const EdgeInsets.symmetric(horizontal: 10),
-                      decoration: BoxDecoration(
-                        color: primaryRed,
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: channelLA3,
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: [channelLA3].map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                          Divider(
-                            height: 1,
-                            color: Colors.white,
-                          ),
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: analysisOptions[0],
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: analysisOptions.map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                        ],
+                    Text(
+                      noOfChannelsThree,
+                      style: TextStyle(
+                        fontSize: 25,
+                        color: Colors.black,
                       ),
                     ),
-                    Container(
-                      margin: const EdgeInsets.only(top: 10),
-                      padding: const EdgeInsets.symmetric(horizontal: 10),
-                      decoration: BoxDecoration(
-                        color: primaryRed,
-                        borderRadius: BorderRadius.circular(6),
-                      ),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: channelLA4,
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: [channelLA4].map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                          Divider(
-                            height: 1,
-                            color: Colors.white,
-                          ),
-                          DropdownButton(
-                            dropdownColor: primaryRed,
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 10,
-                            ),
-                            value: analysisOptions[0],
-                            isExpanded: true,
-                            underline: Container(),
-                            iconEnabledColor: Colors.white,
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                            ),
-                            items: analysisOptions.map(
-                              (String value) {
-                                return DropdownMenuItem<String>(
-                                  value: value,
-                                  child: Text(value),
-                                );
-                              },
-                            ).toList(),
-                            onChanged: (value) => {},
-                          ),
-                        ],
+                    Text(
+                      noOfChannelsFour,
+                      style: TextStyle(
+                        fontSize: 25,
+                        color: Colors.black,
                       ),
                     ),
                   ],
+                  options: CarouselOptions(
+                    height: 40,
+                    enableInfiniteScroll: false,
+                    initialPage: 0,
+                    viewportFraction: 0.4,
+                    enlargeCenterPage: true,
+                    enlargeFactor: 0.4,
+                    onPageChanged: (index, reason) {
+                      setState(() {
+                        provider.channelMode = index + 1;
+                      });
+                    },
+                  ),
                 ),
               ),
-            ),
+              Expanded(
+                child: Container(
+                  margin: const EdgeInsets.only(top: 10, right: 5),
+                  child: ScrollConfiguration(
+                    behavior: ScrollBehavior(),
+                    child: ListView(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10),
+                          decoration: BoxDecoration(
+                            color: primaryRed,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              DropdownButton(
+                                dropdownColor: primaryRed,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                ),
+                                value: provider.channelSelectSpinner1,
+                                isExpanded: true,
+                                underline: Container(),
+                                iconEnabledColor: Colors.white,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                ),
+                                items: channelNames.map(
+                                  (String value) {
+                                    return DropdownMenuItem<String>(
+                                      value: value,
+                                      child: Text(value),
+                                    );
+                                  },
+                                ).toList(),
+                                onChanged: (value) => {
+                                  setState(
+                                    () {
+                                      provider.channelSelectSpinner1 = value!;
+                                    },
+                                  ),
+                                },
+                              ),
+                              Divider(
+                                height: 1,
+                                color: Colors.white,
+                              ),
+                              DropdownButton(
+                                dropdownColor: primaryRed,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 10,
+                                ),
+                                value: provider.edgeSelectSpinner1,
+                                isExpanded: true,
+                                underline: Container(),
+                                iconEnabledColor: Colors.white,
+                                style: TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 14,
+                                ),
+                                items: analysisOptions.map(
+                                  (String value) {
+                                    return DropdownMenuItem<String>(
+                                      value: value,
+                                      child: Text(value),
+                                    );
+                                  },
+                                ).toList(),
+                                onChanged: (value) => {
+                                  setState(
+                                    () {
+                                      provider.edgeSelectSpinner1 = value!;
+                                    },
+                                  ),
+                                },
+                              ),
+                            ],
+                          ),
+                        ),
+                        provider.channelMode > 1
+                            ? Container(
+                                margin: const EdgeInsets.only(top: 10),
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 10),
+                                decoration: BoxDecoration(
+                                  color: primaryRed,
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    DropdownButton(
+                                      dropdownColor: primaryRed,
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                      value: provider.channelSelectSpinner2,
+                                      isExpanded: true,
+                                      underline: Container(),
+                                      iconEnabledColor: Colors.white,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                      ),
+                                      items: channelNames.map(
+                                        (String value) {
+                                          return DropdownMenuItem<String>(
+                                            value: value,
+                                            child: Text(value),
+                                          );
+                                        },
+                                      ).toList(),
+                                      onChanged: (value) => {
+                                        setState(
+                                          () {
+                                            provider.channelSelectSpinner2 =
+                                                value!;
+                                          },
+                                        ),
+                                      },
+                                    ),
+                                    Divider(
+                                      height: 1,
+                                      color: Colors.white,
+                                    ),
+                                    DropdownButton(
+                                      dropdownColor: primaryRed,
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                      value: provider.edgeSelectSpinner2,
+                                      isExpanded: true,
+                                      underline: Container(),
+                                      iconEnabledColor: Colors.white,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                      ),
+                                      items: analysisOptions.map(
+                                        (String value) {
+                                          return DropdownMenuItem<String>(
+                                            value: value,
+                                            child: Text(value),
+                                          );
+                                        },
+                                      ).toList(),
+                                      onChanged: (value) => {
+                                        setState(
+                                          () {
+                                            provider.edgeSelectSpinner2 =
+                                                value!;
+                                          },
+                                        ),
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              )
+                            : Container(),
+                        provider.channelMode > 2
+                            ? Container(
+                                margin: const EdgeInsets.only(top: 10),
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 10),
+                                decoration: BoxDecoration(
+                                  color: primaryRed,
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    DropdownButton(
+                                      dropdownColor: primaryRed,
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                      value: provider.channelSelectSpinner3,
+                                      isExpanded: true,
+                                      underline: Container(),
+                                      iconEnabledColor: Colors.white,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                      ),
+                                      items: channelNames.map(
+                                        (String value) {
+                                          return DropdownMenuItem<String>(
+                                            value: value,
+                                            child: Text(value),
+                                          );
+                                        },
+                                      ).toList(),
+                                      onChanged: (value) => {
+                                        setState(
+                                          () {
+                                            provider.channelSelectSpinner3 =
+                                                value!;
+                                          },
+                                        ),
+                                      },
+                                    ),
+                                    Divider(
+                                      height: 1,
+                                      color: Colors.white,
+                                    ),
+                                    DropdownButton(
+                                      dropdownColor: primaryRed,
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                      value: provider.edgeSelectSpinner3,
+                                      isExpanded: true,
+                                      underline: Container(),
+                                      iconEnabledColor: Colors.white,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                      ),
+                                      items: analysisOptions.map(
+                                        (String value) {
+                                          return DropdownMenuItem<String>(
+                                            value: value,
+                                            child: Text(value),
+                                          );
+                                        },
+                                      ).toList(),
+                                      onChanged: (value) => {
+                                        setState(
+                                          () {
+                                            provider.edgeSelectSpinner3 =
+                                                value!;
+                                          },
+                                        ),
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              )
+                            : Container(),
+                        provider.channelMode > 3
+                            ? Container(
+                                margin: const EdgeInsets.only(top: 10),
+                                padding:
+                                    const EdgeInsets.symmetric(horizontal: 10),
+                                decoration: BoxDecoration(
+                                  color: primaryRed,
+                                  borderRadius: BorderRadius.circular(6),
+                                ),
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: [
+                                    DropdownButton(
+                                      dropdownColor: primaryRed,
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                      value: provider.channelSelectSpinner4,
+                                      isExpanded: true,
+                                      underline: Container(),
+                                      iconEnabledColor: Colors.white,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                      ),
+                                      items: channelNames.map(
+                                        (String value) {
+                                          return DropdownMenuItem<String>(
+                                            value: value,
+                                            child: Text(value),
+                                          );
+                                        },
+                                      ).toList(),
+                                      onChanged: (value) => {
+                                        setState(
+                                          () {
+                                            provider.channelSelectSpinner4 =
+                                                value!;
+                                          },
+                                        ),
+                                      },
+                                    ),
+                                    Divider(
+                                      height: 1,
+                                      color: Colors.white,
+                                    ),
+                                    DropdownButton(
+                                      dropdownColor: primaryRed,
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 10,
+                                      ),
+                                      value: provider.edgeSelectSpinner4,
+                                      isExpanded: true,
+                                      underline: Container(),
+                                      iconEnabledColor: Colors.white,
+                                      style: TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 14,
+                                      ),
+                                      items: analysisOptions.map(
+                                        (String value) {
+                                          return DropdownMenuItem<String>(
+                                            value: value,
+                                            child: Text(value),
+                                          );
+                                        },
+                                      ).toList(),
+                                      onChanged: (value) => {
+                                        setState(
+                                          () {
+                                            provider.edgeSelectSpinner4 =
+                                                value!;
+                                          },
+                                        ),
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              )
+                            : Container(),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              TextButton(
+                style: TextButton.styleFrom(
+                  fixedSize: const Size(200, 40),
+                  backgroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 10,
+                    vertical: 5,
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                ),
+                child: Text(
+                  analyze,
+                  style: TextStyle(
+                    color: primaryRed,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                ),
+                onPressed: () => {
+                  provider.analyze(),
+                },
+              )
+            ],
           ),
-          TextButton(
-            style: TextButton.styleFrom(
-              fixedSize: const Size(200, 40),
-              backgroundColor: Colors.white,
-              padding: const EdgeInsets.symmetric(
-                horizontal: 10,
-                vertical: 5,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(6),
-              ),
-            ),
-            child: Text(
-              analyze,
-              style: TextStyle(
-                color: primaryRed,
-                fontWeight: FontWeight.bold,
-                fontSize: 14,
-              ),
-            ),
-            onPressed: () => {},
-          )
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -36,7 +36,7 @@ class _LogicAnalyzerChannelSelectionState
                 margin: EdgeInsets.only(top: 10),
                 width: double.infinity,
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: logicAnalyzerTextColor,
                   borderRadius: BorderRadius.circular(6),
                 ),
                 child: CarouselSlider(
@@ -45,28 +45,28 @@ class _LogicAnalyzerChannelSelectionState
                       noOfChannelsOne,
                       style: TextStyle(
                         fontSize: 25,
-                        color: Colors.black,
+                        color: logicAnalyzerChannelsTextColor,
                       ),
                     ),
                     Text(
                       noOfChannelsTwo,
                       style: TextStyle(
                         fontSize: 25,
-                        color: Colors.black,
+                        color: logicAnalyzerChannelsTextColor,
                       ),
                     ),
                     Text(
                       noOfChannelsThree,
                       style: TextStyle(
                         fontSize: 25,
-                        color: Colors.black,
+                        color: logicAnalyzerChannelsTextColor,
                       ),
                     ),
                     Text(
                       noOfChannelsFour,
                       style: TextStyle(
                         fontSize: 25,
-                        color: Colors.black,
+                        color: logicAnalyzerChannelsTextColor,
                       ),
                     ),
                   ],
@@ -110,9 +110,9 @@ class _LogicAnalyzerChannelSelectionState
                                 value: provider.channelSelectSpinner1,
                                 isExpanded: true,
                                 underline: Container(),
-                                iconEnabledColor: Colors.white,
+                                iconEnabledColor: logicAnalyzerTextColor,
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: logicAnalyzerTextColor,
                                   fontSize: 14,
                                 ),
                                 items: channelNames.map(
@@ -133,7 +133,7 @@ class _LogicAnalyzerChannelSelectionState
                               ),
                               Divider(
                                 height: 1,
-                                color: Colors.white,
+                                color: logicAnalyzerTextColor,
                               ),
                               DropdownButton(
                                 dropdownColor: primaryRed,
@@ -143,9 +143,9 @@ class _LogicAnalyzerChannelSelectionState
                                 value: provider.edgeSelectSpinner1,
                                 isExpanded: true,
                                 underline: Container(),
-                                iconEnabledColor: Colors.white,
+                                iconEnabledColor: logicAnalyzerTextColor,
                                 style: TextStyle(
-                                  color: Colors.white,
+                                  color: logicAnalyzerTextColor,
                                   fontSize: 14,
                                 ),
                                 items: analysisOptions.map(
@@ -188,9 +188,9 @@ class _LogicAnalyzerChannelSelectionState
                                       value: provider.channelSelectSpinner2,
                                       isExpanded: true,
                                       underline: Container(),
-                                      iconEnabledColor: Colors.white,
+                                      iconEnabledColor: logicAnalyzerTextColor,
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: logicAnalyzerTextColor,
                                         fontSize: 14,
                                       ),
                                       items: channelNames.map(
@@ -212,7 +212,7 @@ class _LogicAnalyzerChannelSelectionState
                                     ),
                                     Divider(
                                       height: 1,
-                                      color: Colors.white,
+                                      color: logicAnalyzerTextColor,
                                     ),
                                     DropdownButton(
                                       dropdownColor: primaryRed,
@@ -222,9 +222,9 @@ class _LogicAnalyzerChannelSelectionState
                                       value: provider.edgeSelectSpinner2,
                                       isExpanded: true,
                                       underline: Container(),
-                                      iconEnabledColor: Colors.white,
+                                      iconEnabledColor: logicAnalyzerTextColor,
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: logicAnalyzerTextColor,
                                         fontSize: 14,
                                       ),
                                       items: analysisOptions.map(
@@ -269,9 +269,9 @@ class _LogicAnalyzerChannelSelectionState
                                       value: provider.channelSelectSpinner3,
                                       isExpanded: true,
                                       underline: Container(),
-                                      iconEnabledColor: Colors.white,
+                                      iconEnabledColor: logicAnalyzerTextColor,
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: logicAnalyzerTextColor,
                                         fontSize: 14,
                                       ),
                                       items: channelNames.map(
@@ -293,7 +293,7 @@ class _LogicAnalyzerChannelSelectionState
                                     ),
                                     Divider(
                                       height: 1,
-                                      color: Colors.white,
+                                      color: logicAnalyzerTextColor,
                                     ),
                                     DropdownButton(
                                       dropdownColor: primaryRed,
@@ -303,9 +303,9 @@ class _LogicAnalyzerChannelSelectionState
                                       value: provider.edgeSelectSpinner3,
                                       isExpanded: true,
                                       underline: Container(),
-                                      iconEnabledColor: Colors.white,
+                                      iconEnabledColor: logicAnalyzerTextColor,
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: logicAnalyzerTextColor,
                                         fontSize: 14,
                                       ),
                                       items: analysisOptions.map(
@@ -350,9 +350,9 @@ class _LogicAnalyzerChannelSelectionState
                                       value: provider.channelSelectSpinner4,
                                       isExpanded: true,
                                       underline: Container(),
-                                      iconEnabledColor: Colors.white,
+                                      iconEnabledColor: logicAnalyzerTextColor,
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: logicAnalyzerTextColor,
                                         fontSize: 14,
                                       ),
                                       items: channelNames.map(
@@ -374,7 +374,7 @@ class _LogicAnalyzerChannelSelectionState
                                     ),
                                     Divider(
                                       height: 1,
-                                      color: Colors.white,
+                                      color: logicAnalyzerTextColor,
                                     ),
                                     DropdownButton(
                                       dropdownColor: primaryRed,
@@ -384,9 +384,9 @@ class _LogicAnalyzerChannelSelectionState
                                       value: provider.edgeSelectSpinner4,
                                       isExpanded: true,
                                       underline: Container(),
-                                      iconEnabledColor: Colors.white,
+                                      iconEnabledColor: logicAnalyzerTextColor,
                                       style: TextStyle(
-                                        color: Colors.white,
+                                        color: logicAnalyzerTextColor,
                                         fontSize: 14,
                                       ),
                                       items: analysisOptions.map(
@@ -418,7 +418,7 @@ class _LogicAnalyzerChannelSelectionState
               TextButton(
                 style: TextButton.styleFrom(
                   fixedSize: const Size(200, 40),
-                  backgroundColor: Colors.white,
+                  backgroundColor: logicAnalyzerTextColor,
                   padding: const EdgeInsets.symmetric(
                     horizontal: 10,
                     vertical: 5,

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -1,0 +1,372 @@
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/theme/colors.dart';
+
+class LogicAnalyzerChannelSelection extends StatefulWidget {
+  const LogicAnalyzerChannelSelection({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _LogicAnalyzerChannelSelectionState();
+}
+
+class _LogicAnalyzerChannelSelectionState
+    extends State<LogicAnalyzerChannelSelection> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(
+        left: 15,
+      ),
+      child: Column(
+        children: [
+          Text(
+            channelSelection,
+            style: TextStyle(
+              fontSize: 14,
+              color: chartTextColor,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Container(
+            margin: EdgeInsets.only(top: 10),
+            width: double.infinity,
+            decoration: BoxDecoration(
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: CarouselSlider(
+              items: [
+                Text(
+                  noOfChannelsOne,
+                  style: TextStyle(
+                    fontSize: 25,
+                    color: Colors.black,
+                  ),
+                ),
+                Text(
+                  noOfChannelsTwo,
+                  style: TextStyle(
+                    fontSize: 25,
+                    color: Colors.black,
+                  ),
+                ),
+                Text(
+                  noOfChannelsThree,
+                  style: TextStyle(
+                    fontSize: 25,
+                    color: Colors.black,
+                  ),
+                ),
+                Text(
+                  noOfChannelsFour,
+                  style: TextStyle(
+                    fontSize: 25,
+                    color: Colors.black,
+                  ),
+                ),
+              ],
+              options: CarouselOptions(
+                height: 40,
+                enableInfiniteScroll: false,
+                initialPage: 0,
+                viewportFraction: 0.4,
+                enlargeCenterPage: true,
+                enlargeFactor: 0.4,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Container(
+              margin: const EdgeInsets.only(top: 10, right: 5),
+              child: ScrollConfiguration(
+                behavior: ScrollBehavior(),
+                child: ListView(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      decoration: BoxDecoration(
+                        color: primaryRed,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: channelLA1,
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: [channelLA1].map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                          Divider(
+                            height: 1,
+                            color: Colors.white,
+                          ),
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: analysisOptions[0],
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: analysisOptions.map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                        ],
+                      ),
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(top: 10),
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      decoration: BoxDecoration(
+                        color: primaryRed,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: channelLA2,
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: [channelLA2].map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                          Divider(
+                            height: 1,
+                            color: Colors.white,
+                          ),
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: analysisOptions[0],
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: analysisOptions.map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                        ],
+                      ),
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(top: 10),
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      decoration: BoxDecoration(
+                        color: primaryRed,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: channelLA3,
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: [channelLA3].map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                          Divider(
+                            height: 1,
+                            color: Colors.white,
+                          ),
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: analysisOptions[0],
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: analysisOptions.map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                        ],
+                      ),
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(top: 10),
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
+                      decoration: BoxDecoration(
+                        color: primaryRed,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: channelLA4,
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: [channelLA4].map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                          Divider(
+                            height: 1,
+                            color: Colors.white,
+                          ),
+                          DropdownButton(
+                            dropdownColor: primaryRed,
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                            ),
+                            value: analysisOptions[0],
+                            isExpanded: true,
+                            underline: Container(),
+                            iconEnabledColor: Colors.white,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                            items: analysisOptions.map(
+                              (String value) {
+                                return DropdownMenuItem<String>(
+                                  value: value,
+                                  child: Text(value),
+                                );
+                              },
+                            ).toList(),
+                            onChanged: (value) => {},
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          TextButton(
+            style: TextButton.styleFrom(
+              fixedSize: const Size(200, 40),
+              backgroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(
+                horizontal: 10,
+                vertical: 5,
+              ),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(6),
+              ),
+            ),
+            child: Text(
+              analyze,
+              style: TextStyle(
+                color: primaryRed,
+                fontWeight: FontWeight.bold,
+                fontSize: 14,
+              ),
+            ),
+            onPressed: () => {},
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/widgets/logic_analyzer_graph.dart
+++ b/lib/view/widgets/logic_analyzer_graph.dart
@@ -1,0 +1,121 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/providers/logic_analyzer_state_provider.dart';
+import 'package:pslab/theme/colors.dart';
+
+class LogicAnalyzerGraph extends StatefulWidget {
+  const LogicAnalyzerGraph({super.key});
+
+  @override
+  State<StatefulWidget> createState() => _LogicAnalyzerGraphState();
+}
+
+class _LogicAnalyzerGraphState extends State<LogicAnalyzerGraph> {
+  Widget sideTitleWidgets(double value, TitleMeta meta) {
+    final style = TextStyle(
+      color: chartTextColor,
+      fontSize: 9,
+    );
+    return SideTitleWidget(
+      meta: meta,
+      child: Text(
+        maxLines: 1,
+        meta.formattedValue,
+        style: style,
+      ),
+    );
+  }
+
+  Widget topTitleWidgets(double value, TitleMeta meta) {
+    final style = TextStyle(
+      color: chartTextColor,
+      fontSize: 9,
+    );
+    return SideTitleWidget(
+      meta: meta,
+      child: Text(
+        maxLines: 1,
+        meta.formattedValue,
+        style: style,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<LogicAnalyzerStateProvider>(
+        builder: (context, provider, _) {
+      return SizedBox(
+        child: LineChart(
+          LineChartData(
+            backgroundColor: chartBackgroundColor,
+            titlesData: FlTitlesData(
+              show: true,
+              topTitles: AxisTitles(
+                axisNameWidget: Text(
+                  logicAnalyzerAxisTitle,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: chartTextColor,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                axisNameSize: 20,
+                sideTitles: SideTitles(
+                  maxIncluded: false,
+                  interval: 1,
+                  reservedSize: 20,
+                  showTitles: true,
+                  getTitlesWidget: topTitleWidgets,
+                ),
+              ),
+              bottomTitles:
+                  const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+              leftTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  interval: 1,
+                  reservedSize: 30,
+                  showTitles: true,
+                  getTitlesWidget: sideTitleWidgets,
+                ),
+              ),
+              rightTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: false,
+                ),
+              ),
+            ),
+            gridData: FlGridData(
+              show: true,
+              drawHorizontalLine: true,
+              drawVerticalLine: true,
+            ),
+            borderData: FlBorderData(
+              show: true,
+              border: Border(
+                bottom: BorderSide(
+                  color: chartBorderColor,
+                ),
+                left: BorderSide(
+                  color: chartBorderColor,
+                ),
+                top: BorderSide(
+                  color: chartBorderColor,
+                ),
+                right: BorderSide(
+                  color: chartBorderColor,
+                ),
+              ),
+            ),
+            maxY: 2,
+            maxX: 10,
+            minY: -1,
+            minX: 0,
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/view/widgets/logic_analyzer_graph.dart
+++ b/lib/view/widgets/logic_analyzer_graph.dart
@@ -47,84 +47,102 @@ class _LogicAnalyzerGraphState extends State<LogicAnalyzerGraph> {
   Widget build(BuildContext context) {
     return Consumer<LogicAnalyzerStateProvider>(
         builder: (context, provider, _) {
-      return SizedBox(
-        child: LineChart(
-          transformationConfig: FlTransformationConfig(
-            minScale: 1,
-            maxScale: 25,
-            scaleAxis: FlScaleAxis.horizontal,
-            panEnabled: true,
-            scaleEnabled: true,
-          ),
-          LineChartData(
-            backgroundColor: chartBackgroundColor,
-            titlesData: FlTitlesData(
-              show: true,
-              topTitles: AxisTitles(
-                axisNameWidget: Text(
-                  logicAnalyzerAxisTitle,
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: chartTextColor,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                axisNameSize: 20,
-                sideTitles: SideTitles(
-                  maxIncluded: false,
-                  interval: 1,
-                  reservedSize: 20,
-                  showTitles: true,
-                  getTitlesWidget: topTitleWidgets,
+      return !provider.isProcessing
+          ? SizedBox(
+              child: provider.isData
+                  ? LineChart(
+                      transformationConfig: FlTransformationConfig(
+                        minScale: 1,
+                        maxScale: 1000,
+                        scaleAxis: FlScaleAxis.horizontal,
+                        panEnabled: true,
+                        scaleEnabled: true,
+                      ),
+                      LineChartData(
+                        backgroundColor: chartBackgroundColor,
+                        titlesData: FlTitlesData(
+                          show: true,
+                          topTitles: AxisTitles(
+                            axisNameWidget: Text(
+                              logicAnalyzerAxisTitle,
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: chartTextColor,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            axisNameSize: 20,
+                            sideTitles: SideTitles(
+                              maxIncluded: false,
+                              reservedSize: 20,
+                              showTitles: true,
+                              getTitlesWidget: topTitleWidgets,
+                            ),
+                          ),
+                          bottomTitles: const AxisTitles(
+                              sideTitles: SideTitles(showTitles: false)),
+                          leftTitles: AxisTitles(
+                            sideTitles: SideTitles(
+                              maxIncluded: false,
+                              minIncluded: false,
+                              interval: 1,
+                              reservedSize: 30,
+                              showTitles: true,
+                              getTitlesWidget: sideTitleWidgets,
+                            ),
+                          ),
+                          rightTitles: AxisTitles(
+                            sideTitles: SideTitles(
+                              showTitles: false,
+                            ),
+                          ),
+                        ),
+                        gridData: FlGridData(
+                          show: true,
+                          drawHorizontalLine: true,
+                          drawVerticalLine: true,
+                        ),
+                        borderData: FlBorderData(
+                          show: true,
+                          border: Border(
+                            bottom: BorderSide(
+                              color: chartBorderColor,
+                            ),
+                            left: BorderSide(
+                              color: chartBorderColor,
+                            ),
+                            top: BorderSide(
+                              color: chartBorderColor,
+                            ),
+                            right: BorderSide(
+                              color: chartBorderColor,
+                            ),
+                          ),
+                        ),
+                        clipData: const FlClipData.all(),
+                        lineBarsData: provider.createPlots(),
+                        maxY: provider.getMaxY(),
+                        minY: provider.getMinY(),
+                      ),
+                    )
+                  : Center(
+                      child: Text(
+                        noChartDataAvailable,
+                        style: TextStyle(
+                          color: logicAnalyzerGraphTextColor,
+                          fontSize: 11,
+                        ),
+                      ),
+                    ),
+            )
+          : SizedBox(
+              height: 200,
+              child: Center(
+                child: CircularProgressIndicator(
+                  color: primaryRed,
                 ),
               ),
-              bottomTitles:
-                  const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-              leftTitles: AxisTitles(
-                sideTitles: SideTitles(
-                  maxIncluded: false,
-                  minIncluded: false,
-                  interval: 1,
-                  reservedSize: 30,
-                  showTitles: true,
-                  getTitlesWidget: sideTitleWidgets,
-                ),
-              ),
-              rightTitles: AxisTitles(
-                sideTitles: SideTitles(
-                  showTitles: false,
-                ),
-              ),
-            ),
-            gridData: FlGridData(
-              show: true,
-              drawHorizontalLine: true,
-              drawVerticalLine: true,
-            ),
-            borderData: FlBorderData(
-              show: true,
-              border: Border(
-                bottom: BorderSide(
-                  color: chartBorderColor,
-                ),
-                left: BorderSide(
-                  color: chartBorderColor,
-                ),
-                top: BorderSide(
-                  color: chartBorderColor,
-                ),
-                right: BorderSide(
-                  color: chartBorderColor,
-                ),
-              ),
-            ),
-            clipData: const FlClipData.all(),
-            lineBarsData: provider.createPlots(),
-            maxY: provider.getMaxY(),
-            minY: provider.getMinY(),
-          ),
-        ),
-      );
+            );
     });
   }
 }

--- a/lib/view/widgets/logic_analyzer_graph.dart
+++ b/lib/view/widgets/logic_analyzer_graph.dart
@@ -49,6 +49,13 @@ class _LogicAnalyzerGraphState extends State<LogicAnalyzerGraph> {
         builder: (context, provider, _) {
       return SizedBox(
         child: LineChart(
+          transformationConfig: FlTransformationConfig(
+            minScale: 1,
+            maxScale: 25,
+            scaleAxis: FlScaleAxis.horizontal,
+            panEnabled: true,
+            scaleEnabled: true,
+          ),
           LineChartData(
             backgroundColor: chartBackgroundColor,
             titlesData: FlTitlesData(
@@ -75,6 +82,8 @@ class _LogicAnalyzerGraphState extends State<LogicAnalyzerGraph> {
                   const AxisTitles(sideTitles: SideTitles(showTitles: false)),
               leftTitles: AxisTitles(
                 sideTitles: SideTitles(
+                  maxIncluded: false,
+                  minIncluded: false,
                   interval: 1,
                   reservedSize: 30,
                   showTitles: true,
@@ -109,10 +118,10 @@ class _LogicAnalyzerGraphState extends State<LogicAnalyzerGraph> {
                 ),
               ),
             ),
-            maxY: 2,
-            maxX: 10,
-            minY: -1,
-            minX: 0,
+            clipData: const FlClipData.all(),
+            lineBarsData: provider.createPlots(),
+            maxY: provider.getMaxY(),
+            minY: provider.getMinY(),
           ),
         ),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,7 @@ dependencies:
   gauge_indicator: ^0.4.3
   light: ^4.1.0
   connectivity_plus: ^6.1.4
+  carousel_slider: ^5.1.1
   vibration: ^3.1.3
   shared_preferences: ^2.5.3
 


### PR DESCRIPTION
Adds the _Logic Analyzer_ instrument.

## Screenshots/Recordings


https://github.com/user-attachments/assets/a482b483-e2d6-4ba5-8ee1-8acfebdd41f3


## Summary by Sourcery

Add full Logic Analyzer support by extending ScienceLab communication APIs, introducing a state provider, and building a dedicated screen with channel selection and waveform visualization

New Features:
- Add a new Logic Analyzer instrument with dedicated screen, channel selection UI, and waveform plotting
- Implement multi-channel capture (1–4 channels) and edge-trigger analysis modes in ScienceLab
- Introduce LogicAnalyzerStateProvider for managing capture workflows and converting digital channel data into chart datasets

Enhancements:
- Extend navigation and routing to include logic analyzer in InstrumentsScreen and main app
- Add new constants and theme colors for logic analyzer labels and channel plots

Build:
- Add carousel_slider dependency for channel selection carousel

## Summary by Sourcery

Implement a new Logic Analyzer instrument with multi-channel digital capture, configurable edge-trigger modes, and interactive waveform visualization.

New Features:
- Add Logic Analyzer screen with channel selection UI and FlChart-based waveform graph.
- Support single-, two-, three-, and four-channel digital captures with configurable edge triggers.
- Introduce LogicAnalyzerStateProvider to manage capture workflows and convert digital data into chart datasets.

Enhancements:
- Extend ScienceLab API with methods to start and fetch logic analyzer data in various channel modes.
- Integrate logic analyzer into app navigation, routing, and InstrumentsScreen menu.
- Define new constants and theme colors for logic analyzer labels, channel plots, and axis titles.

Build:
- Add carousel_slider dependency for channel selection carousel.