### PR TITLE
fix: removed MANAGE_EXTERNAL_STORAGE

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,8 +10,7 @@
         android:name="${applicationName}"
         android:icon="@drawable/launcher_icon"
         android:roundIcon="@drawable/launcher_icon_round"
-        android:requestLegacyExternalStorage="true"
-        tools:ignore="ScopedStorage">
+        >
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <application
         android:label="PSLab"
         android:name="${applicationName}"

--- a/lib/others/csv_service.dart
+++ b/lib/others/csv_service.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:csv/csv.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:intl/intl.dart';
@@ -16,9 +15,8 @@ class CsvService {
 
   Future<Directory> getInstrumentDirectory(String instrumentName) async {
     if (Platform.isAndroid) {
-      await requestStoragePermission();
-      final directory =
-          Directory('/storage/emulated/0/Android/media/PSLab/$instrumentName');
+      final externalDir = await getExternalStorageDirectory();
+      final directory = Directory('${externalDir?.path}/PSLab/$instrumentName');
       if (!await directory.exists()) {
         await directory.create(recursive: true);
       }
@@ -35,15 +33,6 @@ class CsvService {
       return directory;
     } else {
       throw UnsupportedError(appLocalizations.unsupportedPlatform);
-    }
-  }
-
-  Future<void> requestStoragePermission() async {
-    if (Platform.isAndroid) {
-      final status = await Permission.manageExternalStorage.request();
-      if (!status.isGranted) {
-        await openAppSettings();
-      }
     }
   }
 


### PR DESCRIPTION
fixes #2808

<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- removed manage_external_storage permission in androidmanifest.xml
- moved csv file storage to app specific external storage directory
-  /storage/emulated/0/Android/data/io.pslab/files/PSLab/<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  
<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Store CSV files in the app-specific external storage directory on Android and remove the need for MANAGE_EXTERNAL_STORAGE permission.

Bug Fixes:
- Removed MANAGE_EXTERNAL_STORAGE permission from AndroidManifest and related runtime permission requests.

Enhancements:
- Migrated CSV file storage path to the app's external storage directory via path_provider instead of a hardcoded external path.