### PR TITLE
feat: integrated bmp180 sensor in barometer instrument

### DIFF
--- a/lib/communication/peripherals/bmp180.dart
+++ b/lib/communication/peripherals/bmp180.dart
@@ -1,0 +1,221 @@
+import 'dart:math';
+import 'package:pslab/communication/peripherals/i2c.dart';
+import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/others/logger_service.dart';
+
+class BMP180 {
+  static const String tag = "BMP180";
+
+  static const int address = 0x77;
+
+  static const int ultraLowPower = 0;
+  static const int standard = 1;
+  static const int highRes = 2;
+  static const int ultraHighRes = 3;
+
+  static const int calAC1 = 0xAA;
+  static const int calAC2 = 0xAC;
+  static const int calAC3 = 0xAE;
+  static const int calAC4 = 0xB0;
+  static const int calAC5 = 0xB2;
+  static const int calAC6 = 0xB4;
+  static const int calB1 = 0xB6;
+  static const int calB2 = 0xB8;
+  static const int calMB = 0xBA;
+  static const int calMC = 0xBC;
+  static const int calMD = 0xBE;
+  static const int control = 0xF4;
+  static const int tempData = 0xF6;
+  static const int pressData = 0xF6;
+
+  static const int readTempCmd = 0x2E;
+  static const int readPressureCmd = 0x34;
+
+  int mode = highRes;
+  int oversampling = highRes;
+
+  static const int numPlots = 3;
+  static const List<String> plotNames = ["Temperature", "Pressure", "Altitude"];
+  static const String name = "Altimeter BMP180";
+
+  final I2C i2c;
+  late int ac1, ac2, ac3, ac4, ac5, ac6, b1, b2, mb, mc, md;
+  double temperature = 0.0;
+  double pressure = 0.0;
+
+  static const double seaLevelPressure = 101325.0;
+
+  BMP180._(this.i2c);
+
+  static Future<BMP180> create(I2C i2c, ScienceLab scienceLab) async {
+    final bmp180 = BMP180._(i2c);
+    await bmp180._initializeCalibrationValues(scienceLab);
+    return bmp180;
+  }
+
+  Future<void> _initializeCalibrationValues(ScienceLab scienceLab) async {
+    if (!scienceLab.isConnected()) {
+      throw Exception("ScienceLab not connected");
+    }
+
+    try {
+      ac1 = await readInt16(calAC1);
+      ac2 = await readInt16(calAC2);
+      ac3 = await readInt16(calAC3);
+      ac4 = await readUInt16(calAC4);
+      ac5 = await readUInt16(calAC5);
+      ac6 = await readUInt16(calAC6);
+      b1 = await readInt16(calB1);
+      b2 = await readInt16(calB2);
+      mb = await readInt16(calMB);
+      mc = await readInt16(calMC);
+      md = await readInt16(calMD);
+
+      logger.d(
+          "Calibration values: [$ac1, $ac2, $ac3, $ac4, $ac5, $ac6, $b1, $b2, $mb, $mc, $md]");
+    } catch (e) {
+      logger.e("Error initializing BMP180 calibration values: $e");
+      rethrow;
+    }
+  }
+
+  Future<int> readInt16(int registerAddress) async {
+    try {
+      List<int> data = await i2c.readBulk(address, registerAddress, 2);
+      int value = ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
+
+      if ((value & 0x8000) != 0) {
+        value |= 0xFFFF0000;
+      }
+
+      return value;
+    } catch (e) {
+      logger.e("Error reading int16 from register $registerAddress: $e");
+      rethrow;
+    }
+  }
+
+  Future<int> readUInt16(int registerAddress) async {
+    try {
+      List<int> data = await i2c.readBulk(address, registerAddress, 2);
+      return ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
+    } catch (e) {
+      logger.e("Error reading uint16 from register $registerAddress: $e");
+      rethrow;
+    }
+  }
+
+  Future<int> readRawTemperature() async {
+    try {
+      await i2c.write(address, [readTempCmd], control);
+      await Future.delayed(const Duration(milliseconds: 5));
+      int raw = await readUInt16(tempData);
+      return raw;
+    } catch (e) {
+      logger.e("Error reading raw temperature: $e");
+      rethrow;
+    }
+  }
+
+  Future<double> readTemperature() async {
+    try {
+      int ut = await readRawTemperature();
+
+      int x1 = ((ut - ac6) * ac5) >> 15;
+      int x2 = (mc << 11) ~/ (x1 + md);
+      int b5 = x1 + x2;
+      temperature = ((b5 + 8) >> 4) / 10.0;
+
+      return temperature;
+    } catch (e) {
+      logger.e("Error reading temperature: $e");
+      rethrow;
+    }
+  }
+
+  void setOversampling(int num) {
+    oversampling = num;
+  }
+
+  Future<int> readRawPressure() async {
+    try {
+      List<int> delays = [5, 8, 14, 26];
+      await i2c.write(address, [readPressureCmd + (mode << 6)], control);
+      await Future.delayed(Duration(milliseconds: delays[oversampling]));
+
+      int msb = await i2c.readByte(address, pressData) & 0xFF;
+      int lsb = await i2c.readByte(address, pressData + 1) & 0xFF;
+      int xlsb = await i2c.readByte(address, pressData + 2) & 0xFF;
+
+      return ((msb << 16) + (lsb << 8) + xlsb) >> (8 - mode);
+    } catch (e) {
+      logger.e("Error reading raw pressure: $e");
+      rethrow;
+    }
+  }
+
+  Future<double> readPressure() async {
+    try {
+      int ut = await readRawTemperature();
+      int up = await readRawPressure();
+
+      int x1 = ((ut - ac6) * ac5) >> 15;
+      int x2 = (mc << 11) ~/ (x1 + md);
+      int b5 = x1 + x2;
+
+      int b6 = b5 - 4000;
+      x1 = (b2 * (b6 * b6) >> 12) >> 11;
+      x2 = (ac2 * b6) >> 11;
+      int x3 = x1 + x2;
+      int b3 = (((ac1 * 4 + x3) << mode) + 2) ~/ 4;
+
+      x1 = (ac3 * b6) >> 13;
+      x2 = (b1 * ((b6 * b6) >> 12)) >> 16;
+      x3 = ((x1 + x2) + 2) >> 2;
+      int b4 = (ac4 * (x3 + 32768)) >> 15;
+      int b7 = (up - b3) * (50000 >> mode);
+
+      int p;
+      if (b7 < 0x80000000) {
+        p = (b7 * 2) ~/ b4;
+      } else {
+        p = (b7 ~/ b4) * 2;
+      }
+
+      x1 = (p >> 8) * (p >> 8);
+      x1 = (x1 * 3038) >> 16;
+      x2 = (-7357 * p) >> 16;
+      pressure = (p + ((x1 + x2 + 3791) >> 4)).toDouble();
+
+      return pressure;
+    } catch (e) {
+      logger.e("Error reading pressure: $e");
+      rethrow;
+    }
+  }
+
+  double altitude() {
+    return 44330.0 * (1 - pow(pressure / seaLevelPressure, 1 / 5.255));
+  }
+
+  double seaLevel(double pressure, double altitude) {
+    return pressure / pow(1 - (altitude / 44330.0), 5.255);
+  }
+
+  Future<Map<String, double>> getRawData() async {
+    try {
+      temperature = await readTemperature();
+      pressure = await readPressure();
+      double alt = altitude();
+
+      return {
+        'temperature': temperature,
+        'pressure': pressure,
+        'altitude': alt,
+      };
+    } catch (e) {
+      logger.e("Error getting raw data: $e");
+      rethrow;
+    }
+  }
+}

--- a/lib/communication/sensors/bmp180.dart
+++ b/lib/communication/sensors/bmp180.dart
@@ -3,7 +3,12 @@ import 'package:pslab/communication/peripherals/i2c.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/others/logger_service.dart';
 
+import '../../l10n/app_localizations.dart';
+import '../../providers/locator.dart';
+
 class BMP180 {
+  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
   static const String tag = "BMP180";
 
   static const int address = 0x77;
@@ -83,11 +88,7 @@ class BMP180 {
     try {
       List<int> data = await i2c.readBulk(address, registerAddress, 2);
       int value = ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
-
-      if ((value & 0x8000) != 0) {
-        value |= 0xFFFF0000;
-      }
-
+      if (value >= 0x8000) value -= 0x10000;
       return value;
     } catch (e) {
       logger.e("Error reading int16 from register $registerAddress: $e");

--- a/lib/communication/sensors/bmp180.dart
+++ b/lib/communication/sensors/bmp180.dart
@@ -87,6 +87,10 @@ class BMP180 {
   Future<int> readInt16(int registerAddress) async {
     try {
       List<int> data = await i2c.readBulk(address, registerAddress, 2);
+      if (data.length < 2) {
+        throw Exception(
+            "Expected 2 bytes but got ${data.length} from register $registerAddress");
+      }
       int value = ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
       if (value >= 0x8000) value -= 0x10000;
       return value;
@@ -99,6 +103,10 @@ class BMP180 {
   Future<int> readUInt16(int registerAddress) async {
     try {
       List<int> data = await i2c.readBulk(address, registerAddress, 2);
+      if (data.length < 2) {
+        throw Exception(
+            "Expected 2 bytes but got ${data.length} from register $registerAddress");
+      }
       return ((data[0] & 0xFF) << 8) | (data[1] & 0xFF);
     } catch (e) {
       logger.e("Error reading uint16 from register $registerAddress: $e");
@@ -141,8 +149,9 @@ class BMP180 {
   Future<int> readRawPressure() async {
     try {
       List<int> delays = [5, 8, 14, 26];
+      int safeOversampling = oversampling.clamp(0, 3);
       await i2c.write(address, [readPressureCmd + (mode << 6)], control);
-      await Future.delayed(Duration(milliseconds: delays[oversampling]));
+      await Future.delayed(Duration(milliseconds: delays[safeOversampling]));
 
       int msb = await i2c.readByte(address, pressData) & 0xFF;
       int lsb = await i2c.readByte(address, pressData + 1) & 0xFF;

--- a/lib/communication/sensors/bmp180.dart
+++ b/lib/communication/sensors/bmp180.dart
@@ -51,10 +51,30 @@ class BMP180 {
   static const double seaLevelPressure = 101325.0;
 
   BMP180._(this.i2c);
+  bool _validateCalibrationValues() {
+    if (ac1 == 0 || ac2 == 0 || ac3 == 0 || ac4 == 0 || ac5 == 0 || ac6 == 0) {
+      return false;
+    }
+    if (ac1 < -32768 || ac1 > 32767) return false;
+    if (ac2 < -32768 || ac2 > 32767) return false;
+    if (ac3 < -32768 || ac3 > 32767) return false;
+    if (ac4 < 0 || ac4 > 65535) return false;
+    if (ac5 < 0 || ac5 > 65535) return false;
+    if (ac6 < 0 || ac6 > 65535) return false;
+    if (b1 < -32768 || b1 > 32767) return false;
+    if (b2 < -32768 || b2 > 32767) return false;
+    if (mb < -32768 || mb > 32767) return false;
+    if (mc < -32768 || mc > 32767) return false;
+    if (md < -32768 || md > 32767) return false;
+    return true;
+  }
 
   static Future<BMP180> create(I2C i2c, ScienceLab scienceLab) async {
     final bmp180 = BMP180._(i2c);
     await bmp180._initializeCalibrationValues(scienceLab);
+    if (!bmp180._validateCalibrationValues()) {
+      throw Exception('BMP180 calibration values are invalid or out of range.');
+    }
     return bmp180;
   }
 
@@ -126,9 +146,9 @@ class BMP180 {
     }
   }
 
-  Future<double> readTemperature() async {
+  Future<double> readTemperature({int? rawTemp}) async {
     try {
-      int ut = await readRawTemperature();
+      int ut = rawTemp ?? await readRawTemperature();
 
       int x1 = ((ut - ac6) * ac5) >> 15;
       int x2 = (mc << 11) ~/ (x1 + md);
@@ -153,9 +173,14 @@ class BMP180 {
       await i2c.write(address, [readPressureCmd + (mode << 6)], control);
       await Future.delayed(Duration(milliseconds: delays[safeOversampling]));
 
-      int msb = await i2c.readByte(address, pressData) & 0xFF;
-      int lsb = await i2c.readByte(address, pressData + 1) & 0xFF;
-      int xlsb = await i2c.readByte(address, pressData + 2) & 0xFF;
+      List<int> data = await i2c.readBulk(address, pressData, 3);
+      if (data.length < 3) {
+        throw Exception(
+            "Expected 3 bytes but got ${data.length} from pressure data");
+      }
+      int msb = data[0] & 0xFF;
+      int lsb = data[1] & 0xFF;
+      int xlsb = data[2] & 0xFF;
 
       return ((msb << 16) + (lsb << 8) + xlsb) >> (8 - mode);
     } catch (e) {
@@ -164,9 +189,9 @@ class BMP180 {
     }
   }
 
-  Future<double> readPressure() async {
+  Future<double> readPressure({int? rawTemp}) async {
     try {
-      int ut = await readRawTemperature();
+      int ut = rawTemp ?? await readRawTemperature();
       int up = await readRawPressure();
 
       int x1 = ((ut - ac6) * ac5) >> 15;
@@ -214,8 +239,9 @@ class BMP180 {
 
   Future<Map<String, double>> getRawData() async {
     try {
-      temperature = await readTemperature();
-      pressure = await readPressure();
+      int rawTemp = await readRawTemperature();
+      temperature = await readTemperature(rawTemp: rawTemp);
+      pressure = await readPressure(rawTemp: rawTemp);
       double alt = altitude();
 
       return {

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1084,6 +1084,7 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get fileDeleted => 'File deleted';
 
+  @override
   String get soundmeterConfig => 'Soundmeter Configurations';
 
   @override

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
@@ -25,12 +26,15 @@ class BarometerStateProvider extends ChangeNotifier {
   final List<FlSpot> pressureChartData = [];
   double _startTime = 0;
   double _currentTime = 0;
-  final int _maxLength = 50;
+  final int _chartMaxLength = 50;
   double _pressureMin = 0;
   double _pressureMax = 0;
   double _pressureSum = 0;
   int _dataCount = 0;
   bool _sensorAvailable = false;
+  bool _isRecording = false;
+  List<List<dynamic>> _recordedData = [];
+  bool get isRecording => _isRecording;
 
   StreamSubscription? _barometerSubscription;
 
@@ -252,12 +256,24 @@ class BarometerStateProvider extends ChangeNotifier {
 
     final pressure = _currentPressure;
     final time = _currentTime;
+    if (_isRecording) {
+      final now = DateTime.now();
+      final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
+      _recordedData.add([
+        now.millisecondsSinceEpoch.toString(),
+        dateFormat.format(now),
+        pressure.toStringAsFixed(2),
+        getCurrentAltitude().toStringAsFixed(2),
+        0,
+        0
+      ]);
+    }
     _pressureData.add(pressure);
     _timeData.add(time);
     _pressureSum += pressure;
     _dataCount++;
 
-    if (_pressureData.length > _maxLength) {
+    if (_pressureData.length > _chartMaxLength) {
       final removedValue = _pressureData.removeAt(0);
       _timeData.removeAt(0);
       _pressureSum -= removedValue;
@@ -291,6 +307,20 @@ class BarometerStateProvider extends ChangeNotifier {
                 (gasConstant * lapseRate) / gravity));
 
     return altitude;
+  }
+
+  void startRecording() {
+    _isRecording = true;
+    _recordedData = [
+      ['Timestamp', 'DateTime', 'Pressure', 'Altitude', 'Latitude', 'Longitude']
+    ];
+    notifyListeners();
+  }
+
+  List<List<dynamic>> stopRecording() {
+    _isRecording = false;
+    notifyListeners();
+    return _recordedData;
   }
 
   double getCurrentPressure() => _currentPressure;

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -5,14 +5,21 @@ import 'package:flutter/material.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/communication/peripherals/i2c.dart';
+import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/communication/peripherals/bmp180.dart';
+import 'package:pslab/providers/barometer_config_provider.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 import 'package:flutter/foundation.dart';
 
 class BarometerStateProvider extends ChangeNotifier {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
   double _currentPressure = 0.0;
-  StreamSubscription? _barometerSubscription;
+  double _currentTemperature = 0.0;
+  double _currentAltitude = 0.0;
   Timer? _timeTimer;
+  Timer? _dataTimer;
   final List<double> _pressureData = [];
   final List<double> _timeData = [];
   final List<FlSpot> pressureChartData = [];
@@ -25,10 +32,60 @@ class BarometerStateProvider extends ChangeNotifier {
   int _dataCount = 0;
   bool _sensorAvailable = false;
 
+  StreamSubscription? _barometerSubscription;
+
+  BMP180? _bmp180Sensor;
+  I2C? _i2c;
+  ScienceLab? _scienceLab;
+
+  final BarometerConfigProvider _configProvider;
+  String _currentSensorType = 'In-built Sensor';
+
   Function(String)? onSensorError;
 
-  void initializeSensors({Function(String)? onError}) {
+  BarometerStateProvider(this._configProvider) {
+    _configProvider.addListener(_onConfigChanged);
+    _currentSensorType = _configProvider.config.activeSensor;
+  }
+
+  void _onConfigChanged() {
+    final newSensorType = _configProvider.config.activeSensor;
+    if (_currentSensorType != newSensorType) {
+      logger
+          .d("Sensor type changed from $_currentSensorType to $newSensorType");
+      _currentSensorType = newSensorType;
+      _reinitializeSensors();
+    }
+  }
+
+  void _reinitializeSensors() {
+    logger.d("Reinitializing sensors for $_currentSensorType");
+    disposeSensors();
+    _clearData();
+    initializeSensors(
+        onError: onSensorError, i2c: _i2c, scienceLab: _scienceLab);
+  }
+
+  void _clearData() {
+    _pressureData.clear();
+    _timeData.clear();
+    pressureChartData.clear();
+    _pressureSum = 0;
+    _dataCount = 0;
+    _pressureMin = 0;
+    _pressureMax = 0;
+    _currentPressure = 0.0;
+    _currentTemperature = 0.0;
+    _currentAltitude = 0.0;
+    _sensorAvailable = false;
+    notifyListeners();
+  }
+
+  void initializeSensors(
+      {Function(String)? onError, I2C? i2c, ScienceLab? scienceLab}) {
     onSensorError = onError;
+    _i2c = i2c;
+    _scienceLab = scienceLab;
 
     try {
       _startTime = DateTime.now().millisecondsSinceEpoch / 1000.0;
@@ -41,31 +98,107 @@ class BarometerStateProvider extends ChangeNotifier {
         notifyListeners();
       });
 
-      Timer sensorTimeout = Timer(const Duration(seconds: 3), () {
-        if (!_sensorAvailable) {
-          _handleSensorError(appLocalizations.barometerSensorError);
-        }
-      });
-
-      _barometerSubscription = barometerEventStream().listen(
-        (BarometerEvent event) {
-          _currentPressure = event.pressure / 1013.25;
-          if (!_sensorAvailable) {
-            _sensorAvailable = true;
-            sensorTimeout.cancel();
-          }
-          notifyListeners();
-        },
-        onError: (error) {
-          logger.e("${appLocalizations.barometerSensorError} $error");
-          sensorTimeout.cancel();
-          _handleSensorError(error);
-        },
-        cancelOnError: false,
-      );
+      if (_currentSensorType == 'In-built Sensor') {
+        _initializeBuiltInSensor();
+      } else if (_currentSensorType == 'BMP180') {
+        _initializeBMP180Sensor();
+      }
     } catch (e) {
       logger.e("${appLocalizations.barometerSensorInitialError} $e");
       _handleSensorError(e);
+    }
+  }
+
+  void _initializeBuiltInSensor() {
+    Timer sensorTimeout = Timer(const Duration(seconds: 3), () {
+      if (!_sensorAvailable) {
+        _handleSensorError(appLocalizations.barometerSensorError);
+      }
+    });
+
+    _barometerSubscription = barometerEventStream().listen(
+      (BarometerEvent event) {
+        _currentPressure = event.pressure / 1013.25;
+        _currentAltitude = _pressureToAltitude(_currentPressure);
+        _currentTemperature = 0.0;
+
+        if (!_sensorAvailable) {
+          _sensorAvailable = true;
+          sensorTimeout.cancel();
+          _startDataCollection();
+        }
+        notifyListeners();
+      },
+      onError: (error) {
+        logger.e("${appLocalizations.barometerSensorError} $error");
+        sensorTimeout.cancel();
+        _handleSensorError(error);
+      },
+      cancelOnError: false,
+    );
+  }
+
+  void _initializeBMP180Sensor() async {
+    logger.d("Initializing BMP180 sensor...");
+
+    if (_i2c == null || _scienceLab == null) {
+      logger.e("I2C or ScienceLab not provided for BMP180 sensor");
+      _handleSensorError("I2C or ScienceLab not provided for BMP180 sensor");
+      return;
+    }
+
+    if (!_scienceLab!.isConnected()) {
+      logger.e("ScienceLab not connected");
+      _handleSensorError("ScienceLab not connected");
+      return;
+    }
+
+    try {
+      _bmp180Sensor = await BMP180.create(_i2c!, _scienceLab!);
+      _sensorAvailable = true;
+      _startDataCollection();
+      logger.d("BMP180 sensor initialized successfully");
+
+      await _readBMP180Data();
+      notifyListeners();
+    } catch (e) {
+      logger.e("Error initializing BMP180 sensor: $e");
+      _handleSensorError("Failed to initialize BMP180 sensor: $e");
+    }
+  }
+
+  void _startDataCollection() {
+    if (_currentSensorType == 'BMP180') {
+      final updatePeriod = _configProvider.config.updatePeriod;
+      logger
+          .d("Starting BMP180 data collection with period: ${updatePeriod}ms");
+
+      _dataTimer?.cancel();
+      _dataTimer =
+          Timer.periodic(Duration(milliseconds: updatePeriod), (timer) async {
+        await _readBMP180Data();
+      });
+    }
+  }
+
+  Future<void> _readBMP180Data() async {
+    if (_bmp180Sensor == null || !_sensorAvailable) {
+      logger.w("BMP180 sensor not available for reading");
+      return;
+    }
+
+    try {
+      final data = await _bmp180Sensor!.getRawData();
+      _currentTemperature = data['temperature'] ?? 0.0;
+      _currentPressure = (data['pressure'] ?? 0.0) / 101325.0;
+      _currentAltitude = data['altitude'] ?? 0.0;
+
+      logger.d(
+          "BMP180 data - Temp: $_currentTemperature°C, Pressure: $_currentPressure atm, Altitude: $_currentAltitude m");
+      notifyListeners();
+    } catch (e) {
+      logger.e("Error reading BMP180 data: $e");
+      _handleSensorError("Error reading BMP180 data: $e");
     }
   }
 
@@ -76,12 +209,20 @@ class BarometerStateProvider extends ChangeNotifier {
   }
 
   void disposeSensors() {
+    logger.d("Disposing sensors...");
     _barometerSubscription?.cancel();
+    _barometerSubscription = null;
     _timeTimer?.cancel();
+    _timeTimer = null;
+    _dataTimer?.cancel();
+    _dataTimer = null;
+    _bmp180Sensor = null;
+    _sensorAvailable = false;
   }
 
   @override
   void dispose() {
+    _configProvider.removeListener(_onConfigChanged);
     disposeSensors();
     super.dispose();
   }
@@ -95,16 +236,19 @@ class BarometerStateProvider extends ChangeNotifier {
     _timeData.add(time);
     _pressureSum += pressure;
     _dataCount++;
+
     if (_pressureData.length > _maxLength) {
       final removedValue = _pressureData.removeAt(0);
       _timeData.removeAt(0);
       _pressureSum -= removedValue;
       _dataCount--;
     }
+
     if (_pressureData.isNotEmpty) {
       _pressureMin = _pressureData.reduce(min);
       _pressureMax = _pressureData.reduce(max);
     }
+
     pressureChartData.clear();
     for (int i = 0; i < _pressureData.length; i++) {
       pressureChartData.add(FlSpot(_timeData[i], _pressureData[i]));
@@ -135,12 +279,21 @@ class BarometerStateProvider extends ChangeNotifier {
   double getAveragePressure() =>
       _dataCount > 0 ? _pressureSum / _dataCount : 0.0;
 
-  double getCurrentAltitude() => _pressureToAltitude(_currentPressure);
+  double getCurrentAltitude() {
+    if (_currentSensorType == 'BMP180' && _currentAltitude != 0.0) {
+      return _currentAltitude;
+    }
+    return _pressureToAltitude(_currentPressure);
+  }
+
   double getMinAltitude() =>
       _pressureMin > 0 ? _pressureToAltitude(_pressureMin) : 0.0;
   double getMaxAltitude() =>
       _pressureMax > 0 ? _pressureToAltitude(_pressureMax) : 0.0;
   double getAverageAltitude() => _pressureToAltitude(getAveragePressure());
+
+  double getCurrentTemperature() => _currentTemperature;
+  bool hasTemperatureData() => _currentSensorType == 'BMP180';
 
   double getMaxAltitudeForChart() =>
       _pressureMax > 0 ? _pressureToAltitude(0) : 10000.0;
@@ -163,4 +316,19 @@ class BarometerStateProvider extends ChangeNotifier {
   }
 
   bool get sensorAvailable => _sensorAvailable;
+  String get currentSensorType => _currentSensorType;
+  bool get isBMP180Active => _currentSensorType == 'BMP180';
+  bool get isBuiltInActive => _currentSensorType == 'In-built Sensor';
+
+  Future<void> refreshBMP180Data() async {
+    if (_currentSensorType == 'BMP180' && _bmp180Sensor != null) {
+      await _readBMP180Data();
+    }
+  }
+
+  void setBMP180Oversampling(int mode) {
+    if (_bmp180Sensor != null) {
+      _bmp180Sensor!.setOversampling(mode);
+    }
+  }
 }

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -7,7 +7,7 @@ import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/communication/peripherals/i2c.dart';
 import 'package:pslab/communication/science_lab.dart';
-import 'package:pslab/communication/peripherals/bmp180.dart';
+import 'package:pslab/communication/sensors/bmp180.dart';
 import 'package:pslab/providers/barometer_config_provider.dart';
 import 'package:sensors_plus/sensors_plus.dart';
 import 'package:flutter/foundation.dart';
@@ -138,8 +138,21 @@ class BarometerStateProvider extends ChangeNotifier {
     );
   }
 
+  Future<bool> _checkBMP180Connection() async {
+    if (_i2c == null) return false;
+
+    try {
+      int chipId = await _i2c!.readByte(BMP180.address, 0xD0);
+      logger.d("BMP180 Chip ID: 0x${chipId.toRadixString(16)}");
+      return chipId == 0x55;
+    } catch (e) {
+      logger.e("Error checking BMP180 connection: $e");
+      return false;
+    }
+  }
+
   void _initializeBMP180Sensor() async {
-    logger.d("Initializing BMP180 sensor...");
+    logger.d("Checking BMP180 sensor connection...");
 
     if (_i2c == null || _scienceLab == null) {
       logger.e("I2C or ScienceLab not provided for BMP180 sensor");
@@ -150,6 +163,13 @@ class BarometerStateProvider extends ChangeNotifier {
     if (!_scienceLab!.isConnected()) {
       logger.e("ScienceLab not connected");
       _handleSensorError("ScienceLab not connected");
+      return;
+    }
+    bool isConnected = await _checkBMP180Connection();
+    if (!isConnected) {
+      logger.e(
+          "BMP180 sensor not found at address 0x${BMP180.address.toRadixString(16)}");
+      _handleSensorError("BMP180 sensor not connected or not responding");
       return;
     }
 
@@ -319,16 +339,4 @@ class BarometerStateProvider extends ChangeNotifier {
   String get currentSensorType => _currentSensorType;
   bool get isBMP180Active => _currentSensorType == 'BMP180';
   bool get isBuiltInActive => _currentSensorType == 'In-built Sensor';
-
-  Future<void> refreshBMP180Data() async {
-    if (_currentSensorType == 'BMP180' && _bmp180Sensor != null) {
-      await _readBMP180Data();
-    }
-  }
-
-  void setBMP180Oversampling(int mode) {
-    if (_bmp180Sensor != null) {
-      _bmp180Sensor!.setOversampling(mode);
-    }
-  }
 }

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -17,7 +17,7 @@ class BarometerStateProvider extends ChangeNotifier {
 
   double _currentPressure = 0.0;
   double _currentTemperature = 0.0;
-  double _currentAltitude = 0.0;
+  double? _currentAltitude;
   Timer? _timeTimer;
   Timer? _dataTimer;
   final List<double> _pressureData = [];
@@ -76,7 +76,7 @@ class BarometerStateProvider extends ChangeNotifier {
     _pressureMax = 0;
     _currentPressure = 0.0;
     _currentTemperature = 0.0;
-    _currentAltitude = 0.0;
+    _currentAltitude = null;
     _sensorAvailable = false;
     notifyListeners();
   }
@@ -211,7 +211,7 @@ class BarometerStateProvider extends ChangeNotifier {
       final data = await _bmp180Sensor!.getRawData();
       _currentTemperature = data['temperature'] ?? 0.0;
       _currentPressure = (data['pressure'] ?? 0.0) / 101325.0;
-      _currentAltitude = data['altitude'] ?? 0.0;
+      _currentAltitude = data['altitude'];
 
       logger.d(
           "BMP180 data - Temp: $_currentTemperature°C, Pressure: $_currentPressure atm, Altitude: $_currentAltitude m");
@@ -300,8 +300,8 @@ class BarometerStateProvider extends ChangeNotifier {
       _dataCount > 0 ? _pressureSum / _dataCount : 0.0;
 
   double getCurrentAltitude() {
-    if (_currentSensorType == 'BMP180' && _currentAltitude != 0.0) {
-      return _currentAltitude;
+    if (_currentSensorType == 'BMP180' && _currentAltitude != null) {
+      return _currentAltitude!;
     }
     return _pressureToAltitude(_currentPressure);
   }

--- a/lib/view/barometer_screen.dart
+++ b/lib/view/barometer_screen.dart
@@ -11,9 +11,12 @@ import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/barometer_card.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
+import 'package:pslab/others/csv_service.dart';
+import 'package:pslab/view/logged_data_screen.dart';
 
 import '../others/logger_service.dart';
 import '../providers/barometer_config_provider.dart';
+import '../constants.dart';
 import 'barometer_config_screen.dart';
 
 class BarometerScreen extends StatefulWidget {
@@ -24,12 +27,15 @@ class BarometerScreen extends StatefulWidget {
 
 class _BarometerScreenState extends State<BarometerScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  final CsvService _csvService = CsvService();
+  late BarometerStateProvider _provider;
   bool _showGuide = false;
   static const imagePath = 'assets/images/bmp180_schematic.png';
 
   I2C? _i2c;
   ScienceLab? _scienceLab;
   BarometerConfigProvider? _configProvider;
+
   @override
   void initState() {
     super.initState();
@@ -117,7 +123,7 @@ class _BarometerScreenState extends State<BarometerScreen> {
       if (value != null) {
         switch (value) {
           case 'show_logged_data':
-            // TODO
+            _navigateToLoggedData();
             break;
           case 'baro_meter_config':
             _navigateToConfig();
@@ -125,6 +131,19 @@ class _BarometerScreenState extends State<BarometerScreen> {
         }
       }
     });
+  }
+
+  Future<void> _navigateToLoggedData() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => LoggedDataScreen(
+          instrumentName: 'barometer',
+          appBarName: 'Barometer',
+          instrumentIcon: instrumentIcons[7], // Assuming barometer icon index
+        ),
+      ),
+    );
   }
 
   void _navigateToConfig() {
@@ -139,6 +158,92 @@ class _BarometerScreenState extends State<BarometerScreen> {
         ),
       );
     }
+  }
+
+  Future<void> _toggleRecording() async {
+    if (_provider.isRecording) {
+      final data = _provider.stopRecording();
+      await _showSaveFileDialog(data);
+    } else {
+      _provider.startRecording();
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '${appLocalizations.recordingStarted}...',
+            style: TextStyle(color: snackBarContentColor),
+          ),
+          backgroundColor: snackBarBackgroundColor,
+        ),
+      );
+    }
+  }
+
+  Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
+    final TextEditingController filenameController = TextEditingController();
+    final String defaultFilename = '';
+    filenameController.text = defaultFilename;
+
+    final String? fileName = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.saveRecording),
+          content: TextField(
+            controller: filenameController,
+            decoration: InputDecoration(
+              hintText: appLocalizations.enterFileName,
+              labelText: appLocalizations.fileName,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, filenameController.text);
+              },
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (fileName != null) {
+      _csvService.writeMetaData('barometer', data);
+      final file = await _csvService.saveCsvFile('barometer', fileName, data);
+      if (mounted) {
+        if (file != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                '${appLocalizations.fileSaved}: ${file.path.split('/').last}',
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                appLocalizations.failedToSave,
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _provider.dispose();
+    super.dispose();
   }
 
   @override
@@ -156,12 +261,13 @@ class _BarometerScreenState extends State<BarometerScreen> {
           create: (context) {
             final configProvider =
                 Provider.of<BarometerConfigProvider>(context, listen: false);
-            return BarometerStateProvider(configProvider)
+            _provider = BarometerStateProvider(configProvider)
               ..initializeSensors(
                 onError: _showSensorErrorSnackbar,
                 i2c: _i2c,
                 scienceLab: _scienceLab,
               );
+            return _provider;
           },
           update: (context, configProvider, previous) {
             return previous!;
@@ -169,40 +275,47 @@ class _BarometerScreenState extends State<BarometerScreen> {
         ),
       ],
       child: Stack(children: [
-        CommonScaffold(
-          title: appLocalizations.barometerTitle,
-          onGuidePressed: _showInstrumentGuide,
-          onOptionsPressed: _showOptionsMenu,
-          body: SafeArea(child: LayoutBuilder(builder: (context, constraints) {
-            final isLargeScreen = constraints.maxWidth > 900;
-            if (isLargeScreen) {
-              return Row(
-                children: [
-                  const Expanded(
-                    flex: 35,
-                    child: BarometerCard(),
-                  ),
-                  Expanded(
-                    flex: 65,
-                    child: _buildChartSection(),
-                  ),
-                ],
-              );
-            } else {
-              return Column(
-                children: [
-                  const Expanded(
-                    flex: 45,
-                    child: BarometerCard(),
-                  ),
-                  Expanded(
-                    flex: 55,
-                    child: _buildChartSection(),
-                  ),
-                ],
-              );
-            }
-          })),
+        Consumer<BarometerStateProvider>(
+          builder: (context, provider, child) {
+            return CommonScaffold(
+              title: appLocalizations.barometerTitle,
+              onGuidePressed: _showInstrumentGuide,
+              onOptionsPressed: _showOptionsMenu,
+              onRecordPressed: _toggleRecording,
+              isRecording: provider.isRecording,
+              body: SafeArea(
+                  child: LayoutBuilder(builder: (context, constraints) {
+                final isLargeScreen = constraints.maxWidth > 900;
+                if (isLargeScreen) {
+                  return Row(
+                    children: [
+                      const Expanded(
+                        flex: 35,
+                        child: BarometerCard(),
+                      ),
+                      Expanded(
+                        flex: 65,
+                        child: _buildChartSection(),
+                      ),
+                    ],
+                  );
+                } else {
+                  return Column(
+                    children: [
+                      const Expanded(
+                        flex: 45,
+                        child: BarometerCard(),
+                      ),
+                      Expanded(
+                        flex: 55,
+                        child: _buildChartSection(),
+                      ),
+                    ],
+                  );
+                }
+              })),
+            );
+          },
         ),
         if (_showGuide)
           InstrumentOverviewDrawer(

--- a/lib/view/barometer_screen.dart
+++ b/lib/view/barometer_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
-
+import 'package:pslab/communication/peripherals/i2c.dart';
+import 'package:pslab/communication/science_lab.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
@@ -24,6 +25,26 @@ class _BarometerScreenState extends State<BarometerScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
   bool _showGuide = false;
   static const imagePath = 'assets/images/bmp180_schematic.png';
+
+  I2C? _i2c;
+  ScienceLab? _scienceLab;
+  BarometerConfigProvider? _configProvider;
+  @override
+  void initState() {
+    super.initState();
+    _initializeScienceLab();
+  }
+
+  void _initializeScienceLab() async {
+    try {
+      _scienceLab = getIt.get<ScienceLab>();
+      if (_scienceLab != null && _scienceLab!.isConnected()) {
+        _i2c = I2C(_scienceLab!.mPacketHandler);
+      }
+    } catch (e) {
+      //
+    }
+  }
 
   void _showSensorErrorSnackbar(String message) {
     if (mounted) {
@@ -109,8 +130,12 @@ class _BarometerScreenState extends State<BarometerScreen> {
     Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => ChangeNotifierProvider(
-            create: (context) => BarometerConfigProvider(),
+          builder: (context) => MultiProvider(
+            providers: [
+              ChangeNotifierProvider.value(
+                value: _configProvider ?? BarometerConfigProvider(),
+              ),
+            ],
             child: const BarometerConfigScreen(),
           ),
         ));
@@ -120,9 +145,32 @@ class _BarometerScreenState extends State<BarometerScreen> {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider<BarometerStateProvider>(
-          create: (_) => BarometerStateProvider()
-            ..initializeSensors(onError: _showSensorErrorSnackbar),
+        ChangeNotifierProvider<BarometerConfigProvider>(
+          create: (_) {
+            _configProvider = BarometerConfigProvider();
+            return _configProvider!;
+          },
+        ),
+        ChangeNotifierProxyProvider<BarometerConfigProvider,
+            BarometerStateProvider>(
+          create: (context) => BarometerStateProvider(
+              Provider.of<BarometerConfigProvider>(context, listen: false))
+            ..initializeSensors(
+              onError: _showSensorErrorSnackbar,
+              i2c: _i2c,
+              scienceLab: _scienceLab,
+            ),
+          update: (context, configProvider, previous) {
+            if (previous == null) {
+              return BarometerStateProvider(configProvider)
+                ..initializeSensors(
+                  onError: _showSensorErrorSnackbar,
+                  i2c: _i2c,
+                  scienceLab: _scienceLab,
+                );
+            }
+            return previous;
+          },
         ),
       ],
       child: Stack(children: [

--- a/lib/view/barometer_screen.dart
+++ b/lib/view/barometer_screen.dart
@@ -127,18 +127,17 @@ class _BarometerScreenState extends State<BarometerScreen> {
   }
 
   void _navigateToConfig() {
-    Navigator.push(
+    if (_configProvider != null) {
+      Navigator.push(
         context,
         MaterialPageRoute(
-          builder: (context) => MultiProvider(
-            providers: [
-              ChangeNotifierProvider.value(
-                value: _configProvider ?? BarometerConfigProvider(),
-              ),
-            ],
+          builder: (context) => ChangeNotifierProvider.value(
+            value: _configProvider,
             child: const BarometerConfigScreen(),
           ),
-        ));
+        ),
+      );
+    }
   }
 
   @override
@@ -153,23 +152,18 @@ class _BarometerScreenState extends State<BarometerScreen> {
         ),
         ChangeNotifierProxyProvider<BarometerConfigProvider,
             BarometerStateProvider>(
-          create: (context) => BarometerStateProvider(
-              Provider.of<BarometerConfigProvider>(context, listen: false))
-            ..initializeSensors(
-              onError: _showSensorErrorSnackbar,
-              i2c: _i2c,
-              scienceLab: _scienceLab,
-            ),
+          create: (context) {
+            final configProvider =
+                Provider.of<BarometerConfigProvider>(context, listen: false);
+            return BarometerStateProvider(configProvider)
+              ..initializeSensors(
+                onError: _showSensorErrorSnackbar,
+                i2c: _i2c,
+                scienceLab: _scienceLab,
+              );
+          },
           update: (context, configProvider, previous) {
-            if (previous == null) {
-              return BarometerStateProvider(configProvider)
-                ..initializeSensors(
-                  onError: _showSensorErrorSnackbar,
-                  i2c: _i2c,
-                  scienceLab: _scienceLab,
-                );
-            }
-            return previous;
+            return previous!;
           },
         ),
       ],

--- a/lib/view/barometer_screen.dart
+++ b/lib/view/barometer_screen.dart
@@ -12,6 +12,7 @@ import 'package:pslab/view/widgets/barometer_card.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 
+import '../others/logger_service.dart';
 import '../providers/barometer_config_provider.dart';
 import 'barometer_config_screen.dart';
 
@@ -42,7 +43,7 @@ class _BarometerScreenState extends State<BarometerScreen> {
         _i2c = I2C(_scienceLab!.mPacketHandler);
       }
     } catch (e) {
-      //
+      logger.e('Error initializing ScienceLab: $e');
     }
   }
 


### PR DESCRIPTION
Fixes #2805

<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- integrated the BMP180 sensor . 
- Implemented BMP180 sensor similar to the pslab android and used the data in barometer. 
- user can now choose between inbuilt mobile sensor and external BMP180 sensor.

## Screenshots / Recordings  


https://github.com/user-attachments/assets/91b033d0-6670-4ae5-9cba-1206018f808a



<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Integrate the BMP180 sensor into the barometer module, refactor sensor initialization to support both built-in and external sensors with dynamic switching via configuration, and expose full sensor data (pressure, temperature, altitude) in the UI.

New Features:
- Implement BMP180 sensor driver and integrate it into the barometer instrument
- Allow users to switch between the in-built barometer sensor and the BMP180 via a configuration provider
- Expose temperature, pressure, and altitude data from the BMP180 sensor readings
- Automatically reinitialize sensors when the active sensor configuration changes

Enhancements:
- Refactor BarometerStateProvider to support multiple sensor types, dynamic initialization, and disposal
- Add periodic data collection timer for BMP180 based on a configurable update period
- Improve error handling and logging for sensor connection and data acquisition
- Update the barometer screen to initialize I2C and ScienceLab and inject configuration using ChangeNotifierProxyProvider

Documentation:
- Add missing localization entry in app_localizations_en

## Summary by Sourcery

Integrate external BMP180 sensor into barometer instrument, enabling dynamic sensor selection and data logging with CSV export.

New Features:
- Implement BMP180 sensor driver and integrate it into the barometer instrument with pressure, temperature, and altitude readings
- Allow users to switch between built-in and BMP180 sensors via configuration provider
- Add data recording feature with start/stop controls and CSV export for barometer readings

Enhancements:
- Refactor BarometerStateProvider to support multiple sensor types, dynamic initialization on config changes, and unified data handling
- Improve barometer UI setup by injecting I2C/ScienceLab dependencies, using ChangeNotifierProxyProvider, and adding controls for recording and viewing logged data
- Enhance error handling and logging for sensor initialization and data acquisition

Documentation:
- Add missing localization entry for soundmeterConfig in app_localizations_en