### PR TITLE
fix: build fails due to deprecated member use

### DIFF
--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -143,7 +143,7 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                                             Transform.scale(
                                               scale: 0.75,
                                               child: Switch(
-                                                activeColor:
+                                                activeThumbColor:
                                                     multimeterBorderBlack,
                                                 value: provider.isSwitchChecked,
                                                 onChanged: (bool value) {},

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -42,11 +42,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
               style:
                   const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           children: [
-            RadioListTile<bool>(
-              title: Text(appLocalizations.txtFormat),
-              value: true,
+            RadioGroup(
               groupValue: isTxtFormatSelected,
-              activeColor: primaryRed,
               onChanged: (bool? value) {
                 setState(
                   () {
@@ -58,12 +55,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   },
                 );
               },
+              child: RadioListTile<bool>(
+                  title: Text(appLocalizations.txtFormat),
+                  value: true,
+                  activeColor: primaryRed),
             ),
-            RadioListTile<bool>(
-              title: Text(appLocalizations.csvFormat),
-              value: true,
+            RadioGroup(
               groupValue: isCsvFormatSelected,
-              activeColor: primaryRed,
               onChanged: (bool? value) {
                 setState(
                   () {
@@ -75,6 +73,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   },
                 );
               },
+              child: RadioListTile<bool>(
+                title: Text(appLocalizations.csvFormat),
+                value: true,
+                activeColor: primaryRed,
+              ),
             ),
             Align(
               alignment: Alignment.bottomRight,

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -243,13 +243,9 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                   mainAxisSize: MainAxisSize.min,
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    Radio<bool>(
-                      activeColor: radioButtonActiveColor,
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      value: true,
+                    RadioGroup(
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
-                      toggleable: true,
                       onChanged: (bool? value) {
                         setState(
                           () {
@@ -276,6 +272,12 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                           },
                         );
                       },
+                      child: Radio<bool>(
+                        activeColor: radioButtonActiveColor,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        value: true,
+                        toggleable: true,
+                      ),
                     ),
                     Text(
                       appLocalizations.inBuiltMic,
@@ -286,12 +288,8 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                         fontStyle: FontStyle.normal,
                       ),
                     ),
-                    Radio<bool>(
-                      activeColor: radioButtonActiveColor,
-                      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      value: true,
+                    RadioGroup(
                       groupValue: oscilloscopeStateProvider.isMICSelected,
-                      toggleable: true,
                       onChanged: (bool? value) {
                         setState(
                           () {
@@ -309,6 +307,12 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                           },
                         );
                       },
+                      child: Radio<bool>(
+                        activeColor: radioButtonActiveColor,
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        value: true,
+                        toggleable: true,
+                      ),
                     ),
                     Text(
                       appLocalizations.pslabMic,

--- a/lib/view/widgets/config_widgets.dart
+++ b/lib/view/widgets/config_widgets.dart
@@ -155,19 +155,20 @@ class ConfigDropdownItem extends StatelessWidget {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: options.map((option) {
-              return RadioListTile<String>(
-                title: Text(option.displayName),
-                value: option.value,
-                groupValue: selectedValue,
-                onChanged: (String? value) {
-                  if (value != null) {
-                    onChanged(value);
-                    Navigator.of(context).pop();
-                  }
-                },
-                activeColor: primaryRed,
-                contentPadding: EdgeInsets.zero,
-              );
+              return RadioGroup(
+                  groupValue: selectedValue,
+                  onChanged: (String? value) {
+                    if (value != null) {
+                      onChanged(value);
+                      Navigator.of(context).pop();
+                    }
+                  },
+                  child: RadioListTile<String>(
+                    title: Text(option.displayName),
+                    value: option.value,
+                    activeColor: primaryRed,
+                    contentPadding: EdgeInsets.zero,
+                  ));
             }).toList(),
           ),
           actions: [

--- a/lib/view/widgets/robotic_arm_controls.dart
+++ b/lib/view/widgets/robotic_arm_controls.dart
@@ -178,13 +178,15 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Radio<String>(
-                                  value: appLocalizations.duration1Min,
+                                RadioGroup(
                                   groupValue: provider.selectedDuration,
-                                  activeColor: primaryRed,
                                   onChanged: (value) {
                                     provider.setSelectedDuration(value!);
                                   },
+                                  child: Radio<String>(
+                                    value: appLocalizations.duration1Min,
+                                    activeColor: primaryRed,
+                                  ),
                                 ),
                                 Text(
                                   appLocalizations.duration1Min,
@@ -198,13 +200,15 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.center,
                               children: [
-                                Radio<String>(
-                                  value: appLocalizations.duration2Min,
+                                RadioGroup(
                                   groupValue: provider.selectedDuration,
-                                  activeColor: primaryRed,
                                   onChanged: (value) {
                                     provider.setSelectedDuration(value!);
                                   },
+                                  child: Radio<String>(
+                                    value: appLocalizations.duration2Min,
+                                    activeColor: primaryRed,
+                                  ),
                                 ),
                                 Text(
                                   appLocalizations.duration2Min,
@@ -358,10 +362,8 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Radio<String>(
-                            value: appLocalizations.frequency50Hz,
+                          RadioGroup(
                             groupValue: provider.selectedFrequency,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               if (provider.isPlaying) {
                                 ScaffoldMessenger.of(context).showSnackBar(
@@ -377,6 +379,10 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                               }
                               provider.setSelectedFrequency(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.frequency50Hz,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.frequency50Hz,
@@ -384,10 +390,8 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                                 color: Colors.black, fontSize: 12),
                           ),
                           const SizedBox(width: 16),
-                          Radio<String>(
-                            value: appLocalizations.frequency100Hz,
+                          RadioGroup(
                             groupValue: provider.selectedFrequency,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               if (provider.isPlaying) {
                                 ScaffoldMessenger.of(context).showSnackBar(
@@ -403,6 +407,10 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                               }
                               provider.setSelectedFrequency(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.frequency100Hz,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.frequency100Hz,
@@ -449,26 +457,30 @@ class _RoboticArmControlsState extends State<RoboticArmControls> {
                       child: Row(
                         mainAxisAlignment: MainAxisAlignment.center,
                         children: [
-                          Radio<String>(
-                            value: appLocalizations.angle180,
+                          RadioGroup(
                             groupValue: provider.selectedMaxAngle,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               provider.setSelectedMaxAngle(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.angle180,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.angle180,
                             style: TextStyle(color: Colors.black, fontSize: 12),
                           ),
                           const SizedBox(width: 16),
-                          Radio<String>(
-                            value: appLocalizations.angle360,
+                          RadioGroup(
                             groupValue: provider.selectedMaxAngle,
-                            activeColor: primaryRed,
                             onChanged: (value) {
                               provider.setSelectedMaxAngle(value!);
                             },
+                            child: Radio<String>(
+                              value: appLocalizations.angle360,
+                              activeColor: primaryRed,
+                            ),
                           ),
                           Text(
                             appLocalizations.angle360,


### PR DESCRIPTION
fixes: #2845

Replaced deprecated code to fix warnings which caused build to fail.

## Summary by Sourcery

Replace deprecated Flutter radio and switch properties to fix build errors

Bug Fixes:
- Fix build failures caused by deprecated member usage

Enhancements:
- Wrap Radio and RadioListTile widgets in new RadioGroup across robotic arm controls, config dropdown, channel parameters, and settings screens
- Update Switch.activeColor to activeThumbColor in the multimeter screen