### PR TITLE
fix: fix data acquisition from TSL2561 luminosity sensor

### DIFF
--- a/app/src/main/java/io/pslab/activity/SensorActivity.java
+++ b/app/src/main/java/io/pslab/activity/SensorActivity.java
@@ -56,7 +56,7 @@ public class SensorActivity extends GuideActivity {
     private I2C i2c;
     private ScienceLab scienceLab;
     private final Map<Integer, List<String>> sensorAddr = new LinkedHashMap<>();
-    private final List<String> dataAddress = new ArrayList<>();
+    private final List<Integer> dataAddress = new ArrayList<>();
     private final List<String> dataName = new ArrayList<>();
     private ArrayAdapter<String> adapter;
     private ListView lvSensor;
@@ -83,15 +83,16 @@ public class SensorActivity extends GuideActivity {
         i2c = scienceLab.i2c;
 
         // Populate sensor addresses with multiple sensors mapped to the same address
-        sensorAddr.put(0x48, List.of("ADS1115"));
-        sensorAddr.put(0x77, List.of("BMP180"));
-        sensorAddr.put(0x5A, List.of("MLX90614", "CCS811"));
-        sensorAddr.put(0x1E, List.of("HMC5883L"));
-        sensorAddr.put(0x68, List.of("MPU6050"));
-        sensorAddr.put(0x40, List.of("SHT21"));
+        sensorAddr.put(0x29, List.of("TSL2561", "VL53L0X"));
         sensorAddr.put(0x39, List.of("TSL2561", "APDS9960"));
+        sensorAddr.put(0x40, List.of("SHT21"));
+        sensorAddr.put(0x48, List.of("ADS1115"));
+        sensorAddr.put(0x49, List.of("TSL2561"));
+        sensorAddr.put(0x68, List.of("MPU6050"));
         sensorAddr.put(0x69, List.of("MPU925x"));
-        sensorAddr.put(0x29, List.of("VL53L0X"));
+        sensorAddr.put(0x77, List.of("BMP180"));
+        sensorAddr.put(0x1E, List.of("HMC5883L"));
+        sensorAddr.put(0x5A, List.of("MLX90614", "CCS811"));
 
         adapter = new ArrayAdapter<>(getApplication(), R.layout.sensor_list_item, R.id.tv_sensor_list_item, dataName);
 
@@ -104,7 +105,7 @@ public class SensorActivity extends GuideActivity {
         if (savedInstanceState != null) {
             String savedScanResults = savedInstanceState.getString(KEY_VALUE_SCAN);
             List<String> savedNames = savedInstanceState.getStringArrayList(KEY_ENTRIES_NAMES);
-            List<String> savedAddresses = savedInstanceState.getStringArrayList(KEY_ENTRIES_ADDRESSES);
+            List<Integer> savedAddresses = savedInstanceState.getIntegerArrayList(KEY_ENTRIES_ADDRESSES);
             if (savedScanResults != null) tvSensorScan.setText(savedScanResults);
             if (savedNames != null) dataName.addAll(savedNames);
             if (savedAddresses != null) dataAddress.addAll(savedAddresses);
@@ -176,7 +177,7 @@ public class SensorActivity extends GuideActivity {
         super.onSaveInstanceState(outState);
         outState.putString(KEY_VALUE_SCAN, tvSensorScan.getText().toString());
         outState.putStringArrayList(KEY_ENTRIES_NAMES, new ArrayList<>(dataName));
-        outState.putStringArrayList(KEY_ENTRIES_ADDRESSES, new ArrayList<>(dataAddress));
+        outState.putIntegerArrayList(KEY_ENTRIES_ADDRESSES, new ArrayList<>(dataAddress));
     }
 
     private class PopulateSensors extends AsyncTask<Void, Void, Void> {
@@ -210,22 +211,29 @@ public class SensorActivity extends GuideActivity {
             if (detectedSensors != null && scienceLab.isConnected()) {
                 for (Integer address : detectedSensors) {
                     if (address != null && sensorAddr.containsKey(address)) {
-                        dataAddress.add(String.valueOf(address));
+                        dataAddress.add(address);
                         dataName.addAll(sensorAddr.get(address));
                     }
                 }
 
                 // Build scan results for detected sensors
-                for (final String address : dataAddress) {
-                    scanResults.append(address).append(": ").append(sensorAddr.get(Integer.parseInt(address))).append("\n");
+                for (final Integer address : dataAddress) {
+                    scanResults
+                            .append("0x")
+                            .append(Integer.toHexString(address))
+                            .append(": ")
+                            .append(sensorAddr.get(address))
+                            .append("\n");
                 }
                 tvSensorScan.setText(scanResults);
             }
 
             // Ensure the full list of sensors is displayed, even if not connected
             for (List<String> sensors : sensorAddr.values()) {
-                if (!dataName.containsAll(sensors)) {
-                    dataName.addAll(sensors);
+                for (String sensor : sensors) {
+                    if (!dataName.contains(sensor)) {
+                        dataName.add(sensor);
+                    }
                 }
             }
 

--- a/app/src/main/java/io/pslab/communication/sensors/TSL2561.java
+++ b/app/src/main/java/io/pslab/communication/sensors/TSL2561.java
@@ -52,13 +52,17 @@ public class TSL2561 {
         // set timing 101ms & 16x gain
         if (scienceLab.isConnected()) {
 
-            /* Here we check if any of the possible addresses has an ID in the expected format.
-             * If no sensor is available with teh given ID, the value 0xFFFFFFFF will be returned.
-             * If a different value is returned, we can check for teh expected value (see data sheet
+            /* Here we probe if any of the expected I2C addresses has an ID in the expected format.
+             * If no sensor is available with the given ID, the value 0xFFFFFFFF will be returned.
+             * If a different value is returned, we can check for the expected value (see data sheet
              * for details).
              */
             for (byte addr : ADDRESSES) {
                 address = addr;
+                /* We disable the sensor before probing since it will not return the expected value
+                 * if it is still active due to a previous data capture.
+                 */
+                disable();
                 Log.d(TAG, "Checking address 0x" + Integer.toHexString(address));
                 int id = i2c.readByte(address, REGISTER_ID);
                 if (id != 0xffffffff && (id & 0x0A) == 0x0A) {

--- a/app/src/main/java/io/pslab/communication/sensors/TSL2561.java
+++ b/app/src/main/java/io/pslab/communication/sensors/TSL2561.java
@@ -2,123 +2,148 @@ package io.pslab.communication.sensors;
 
 import android.util.Log;
 
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import io.pslab.communication.ScienceLab;
 import io.pslab.communication.peripherals.I2C;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
-
-/**
- * Created by akarshan on 4/15/17.
+/*
+ * See https://www.digikey.in/htmldatasheets/production/1640693/0/0/1/tsl2560-tsl2561-datasheet.html
  */
-
 public class TSL2561 {
-    private String TAG = "TSL2561";
-    private int VISIBLE = 2;  // channel 0 - channel 1
-    private int INFRARED = 1;  // channel 1
-    private int FULLSPECTRUM = 0;  // channel 0
+    private static final String TAG = TSL2561.class.getSimpleName();
 
-    private int READBIT = 0x01;
-    private int COMMAND_BIT = 0x80; // Must be 1
+    /* See https://github.com/adafruit/TSL2561-Arduino-Library/blob/master/TSL2561.h for all constants. */
 
-    private int CONTROL_POWERON = 0x03;
-    private int CONTROL_POWEROFF = 0x00;
+    private static final byte VISIBLE = 2;      // channel 0 - channel 1
+    private static final byte INFRARED = 1;     // channel 1
+    private static final byte FULLSPECTRUM = 0; // channel 0
 
-    private int REGISTER_CONTROL = 0x00;
-    private int REGISTER_TIMING = 0x01;
-    private int REGISTER_ID = 0x0A;
+    private static final byte READBIT = 0x01;
 
-    private int INTEGRATIONTIME_13MS = 0x00;  // 13.7ms
-    private int INTEGRATIONTIME_101MS = 0x01;  // 101ms
-    private int INTEGRATIONTIME_402MS = 0x02;  // 402ms
+    private static final byte COMMAND_BIT = (byte) 0x80; // Must be 1
+    private static final byte CLEAR_BIT = (0x40);        // Clears any pending interrupt (write 1 to clear)
+    private static final byte WORD_BIT = (0x20);         // 1 = read/write word (rather than byte)
+    private static final byte BLOCK_BIT = (0x10);        // 1 = using block read/write
 
-    private int GAIN_1X = 0x00;     // No gain
-    private int GAIN_16X = 0x10;    // 16x gain
-    private int GAIN_OX;
+    private static final byte CONTROL_POWERON = 0x03;
+    private static final byte CONTROL_POWEROFF = 0x00;
 
-    private int ADDRESS = 0x39;  // addr normal
-    private int timing = INTEGRATIONTIME_13MS;
-    private int gain = GAIN_16X;
+    private static final byte REGISTER_CONTROL = 0x00;
+    private static final byte REGISTER_TIMING = 0x01;
+    private static final byte REGISTER_ID = 0x0A;
+    private static final byte REGISTER_CHAN0_LOW = 0x0C;
+    private static final byte REGISTER_CHAN1_LOW = 0x0E;
 
-    public String name = "TSL2561 Luminosity";
-    public int NUMPLOTS = 3;
-    public String[] PLOTNAMES = {"Full", "IR", "Visible"};
+    private static final byte INTEGRATIONTIME_13MS = 0x00;  // 13.7ms
+    private static final byte INTEGRATIONTIME_101MS = 0x01;  // 101ms
+    private static final byte INTEGRATIONTIME_402MS = 0x02;  // 402ms
 
-    private I2C i2c;
-    private int full, infra;
-    private ArrayList<Integer> infraList, fullList;
-    private ArrayList<java.io.Serializable> setGain = new ArrayList<java.io.Serializable>(Arrays.asList("1x", "16x"));
-    private ArrayList<java.io.Serializable> setTiming = new ArrayList<java.io.Serializable>(Arrays.asList(0, 1, 2));
+    private static final byte GAIN_0X = 0x00;     // No gain
+    private static final byte GAIN_16X = 0x10;    // 16x gain
+
+    /**
+     * Normal address is 0x39, but it may also be configured to 0x29 or 0x49.
+     * We use the normal address first before querying the alternatives.
+     */
+    private static final byte[] ADDRESSES = new byte[]{0x39, 0x29, 0x49};
+    private static final byte[] TIMINGS = new byte[]{INTEGRATIONTIME_13MS, INTEGRATIONTIME_101MS, INTEGRATIONTIME_402MS};
+    private byte address;
+    private byte timing = INTEGRATIONTIME_13MS;
+    private byte gain = GAIN_16X;
+
+    private final I2C i2c;
+    private final List<Serializable> setGain = Arrays.asList("1x", "16x");
+    private final List<Serializable> setTiming = Arrays.asList(0, 1, 2);
 
     public TSL2561(I2C i2c, ScienceLab scienceLab) throws IOException, InterruptedException {
         this.i2c = i2c;
         // set timing 101ms & 16x gain
         if (scienceLab.isConnected()) {
+
+            /* Here we check if any of the possible addresses has an ID in the expected format.
+             * If no sensor is available with teh given ID, the value 0xFFFFFFFF will be returned.
+             * If a different value is returned, we can check for teh expected value (see data sheet
+             * for details).
+             */
+            for (byte addr : ADDRESSES) {
+                address = addr;
+                Log.d(TAG, "Checking address 0x" + Integer.toHexString(address));
+                int id = i2c.readByte(address, REGISTER_ID);
+                if (id != 0xffffffff && (id & 0x0A) == 0x0A) {
+                    Log.d(TAG, "TSL2561 found!");
+                    break;
+                } else {
+                    Log.d(TAG, "TSL2561 not found.");
+                }
+            }
+
             enable();
             _wait();
-            i2c.writeBulk(ADDRESS, new int[]{0x80 | 0x01, 0x01 | 0x10});
-            //full scale luminosity
-            infraList = i2c.readBulk(ADDRESS, 0x80 | 0x20 | 0x0E, 2);
-            fullList = i2c.readBulk(ADDRESS, 0x80 | 0x20 | 0x0C, 2);
-            full = (fullList.get(1) << 8) | fullList.get(0);
-            infra = (infraList.get(1) << 8) | infraList.get(0);
-
-            Log.v(TAG, "Full - " + Integer.toString(full));
-            Log.v(TAG, "Infrared - " + Integer.toString(infra));
-            Log.v(TAG, "Visible -" + Integer.toString(full - infra));
+            i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_TIMING, timing | gain});
         }
     }
 
     public int getID() throws IOException {
-        ArrayList<Integer> _ID_ = i2c.readBulk(ADDRESS, REGISTER_ID, 1);
+        List<Integer> _ID_ = i2c.readBulk(address, REGISTER_ID, 1);
         int ID = Integer.parseInt(Character.getNumericValue(_ID_.get(0)) + "", 16);
-        Log.d("ID", Integer.toString(ID));
+        Log.d(TAG, "ID: " + ID);
         return ID;
     }
 
     public int[] getRaw() throws IOException {
-        fullList = i2c.readBulk(ADDRESS, 0x80 | 0x20 | 0x0E, 2);
-        infraList = i2c.readBulk(ADDRESS, 0x80 | 0x20 | 0x0C, 2);
+        List<Integer> infraList = i2c.readBulk(address, COMMAND_BIT | WORD_BIT | REGISTER_CHAN1_LOW, 2);
+        List<Integer> fullList = i2c.readBulk(address, COMMAND_BIT | WORD_BIT | REGISTER_CHAN0_LOW, 2);
         if (!infraList.isEmpty()) {
-            full = (fullList.get(0) << 8) | fullList.get(0);
-            infra = (infraList.get(0) << 8) | infraList.get(0);
+            int full = ((fullList.get(1) & 0xff) << 8) | fullList.get(0) & 0xff;
+            int infra = ((infraList.get(1) & 0xff) << 8) | infraList.get(0) & 0xff;
             return (new int[]{full, infra, full - infra});
         } else
             return null;
     }
 
-    public void setGain(String _gain_) throws IOException {
-        if (_gain_.equals("1x"))
-            gain = GAIN_1X;
+    public void setGain(String gain) throws IOException {
+        if (gain.equals("1x"))
+            this.gain = GAIN_0X;
 
-        else if (_gain_.equals("16x"))
-            gain = GAIN_16X;
-        else
-            gain = GAIN_OX;
-        i2c.writeBulk(ADDRESS, new int[]{COMMAND_BIT | REGISTER_TIMING, gain | timing});
+        else if (gain.equals("16x"))
+            this.gain = GAIN_16X;
+
+        i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_TIMING, this.gain | timing});
     }
 
     public void setTiming(int timing) throws IOException {
         Log.v(TAG, new int[]{13, 101, 404}[timing] + "mS");
-        this.timing = timing;
-        i2c.writeBulk(ADDRESS, new int[]{COMMAND_BIT | REGISTER_TIMING, gain | timing});
+        this.timing = TIMINGS[timing];
+        i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_TIMING, gain | timing});
     }
 
     private void enable() throws IOException {
-        i2c.writeBulk(ADDRESS, new int[]{COMMAND_BIT | REGISTER_CONTROL, CONTROL_POWERON});
+        i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_CONTROL, CONTROL_POWERON});
     }
 
     public void disable() throws IOException {
-        i2c.writeBulk(ADDRESS, new int[]{COMMAND_BIT | REGISTER_CONTROL, CONTROL_POWEROFF});
+        i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_CONTROL, CONTROL_POWEROFF});
     }
 
     private void _wait() throws InterruptedException {
-        if (timing == INTEGRATIONTIME_13MS) TimeUnit.MILLISECONDS.sleep(14);
-        if (timing == INTEGRATIONTIME_101MS) TimeUnit.MILLISECONDS.sleep(102);
-        if (timing == INTEGRATIONTIME_402MS) TimeUnit.MILLISECONDS.sleep(403);
-
+        switch (timing) {
+            case INTEGRATIONTIME_13MS: {
+                TimeUnit.MILLISECONDS.sleep(14);
+                break;
+            }
+            case INTEGRATIONTIME_101MS: {
+                TimeUnit.MILLISECONDS.sleep(102);
+                break;
+            }
+            default: {
+                TimeUnit.MILLISECONDS.sleep(403);
+            }
+        }
     }
 
 }

--- a/app/src/main/java/io/pslab/communication/sensors/TSL2561.java
+++ b/app/src/main/java/io/pslab/communication/sensors/TSL2561.java
@@ -3,8 +3,6 @@ package io.pslab.communication.sensors;
 import android.util.Log;
 
 import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -19,16 +17,8 @@ public class TSL2561 {
 
     /* See https://github.com/adafruit/TSL2561-Arduino-Library/blob/master/TSL2561.h for all constants. */
 
-    private static final byte VISIBLE = 2;      // channel 0 - channel 1
-    private static final byte INFRARED = 1;     // channel 1
-    private static final byte FULLSPECTRUM = 0; // channel 0
-
-    private static final byte READBIT = 0x01;
-
     private static final byte COMMAND_BIT = (byte) 0x80; // Must be 1
-    private static final byte CLEAR_BIT = (0x40);        // Clears any pending interrupt (write 1 to clear)
     private static final byte WORD_BIT = (0x20);         // 1 = read/write word (rather than byte)
-    private static final byte BLOCK_BIT = (0x10);        // 1 = using block read/write
 
     private static final byte CONTROL_POWERON = 0x03;
     private static final byte CONTROL_POWEROFF = 0x00;
@@ -51,14 +41,11 @@ public class TSL2561 {
      * We use the normal address first before querying the alternatives.
      */
     private static final byte[] ADDRESSES = new byte[]{0x39, 0x29, 0x49};
-    private static final byte[] TIMINGS = new byte[]{INTEGRATIONTIME_13MS, INTEGRATIONTIME_101MS, INTEGRATIONTIME_402MS};
     private byte address;
     private byte timing = INTEGRATIONTIME_13MS;
     private byte gain = GAIN_16X;
 
     private final I2C i2c;
-    private final List<Serializable> setGain = Arrays.asList("1x", "16x");
-    private final List<Serializable> setTiming = Arrays.asList(0, 1, 2);
 
     public TSL2561(I2C i2c, ScienceLab scienceLab) throws IOException, InterruptedException {
         this.i2c = i2c;
@@ -116,12 +103,6 @@ public class TSL2561 {
         i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_TIMING, this.gain | timing});
     }
 
-    public void setTiming(int timing) throws IOException {
-        Log.v(TAG, new int[]{13, 101, 404}[timing] + "mS");
-        this.timing = TIMINGS[timing];
-        i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_TIMING, gain | timing});
-    }
-
     private void enable() throws IOException {
         i2c.writeBulk(address, new int[]{COMMAND_BIT | REGISTER_CONTROL, CONTROL_POWERON});
     }
@@ -140,6 +121,7 @@ public class TSL2561 {
                 TimeUnit.MILLISECONDS.sleep(102);
                 break;
             }
+            case INTEGRATIONTIME_402MS:
             default: {
                 TimeUnit.MILLISECONDS.sleep(403);
             }


### PR DESCRIPTION
Fixes #2783

## Changes 
- Try to find sensor by checking all possible sensor IDs (0x29, 0x39, 0x49)
- Fix data acquisition
- Display sensor IDs in hex format in Sensors screen

I think there are still a few things to fix in the screen, but data acquisition works, which was the scope of the issue.

## Screenshots / Recordings 
https://github.com/user-attachments/assets/2c104bca-7251-427d-94c2-fbf6bb2cda40

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Add support for detecting TSL2561 sensors at multiple I2C addresses and correct raw luminosity reads, while updating the sensor screen to display addresses in hex

New Features:
- Detect TSL2561 devices by probing all potential I2C addresses (0x29, 0x39, 0x49)
- Display sensor addresses in hexadecimal format in the Sensor screen

Bug Fixes:
- Fix raw data acquisition for full spectrum, infrared, and visible channels using correct read commands and bit operations

Enhancements:
- Refactor TSL2561 class to centralize constants, use byte types, and streamline enable/read logic
- Update SensorActivity to use integer lists for addresses and rebuild scan output accordingly