### PR TITLE
fix: iOS push workflow

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,6 +30,8 @@
 	<string>Main</string>
 	<key>NSMicrophoneUsageDescription</key>
     <string>App needs Microphone access to capture audio</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+    <string>App needs access to photo library</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2050,6 +2050,18 @@ abstract class AppLocalizations {
   /// **'Are you sure you want to delete this file?'**
   String get deleteHint;
 
+  /// No description provided for @documentationLink.
+  ///
+  /// In en, this message translates to:
+  /// **'https://docs.pslab.io/'**
+  String get documentationLink;
+
+  /// No description provided for @documentationError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open the documentation link'**
+  String get documentationError;
+
   /// No description provided for @deleteFile.
   ///
   /// In en, this message translates to:
@@ -2248,18 +2260,6 @@ abstract class AppLocalizations {
   /// **'Please provide the maximum limit of lux value to be recorded'**
   String get accelerometerHighLimitHint;
 
-  /// No description provided for @documentationLink.
-  ///
-  /// In en, this message translates to:
-  /// **'https://docs.pslab.io/'**
-  String get documentationLink;
-
-  /// No description provided for @documentationError.
-  ///
-  /// In en, this message translates to:
-  /// **'Could not open the documentation link'**
-  String get documentationError;
-
   /// No description provided for @roboticArmIntro.
   ///
   /// In en, this message translates to:
@@ -2271,7 +2271,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'• In the above figure, SQ1 is connected to the signal pin of the first servo motor. The servo\'s GND pin is connected to both the PSLab’s GND and the external power supply GND, while the VCC pin is connected to the external power supply VCC.\n• Similarly, connect the remaining servos to SQ2, SQ3, and SQ4 along with their respective GND and power supply connections.\n• Once connected, each servo can be controlled using either circular sliders for manual control or a timeline-based sequence for automated movement.'**
   String get roboticArmConnection;
-
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1047,6 +1047,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get deleteHint => 'Are you sure you want to delete this file?';
 
   @override
+  String get documentationLink => 'https://docs.pslab.io/';
+
+  @override
+  String get documentationError => 'Could not open the documentation link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1151,12 +1157,6 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get accelerometerHighLimitHint =>
       'Please provide the maximum limit of lux value to be recorded';
-
-  @override
-  String get documentationLink => 'https://docs.pslab.io/';
-
-  @override
-  String get documentationError => 'Could not open the documentation link';
 
   @override
   String get roboticArmIntro =>


### PR DESCRIPTION
## Summary by Sourcery

Add new documentation link and error message localizations, clean up their duplicate definitions, and update iOS Info.plist to include photo library usage description

New Features:
- Introduce documentationLink and documentationError localization getters with corresponding English translations

Enhancements:
- Remove duplicate definitions of documentationLink and documentationError in app_localizations

Chores:
- Add NSPhotoLibraryUsageDescription entry to iOS Info.plist to request photo library access