### PR TITLE
fix: initialization of BoardStateProvider

### DIFF
--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -20,6 +20,7 @@ class BoardStateProvider extends ChangeNotifier {
   int pslabVersion = 0;
   late String exportFormat;
   bool autoStart = true;
+  bool _isProcessing = false;
 
   BoardStateProvider() {
     scienceLabCommon = getIt.get<ScienceLabCommon>();
@@ -27,16 +28,22 @@ class BoardStateProvider extends ChangeNotifier {
   }
 
   Future<void> initialize() async {
+    if (_isProcessing) return;
+    _isProcessing = true;
     await scienceLabCommon.initialize();
     pslabIsConnected = await scienceLabCommon.openDevice();
     setPSLabVersionIDs();
+    _isProcessing = false;
     if (autoStart) {
       UsbSerial.usbEventStream?.listen(
         (UsbEvent usbEvent) async {
           if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
+            if (_isProcessing) return;
+            _isProcessing = true;
             if (await attemptToConnectPSLab()) {
               pslabIsConnected = await scienceLabCommon.openDevice();
               setPSLabVersionIDs();
+              _isProcessing = false;
             }
           } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
               !scienceLabCommon.isWiFiConnected()) {


### PR DESCRIPTION
Fixes #2849.

## Screenshots / Recordings

https://github.com/user-attachments/assets/0fdc4a66-a206-4ea1-a720-b6bba0121088

## Summary by Sourcery

Add processing guard to BoardStateProvider to prevent overlapping initialization and USB connection attempts

Bug Fixes:
- Introduce private _isProcessing flag to prevent concurrent calls to initialize()
- Apply the same guard to the USB attached event handler to avoid overlapping connection attempts