### PR TITLE
chore: push only release APKs to apk branch

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -105,8 +105,8 @@ jobs:
 
           echo "Copying new build files"
 
-          find ../build/app/outputs/flutter-apk -type f \( -name '*.apk' -o -name '*.aab' \) -exec cp -v {} . \;
-          find ../build/app/outputs/bundle -type f \( -name '*.apk' -o -name '*.aab' \) -exec cp -v {} . \;
+          find ../build/app/outputs/flutter-apk -type f \( -name '*release.apk' -o -name '*release.aab' \) -exec cp -v {} . \;
+          find ../build/app/outputs/bundle -type f \( -name '*release.apk' -o -name '*release.aab' \) -exec cp -v {} . \;
 
           ls
 


### PR DESCRIPTION
@marcnause To fix the failing CD.

## Summary by Sourcery

CI:
- Restrict artifact copy commands in push-event.yml to match only '*release.apk' and '*release.aab'