### PR TITLE
fix: multimeter knob UI

### DIFF
--- a/lib/view/widgets/multimeter_knob.dart
+++ b/lib/view/widgets/multimeter_knob.dart
@@ -12,7 +12,7 @@ class InnerDialPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final center = Offset(size.width / 2, size.height / 2);
-    final radius = min(size.width / 2, size.height / 2) * 0.7;
+    final radius = 105.r;
 
     final paint = Paint()
       ..color = multimeterBorderBlack
@@ -32,7 +32,7 @@ class InnerDialFillPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final center = Offset(size.width / 2, size.height / 2);
-    final radius = min(size.width / 2, size.height / 2) * 0.7;
+    final radius = 105.r;
 
     final fillPaint = Paint()
       ..color = innerDialFillColor
@@ -59,13 +59,13 @@ class InnerPointerPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final center = Offset(size.width / 2, size.height / 2);
-    final radius = min(size.width / 2, size.height / 2) * 0.5;
+    final radius = 105.r;
 
     final pointerAngle = -pi / 2 + (2 * pi * (value / max));
 
     final pointerPaint = Paint()
       ..color = color
-      ..strokeCap = StrokeCap.square
+      ..strokeCap = StrokeCap.butt
       ..strokeWidth = 30;
 
     final pointerStart = Offset(
@@ -82,12 +82,12 @@ class InnerPointerPainter extends CustomPainter {
       ..strokeCap = StrokeCap.square
       ..strokeWidth = 10;
     final pointerStartInner = Offset(
-      center.dx + radius * 1.1 * cos(pointerAngle),
-      center.dy + radius * 1.1 * sin(pointerAngle),
+      center.dx + radius * 1.0 * cos(pointerAngle),
+      center.dy + radius * 1.0 * sin(pointerAngle),
     );
     final pointerEndInner = Offset(
-      center.dx + radius * 0.9 * cos(pointerAngle),
-      center.dy + radius * 0.9 * sin(pointerAngle),
+      center.dx + radius * 0.77 * cos(pointerAngle),
+      center.dy + radius * 0.77 * sin(pointerAngle),
     );
     canvas.drawLine(pointerStart, pointerEnd, pointerPaint);
     canvas.drawLine(pointerStartInner, pointerEndInner, pointerPaintInner);
@@ -271,14 +271,8 @@ class _MultimeterKnobState extends State<MultimeterKnob> {
                   color: pointerColor,
                 ),
                 child: SizedBox(
-                  width: constraints.maxWidth < 600 ||
-                          constraints.maxWidth > constraints.maxHeight
-                      ? 360.w
-                      : 385.w,
-                  height: constraints.maxWidth < 600 ||
-                          constraints.maxWidth > constraints.maxHeight
-                      ? 360.h
-                      : 385.h,
+                  width: 300.w,
+                  height: 300.h,
                 ),
               ),
             ),


### PR DESCRIPTION
Fixes the multimeter knob UI which was still rendered incorrectly on some screen sizes.

## Screenshots / Recordings:
<img width="1600" height="2560" alt="Screenshot_1755755859" src="https://github.com/user-attachments/assets/f0b73da8-a6c4-4fd6-96e3-31741f8832e3" />
<img width="1080" height="2400" alt="Screenshot_1755755951" src="https://github.com/user-attachments/assets/3db3c4c3-252e-4c7b-bc4e-6e96b8432193" />

## Summary by Sourcery

Standardize multimeter knob UI dimensions and pointer styling to ensure consistent rendering across screen sizes

Bug Fixes:
- Use fixed responsive radius (105.r) for inner dial and fill painters instead of dynamic size-based calculation
- Change pointer stroke cap to butt and adjust outer and inner pointer line multipliers for correct positioning
- Standardize knob widget dimensions to 300.w by 300.h for consistent layout