### PR TITLE
fix: logic analyzer channel selection

### DIFF
--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -77,10 +77,10 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     channelSelectSpinner2 = channelNames[1];
     channelSelectSpinner3 = channelNames[2];
     channelSelectSpinner4 = channelNames[3];
-    edgeSelectSpinner1 = appLocalizations.analysisOptionEveryEdge;
-    edgeSelectSpinner2 = appLocalizations.analysisOptionEveryEdge;
-    edgeSelectSpinner3 = appLocalizations.analysisOptionEveryEdge;
-    edgeSelectSpinner4 = appLocalizations.analysisOptionEveryEdge;
+    edgeSelectSpinner1 = appLocalizations.analysisOptionEveryEdge.toUpperCase();
+    edgeSelectSpinner2 = appLocalizations.analysisOptionEveryEdge.toUpperCase();
+    edgeSelectSpinner3 = appLocalizations.analysisOptionEveryEdge.toUpperCase();
+    edgeSelectSpinner4 = appLocalizations.analysisOptionEveryEdge.toUpperCase();
 
     maxY = singleChannelAxisMax;
     minY = singleChannelAxisMin;


### PR DESCRIPTION
Fixes a small bug in the _Logic Analyzer_ screen arisen due refactoring our translations to use normal casing.

## Summary by Sourcery

Bug Fixes:
- Convert analysisOptionEveryEdge translation to uppercase for all logic analyzer edge select spinners to restore expected behavior