### PR TITLE
fix: multimeter layout fixes

### DIFF
--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1058,6 +1058,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get temperatureSensorUnavailableMessage =>
       'Ambient temperature sensor is not available on this device';
 
+  @override
   String get sharingMessage => 'Sharing PSLab Data';
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/board_state_provider.dart';
@@ -46,39 +47,44 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     _preCacheImages(context);
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
+    return ScreenUtilInit(
+      designSize: const Size(360, 690),
       builder: (context, child) {
-        registerAppLocalizations(AppLocalizations.of(context)!);
-        getIt<BoardStateProvider>().initialize();
-        return child!;
-      },
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.system,
-      localizationsDelegates: AppLocalizations.localizationsDelegates,
-      supportedLocales: AppLocalizations.supportedLocales,
-      initialRoute: '/',
-      routes: {
-        '/': (context) => const InstrumentsScreen(),
-        '/oscilloscope': (context) => const OscilloscopeScreen(),
-        '/multimeter': (context) => const MultimeterScreen(),
-        '/waveGenerator': (context) => const WaveGeneratorScreen(),
-        '/logicAnalyzer': (context) => const LogicAnalyzerScreen(),
-        '/powerSource': (context) => const PowerSourceScreen(),
-        '/connectDevice': (context) => const ConnectDeviceScreen(),
-        '/faq': (context) => FAQScreen(),
-        '/settings': (context) => const SettingsScreen(),
-        '/aboutUs': (context) => const AboutUsScreen(),
-        '/softwareLicenses': (context) => SoftwareLicensesScreen(),
-        '/accelerometer': (context) => const AccelerometerScreen(),
-        '/gyroscope': (context) => const GyroscopeScreen(),
-        '/roboticArm': (context) => const RoboticArmScreen(),
-        '/luxmeter': (context) => const LuxMeterScreen(),
-        '/barometer': (context) => const BarometerScreen(),
-        '/soundmeter': (context) => const SoundMeterScreen(),
-        '/thermometer': (context) => const ThermometerScreen(),
-        '/sensors': (context) => const SensorsScreen()
+        return MaterialApp(
+          debugShowCheckedModeBanner: false,
+          builder: (context, child) {
+            registerAppLocalizations(AppLocalizations.of(context)!);
+            getIt<BoardStateProvider>().initialize();
+            return child!;
+          },
+          theme: AppTheme.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: ThemeMode.system,
+          localizationsDelegates: AppLocalizations.localizationsDelegates,
+          supportedLocales: AppLocalizations.supportedLocales,
+          initialRoute: '/',
+          routes: {
+            '/': (context) => const InstrumentsScreen(),
+            '/oscilloscope': (context) => const OscilloscopeScreen(),
+            '/multimeter': (context) => const MultimeterScreen(),
+            '/waveGenerator': (context) => const WaveGeneratorScreen(),
+            '/logicAnalyzer': (context) => const LogicAnalyzerScreen(),
+            '/powerSource': (context) => const PowerSourceScreen(),
+            '/connectDevice': (context) => const ConnectDeviceScreen(),
+            '/faq': (context) => FAQScreen(),
+            '/settings': (context) => const SettingsScreen(),
+            '/aboutUs': (context) => const AboutUsScreen(),
+            '/softwareLicenses': (context) => SoftwareLicensesScreen(),
+            '/accelerometer': (context) => const AccelerometerScreen(),
+            '/gyroscope': (context) => const GyroscopeScreen(),
+            '/roboticArm': (context) => const RoboticArmScreen(),
+            '/luxmeter': (context) => const LuxMeterScreen(),
+            '/barometer': (context) => const BarometerScreen(),
+            '/soundmeter': (context) => const SoundMeterScreen(),
+            '/thermometer': (context) => const ThermometerScreen(),
+            '/sensors': (context) => const SensorsScreen()
+          },
+        );
       },
     );
   }

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -194,7 +194,16 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                             ),
                           ],
                         ),
-                        MultimeterKnob(),
+                        Positioned(
+                          left: 0,
+                          top: 0,
+                          right: 0,
+                          bottom: 0,
+                          child: Align(
+                            alignment: Alignment.center,
+                            child: MultimeterKnob(),
+                          ),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/view/widgets/multimeter_knob.dart
+++ b/lib/view/widgets/multimeter_knob.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
@@ -247,8 +248,9 @@ class _MultimeterKnobState extends State<MultimeterKnob> {
       children: [
         CustomPaint(
           painter: InnerDialFillPainter(),
-          child: Container(
-            width: 300,
+          child: SizedBox(
+            width: 300.w,
+            height: 300.h,
           ),
         ),
         GestureDetector(
@@ -267,8 +269,8 @@ class _MultimeterKnobState extends State<MultimeterKnob> {
               color: pointerColor,
             ),
             child: SizedBox(
-              width: 430,
-              height: 450,
+              width: 360.w,
+              height: 360.h,
             ),
           ),
         ),
@@ -276,8 +278,9 @@ class _MultimeterKnobState extends State<MultimeterKnob> {
           ignoring: true,
           child: CustomPaint(
             painter: InnerDialPainter(),
-            child: Container(
-              width: 300,
+            child: SizedBox(
+              height: 300.h,
+              width: 300.w,
             ),
           ),
         ),
@@ -287,11 +290,7 @@ class _MultimeterKnobState extends State<MultimeterKnob> {
             painter: RadialLabelPainter(
               labels: knobMarker,
               labelColors: knobLabelColors,
-              radius: 112,
-            ),
-            child: SizedBox(
-              width: 430,
-              height: 450,
+              radius: 112.r,
             ),
           ),
         )

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,7 @@ dependencies:
   share_plus: ^11.0.0
   path_provider: ^2.1.5
   file_picker: ^10.2.4
+  flutter_screenutil: ^5.9.3
 
 
 dev_dependencies:


### PR DESCRIPTION
Some minor fixes for the layout of the _Multimeter_ screen, to make it adapt to iOS devices and large screen sizes.

## Summary by Sourcery

Enable responsive scaling throughout the multimeter screen by integrating flutter_screenutil, updating hardcoded dimensions, and adjusting widget alignment to fix layout issues on various devices.

Bug Fixes:
- Correct multimeter screen layout issues on iOS devices and large screens

Enhancements:
- Initialize ScreenUtil in main.dart to enable responsive layouts
- Replace fixed sizes in MultimeterKnob with .w, .h, and .r extensions for dynamic scaling
- Center the MultimeterKnob within its container using Positioned and Align

Build:
- Add flutter_screenutil dependency to pubspec.yaml

Chores:
- Add missing @override annotation in English localizations