### PR TITLE
fix: build fails due to deprecated members

### DIFF
--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -143,7 +143,7 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                                             Transform.scale(
                                               scale: 0.75,
                                               child: Switch(
-                                                activeColor:
+                                                activeThumbColor:
                                                     multimeterBorderBlack,
                                                 value: provider.isSwitchChecked,
                                                 onChanged: (bool value) {},

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -42,11 +42,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
               style:
                   const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           children: [
-            RadioListTile<bool>(
-              title: Text(appLocalizations.txtFormat),
-              value: true,
+            RadioGroup(
               groupValue: isTxtFormatSelected,
-              activeColor: primaryRed,
               onChanged: (bool? value) {
                 setState(
                   () {
@@ -58,12 +55,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   },
                 );
               },
+              child: RadioListTile<bool>(
+                  title: Text(appLocalizations.txtFormat),
+                  value: true,
+                  activeColor: primaryRed),
             ),
-            RadioListTile<bool>(
-              title: Text(appLocalizations.csvFormat),
-              value: true,
+            RadioGroup(
               groupValue: isCsvFormatSelected,
-              activeColor: primaryRed,
               onChanged: (bool? value) {
                 setState(
                   () {
@@ -75,6 +73,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   },
                 );
               },
+              child: RadioListTile<bool>(
+                title: Text(appLocalizations.csvFormat),
+                value: true,
+                activeColor: primaryRed,
+              ),
             ),
             Align(
               alignment: Alignment.bottomRight,

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -243,13 +243,9 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Radio<bool>(
-                      activeColor: radioButtonActiveColor,
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      value: true,
+                    RadioGroup(
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
-                      toggleable: true,
                       onChanged: (bool? value) {
                         setState(
                           () {
@@ -276,6 +272,12 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                           },
                         );
                       },
+                      child: Radio<bool>(
+                        activeColor: radioButtonActiveColor,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        value: true,
+                        toggleable: true,
+                      ),
                     ),
                     Text(
                       appLocalizations.inBuiltMic,

--- a/lib/view/widgets/config_widgets.dart
+++ b/lib/view/widgets/config_widgets.dart
@@ -155,19 +155,20 @@ class ConfigDropdownItem extends StatelessWidget {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: options.map((option) {
-              return RadioListTile<String>(
-                title: Text(option.displayName),
-                value: option.value,
-                groupValue: selectedValue,
-                onChanged: (String? value) {
-                  if (value != null) {
-                    onChanged(value);
-                    Navigator.of(context).pop();
-                  }
-                },
-                activeColor: primaryRed,
-                contentPadding: EdgeInsets.zero,
-              );
+              return RadioGroup(
+                  groupValue: selectedValue,
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      onChanged(value);
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  child: RadioListTile<String>(
+                    title: Text(option.displayName),
+                    value: option.value,
+                    activeColor: primaryRed,
+                    contentPadding: EdgeInsets.zero,
+                  ));
             }).toList(),
           ),
           actions: [

--- a/lib/view/widgets/robotic_arm_controls.dart
+++ b/lib/view/widgets/robotic_arm_controls.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/locator.dart';
 import 'package:pslab/theme/colors.dart';
-import '../../l10n/app_localizations.dart';
-import '../../providers/locator.dart';
+
 import '../../providers/robotic_arm_state_provider.dart';
 
 class RoboticArmControls extends StatefulWidget {
@@ -178,13 +179,15 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Radio<String>(
-                                  value: appLocalizations.duration1Min,
+                                RadioGroup(
                                   groupValue: provider.selectedDuration,
-                                  activeColor: primaryRed,
                                   onChanged: (value) {
                                     provider.setSelectedDuration(value!);
                                   },
+                                  child: Radio<String>(
+                                    value: appLocalizations.duration1Min,
+                                    activeColor: primaryRed,
+                                  ),
                                 ),
                                 Text(
                                   appLocalizations.duration1Min,
@@ -198,13 +201,15 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Radio<String>(
-                                  value: appLocalizations.duration2Min,
+                                RadioGroup(
                                   groupValue: provider.selectedDuration,
-                                  activeColor: primaryRed,
                                   onChanged: (value) {
                                     provider.setSelectedDuration(value!);
                                   },
+                                  child: Radio<String>(
+                                    value: appLocalizations.duration2Min,
+                                    activeColor: primaryRed,
+                                  ),
                                 ),
                                 Text(
                                   appLocalizations.duration2Min,
@@ -358,10 +363,8 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Radio<String>(
-                            value: appLocalizations.frequency50Hz,
+                          RadioGroup(
                             groupValue: provider.selectedFrequency,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               if (provider.isPlaying) {
                                 ScaffoldMessenger.of(context).showSnackBar(
@@ -377,6 +380,10 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                               }
                               provider.setSelectedFrequency(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.frequency50Hz,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.frequency50Hz,
@@ -384,10 +391,8 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                                 color: Colors.black, fontSize: 12),
                           ),
                           const SizedBox(width: 16),
-                          Radio<String>(
-                            value: appLocalizations.frequency100Hz,
+                          RadioGroup(
                             groupValue: provider.selectedFrequency,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               if (provider.isPlaying) {
                                 ScaffoldMessenger.of(context).showSnackBar(
@@ -403,6 +408,10 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                               }
                               provider.setSelectedFrequency(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.frequency100Hz,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.frequency100Hz,
@@ -449,26 +458,30 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Radio<String>(
-                            value: appLocalizations.angle180,
+                          RadioGroup(
                             groupValue: provider.selectedMaxAngle,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               provider.setSelectedMaxAngle(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.angle180,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.angle180,
                             style: TextStyle(color: Colors.black, fontSize: 12),
                           ),
                           const SizedBox(width: 16),
-                          Radio<String>(
-                            value: appLocalizations.angle360,
+                          RadioGroup(
                             groupValue: provider.selectedMaxAngle,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               provider.setSelectedMaxAngle(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.angle360,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.angle360,

--- a/lib/view/widgets/robotic_arm_controls.dart
+++ b/lib/view/widgets/robotic_arm_controls.dart
@@ -169,13 +169,15 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
-                              Radio<String>(
-                                value: appLocalizations.duration1Min,
+                              RadioGroup(
                                 groupValue: provider.selectedDuration,
-                                activeColor: primaryRed,
                                 onChanged: (value) {
                                   provider.setSelectedDuration(value!);
                                 },
+                                child: Radio<String>(
+                                  value: appLocalizations.duration1Min,
+                                  activeColor: primaryRed,
+                                ),
                               ),
                               Text(appLocalizations.duration1Min,
                                   style: TextStyle(
@@ -187,13 +189,15 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                           child: Row(
                             mainAxisAlignment: MainAxisAlignment.center,
                             children: [
-                              Radio<String>(
-                                value: appLocalizations.duration2Min,
+                              RadioGroup(
                                 groupValue: provider.selectedDuration,
-                                activeColor: primaryRed,
                                 onChanged: (value) {
                                   provider.setSelectedDuration(value!);
                                 },
+                                child: Radio<String>(
+                                  value: appLocalizations.duration2Min,
+                                  activeColor: primaryRed,
+                                ),
                               ),
                               Text(appLocalizations.duration2Min,
                                   style: TextStyle(
@@ -315,10 +319,8 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Radio<String>(
-                        value: appLocalizations.frequency50Hz,
+                      RadioGroup(
                         groupValue: provider.selectedFrequency,
-                        activeColor: primaryRed,
                         onChanged: (value) {
                           if (provider.isPlaying) {
                             ScaffoldMessenger.of(context).showSnackBar(
@@ -333,6 +335,10 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                           }
                           provider.setSelectedFrequency(value!);
                         },
+                        child: Radio<String>(
+                          value: appLocalizations.frequency50Hz,
+                          activeColor: primaryRed,
+                        ),
                       ),
                       Text(
                         appLocalizations.frequency50Hz,
@@ -340,10 +346,8 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                             const TextStyle(color: Colors.black, fontSize: 12),
                       ),
                       const SizedBox(width: 16),
-                      Radio<String>(
-                        value: appLocalizations.frequency100Hz,
+                      RadioGroup(
                         groupValue: provider.selectedFrequency,
-                        activeColor: primaryRed,
                         onChanged: (value) {
                           if (provider.isPlaying) {
                             ScaffoldMessenger.of(context).showSnackBar(
@@ -358,6 +362,10 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                           }
                           provider.setSelectedFrequency(value!);
                         },
+                        child: Radio<String>(
+                          value: appLocalizations.frequency100Hz,
+                          activeColor: primaryRed,
+                        ),
                       ),
                       Text(
                         appLocalizations.frequency100Hz,
@@ -382,13 +390,14 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                   child: Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Radio<String>(
-                        value: appLocalizations.angle180,
+                      RadioGroup(
                         groupValue: provider.selectedMaxAngle,
-                        activeColor: primaryRed,
                         onChanged: (value) {
                           provider.setSelectedMaxAngle(value!);
                         },
+                        child: Radio<String>(
+                          value: appLocalizations.angle180,
+                        ),
                       ),
                       Text(
                         appLocalizations.angle180,
@@ -397,11 +406,7 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                       const SizedBox(width: 16),
                       Radio<String>(
                         value: appLocalizations.angle360,
-                        groupValue: provider.selectedMaxAngle,
                         activeColor: primaryRed,
-                        onChanged: (value) {
-                          provider.setSelectedMaxAngle(value!);
-                        },
                       ),
                       Text(
                         appLocalizations.angle360,

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <flutter_audio_capture/flutter_audio_capture_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) flutter_audio_capture_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterAudioCapturePlugin");
   flutter_audio_capture_plugin_register_with_registrar(flutter_audio_capture_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   flutter_audio_capture
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,22 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
+import device_info_plus
+import file_picker
+import package_info_plus
 import path_provider_foundation
+import share_plus
+import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -26,7 +26,7 @@ packages:
     source: hosted
     version: "2.1.2"
   carousel_slider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: carousel_slider
       sha256: bcc61735345c9ab5cb81073896579e735f81e35fd588907a393143ea986be8ff
@@ -58,7 +58,7 @@ packages:
     source: hosted
     version: "1.19.1"
   connectivity_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: connectivity_plus
       sha256: "051849e2bd7c7b3bc5844ea0d096609ddc3a859890ec3a9ac4a65a2620cc1f99"
@@ -90,7 +90,7 @@ packages:
     source: hosted
     version: "3.0.6"
   csv:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: csv
       sha256: c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c
@@ -178,7 +178,7 @@ packages:
     source: hosted
     version: "7.0.1"
   file_picker:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: file_picker
       sha256: "970d33d79e1da667b6da222575fd7f2e30e323ca76251504477e6d51405b2d9a"
@@ -224,12 +224,12 @@ packages:
     source: hosted
     version: "6.0.0"
   flutter_localizations:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
   flutter_oss_licenses:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: flutter_oss_licenses
       sha256: e4bbaeb00bc768e8430ee0c95ad304d2f256fb15194d30b912cea269871c8885
@@ -244,6 +244,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.28"
+  flutter_screenutil:
+    dependency: "direct main"
+    description:
+      name: flutter_screenutil
+      sha256: "8239210dd68bee6b0577aa4a090890342d04a136ce1c81f98ee513fc0ce891de"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.3"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -263,7 +271,7 @@ packages:
     source: sdk
     version: "0.0.0"
   font_awesome_flutter:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: font_awesome_flutter
       sha256: f50ce90dbe26d977415b9540400d6778bef00894aced6358ae578abd92b14b10
@@ -271,7 +279,7 @@ packages:
     source: hosted
     version: "10.9.0"
   gauge_indicator:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: gauge_indicator
       sha256: "483abfae360ddffdf7b89fbd25192f83d1a6513d5da18f2388131566ab0793fd"
@@ -311,7 +319,7 @@ packages:
     source: hosted
     version: "4.1.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
@@ -330,28 +338,28 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   light:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: light
       sha256: cb6551bf3ac336fcd5d0ce85ba3345a6f195785bb913f7541a976b4367aeb3a3
@@ -439,7 +447,7 @@ packages:
     source: hosted
     version: "0.5.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: "7976bfe4c583170d6cdc7077e3237560b364149fcd268b5f53d95a991963b191"
@@ -471,7 +479,7 @@ packages:
     source: hosted
     version: "1.1.0"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
@@ -599,7 +607,7 @@ packages:
     source: hosted
     version: "6.1.5"
   sensors_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sensors_plus
       sha256: "905282c917c6bb731c242f928665c2ea15445aa491249dea9d98d7c79dc8fd39"
@@ -615,7 +623,7 @@ packages:
     source: hosted
     version: "2.0.1"
   share_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: share_plus
       sha256: b2961506569e28948d75ec346c28775bb111986bb69dc6a20754a457e3d97fa0
@@ -631,7 +639,7 @@ packages:
     source: hosted
     version: "6.0.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
@@ -692,7 +700,7 @@ packages:
     source: sdk
     version: "0.0.0"
   sleek_circular_slider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: sleek_circular_slider
       sha256: "89c7d0d37befc9818a2b53ef6ff126c43b70485dabb189b734d46106db190931"
@@ -751,10 +759,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -872,12 +880,12 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vibration:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: vibration
       sha256: "804ee8f9628f31ee71fbe6137a2bc6206a64e101ec22cd9dd6d3a7dc0272591b"
@@ -949,5 +957,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.8.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,18 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
+#include <share_plus/share_plus_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
+  SharePlusWindowsPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,10 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   permission_handler_windows
+  share_plus
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
I replaced the deprecated code to fix the build.

## Summary by Sourcery

Replace deprecated radio and switch widget properties to restore build compatibility

Bug Fixes:
- Fix build failures caused by deprecated Radio and Switch members

Enhancements:
- Refactor Radio and RadioListTile usage to wrap them in RadioGroup with groupValue and onChanged handlers
- Update Switch widgets to use activeThumbColor instead of deprecated activeColor