### PR TITLE
fix: orientation not resetting

### DIFF
--- a/lib/view/robotic_arm_screen.dart
+++ b/lib/view/robotic_arm_screen.dart
@@ -50,6 +50,12 @@ class _RoboticArmScreenState extends State<RoboticArmScreen> {
     };
   }
 
+  @override
+  void dispose() {
+    provider.disposeResources();
+    super.dispose();
+  }
+
   void _hideInstrumentGuide() {
     setState(() {
       _showGuide = false;


### PR DESCRIPTION
Fixes #2831 

### Changes  
- Added a `dispose()` method in `robotic_arm_screen.dart`.  
- Inside `dispose()`, called `provider.disposeResources()` so that the screen’s orientation is reset properly.

## Summary by Sourcery

Bug Fixes:
- Add a dispose method to RoboticArmScreen to call provider.disposeResources and reset orientation