### PR TITLE
chore: fix screenshot workflows

### DIFF
--- a/.github/actions/screenshot-ipad/action.yml
+++ b/.github/actions/screenshot-ipad/action.yml
@@ -1,0 +1,62 @@
+name: "iPad Screenshots Workflow"
+
+inputs:
+  IPAD_DEVICE_MODEL:
+    description: 'Model of the iPad device to be used when running tests'
+    required: false
+    default: iPad Pro 13-inch (M4)
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        cache: true
+
+    - name: Update Podfile
+      shell: bash
+      run: |
+        cd ./iOS
+        flutter pub get
+        pod install --repo-update
+
+    - name: Create iPad Simulator
+      id: ipad_sim
+      uses: futureware-tech/simulator-action@v4
+      with:
+        model: ${{ inputs.IPAD_DEVICE_MODEL }}
+        wait_for_boot: true
+
+    - name: Capture iPad Screenshots
+      shell: bash
+      run: |
+        DEVICE_NAME="${{ inputs.IPAD_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ steps.ipad_sim.outputs.udid }}"
+
+    - name: Update Fastlane Metadata
+      if: ${{ github.event_name == 'push' }}
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
+        cd ./iOS
+        git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+        cd fastlane
+        
+        rm -rf screenshots/*
+        cp -r ../../screenshots/. screenshots/
+        
+        # Force push to fastlane branch
+        git checkout --orphan temporary
+        git add --all .
+        git commit -am "[Auto] Update screenshots ($(date +%Y-%m-%d.%H:%M:%S))"
+        git branch -D fastlane-ios
+        git branch -m fastlane-ios
+        git push --force origin fastlane-ios
+
+    - name: Upload Screenshots
+      uses: actions/upload-artifact@v4
+      with:
+        name: iPad Screenshots
+        path: screenshots/*

--- a/.github/actions/screenshot-iphone/action.yml
+++ b/.github/actions/screenshot-iphone/action.yml
@@ -1,14 +1,10 @@
-name: "iOS Screenshots Workflow"
+name: "iPhone Screenshots Workflow"
 
 inputs:
   IPHONE_DEVICE_MODEL:
     description: 'Model of the iPhone device to be used when running tests'
     required: false
     default: iPhone 16 Pro Max
-  IPAD_DEVICE_MODEL:
-    description: 'Model of the iPad device to be used when running tests'
-    required: false
-    default: iPad Pro 13-inch (M4)
 
 runs:
   using: "composite"
@@ -26,26 +22,16 @@ runs:
         pod install --repo-update
 
     - name: Create iPhone Simulator
+      id: iphone_sim
       uses: futureware-tech/simulator-action@v4
       with:
         model: ${{ inputs.IPHONE_DEVICE_MODEL }}
         wait_for_boot: true
 
-    - name: Create iPad Simulator
-      uses: futureware-tech/simulator-action@v4
-      with:
-        model: ${{ inputs.IPAD_DEVICE_MODEL }}
-        wait_for_boot: true
-
     - name: Capture iPhone Screenshots
       shell: bash
       run: |
-        DEVICE_NAME="${{ inputs.IPHONE_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPHONE_DEVICE_MODEL }}"
-
-    - name: Capture iPad Screenshots
-      shell: bash
-      run: |
-        DEVICE_NAME="${{ inputs.IPAD_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ inputs.IPAD_DEVICE_MODEL }}"
+        DEVICE_NAME="${{ inputs.IPHONE_DEVICE_MODEL }}" flutter drive --driver=test_integration/test_driver.dart --target=test_integration/screenshots.dart -d "${{ steps.iphone_sim.outputs.udid }}"
 
     - name: Update Fastlane Metadata
       if: ${{ github.event_name == 'push' }}
@@ -72,5 +58,5 @@ runs:
     - name: Upload Screenshots
       uses: actions/upload-artifact@v4
       with:
-        name: iOS Screenshots
+        name: iPhone Screenshots
         path: screenshots/*

--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -47,17 +47,29 @@ jobs:
 
             fs.writeFileSync('${{github.workspace}}/androidScreenshots.zip', Buffer.from(downloadAndroidScreenshots.data));
 
-            var iosScreenshots = artifacts.data.artifacts.filter((artifact) => {
-              return artifact.name == "iOS Screenshots"
+            var iPadScreenshots = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "iPad Screenshots"
             })[0];
-            var downloadIosScreenshots = await github.rest.actions.downloadArtifact({
+            var downloadiPadScreenshots = await github.rest.actions.downloadArtifact({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               artifact_id: iosScreenshots.id,
+               artifact_id: iPadScreenshots.id,
                archive_format: 'zip',
             });
 
-            fs.writeFileSync('${{github.workspace}}/iosScreenshots.zip', Buffer.from(downloadIosScreenshots.data));
+            fs.writeFileSync('${{github.workspace}}/iPadScreenshots.zip', Buffer.from(downloadiPadScreenshots.data));
+
+            var iPhoneScreenshots = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "iPhone Screenshots"
+            })[0];
+            var downloadiPhoneScreenshots = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: iPhoneScreenshots.id,
+               archive_format: 'zip',
+            });
+
+            fs.writeFileSync('${{github.workspace}}/iPhoneScreenshots.zip', Buffer.from(downloadiPhoneScreenshots.data));
 
       - name: Unzip Artifacts
         shell: bash
@@ -65,8 +77,9 @@ jobs:
           unzip pr.zip
           mkdir screenshots
           unzip androidScreenshots.zip -d screenshots/
-          unzip iosScreenshots.zip -d screenshots/
-        
+          unzip iPadScreenshots.zip -d screenshots/
+          unzip iPhoneScreenshots.zip -d screenshots/
+
       - name: Fetch PR Number
         id: fetch-pr-number
         uses: actions/github-script@v7
@@ -135,6 +148,8 @@ jobs:
             var statusText = `Build successful. APKs to test: ${artifact_url}.`;
 
             var androidScreenshots = `
+            <details>
+            <summary>Android Screenshots</summary>
             <table>
               <tr>
                 <td><img src="https://github.com/${owner}/${repo}/blob/pr-screenshots/${issue_number}_Pixel_6-1_instruments_screen.png?raw=true" width="1080"/></td>
@@ -150,9 +165,12 @@ jobs:
                 </td>
               </tr>
             </table>
+            </details>
             `;
 
             var iPhoneScreenshots = `
+            <details>
+            <summary>iPhone Screenshots</summary>
             <table>
               <tr>
                 <td><img src="https://github.com/${owner}/${repo}/blob/pr-screenshots/${issue_number}_iPhone_16_Pro_Max-1_instruments_screen.png?raw=true" width="1080"/></td>
@@ -168,9 +186,12 @@ jobs:
                 </td>
               </tr>
             </table>
+            </details>
             `;
 
             var iPadScreenshots = `
+            <details>
+            <summary>iPad Screenshots</summary>
             <table>
               <tr>
                 <td><img src="https://github.com/${owner}/${repo}/blob/pr-screenshots/${issue_number}_iPad_Pro_13-inch_(M4)-1_instruments_screen.png?raw=true" width="1080"/></td>
@@ -186,19 +207,16 @@ jobs:
                 </td>
               </tr>
             </table>
+            </details>
             `;
 
             const body = `
             ## Build Status
             ${statusText}
 
-            ## Screenshots (Android)
+            ## Screenshots
             ${androidScreenshots}
-
-            ## Screenshots (iPhone)
             ${iPhoneScreenshots}
-
-            ## Screenshots (iPad)
             ${iPadScreenshots}
             `;
             
@@ -245,13 +263,7 @@ jobs:
             ## Build Status
             _Build workflow failed. Please check the logs for more information._
 
-            ## Screenshots (Android)
-            _Not able to fetch screenshots._
-
-            ## Screenshots (iPhone)
-            _Not able to fetch screenshots._
-
-            ## Screenshots (iPad)
+            ## Screenshots
             _Not able to fetch screenshots._
             `;
             

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches: ["flutter"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   ANDROID_EMULATOR_API: 34
   ANDROID_EMULATOR_ARCH: x86_64
-  IPHONE_DEVICE_MODEL: iPhone 16
-  IPAD_DEVICE_MODEL: iPad (10th generation)
+  IPHONE_DEVICE_MODEL: iPhone 16 Pro Max
+  IPAD_DEVICE_MODEL: iPad Pro 13-inch (M4)
 
 jobs:
   common:
@@ -58,6 +62,7 @@ jobs:
   screenshots-android:
     name: Screenshots (Android)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 
@@ -67,9 +72,10 @@ jobs:
           ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
           ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
 
-  screenshots-ios:
-    name: Screenshots (iOS)
+  screenshots-iphone:
+    name: Screenshots (iPhone)
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1.6.0
@@ -78,11 +84,24 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: List available simulators
-        run: xcrun simctl list devices
-
-      - name: iOS Screenshot Workflow
-        uses: ./.github/actions/screenshot-ios
+      - name: iPhone Screenshot Workflow
+        uses: ./.github/actions/screenshot-iphone
         with:
           IPHONE_DEVICE_MODEL: ${{ env.IPHONE_DEVICE_MODEL }}
+  
+  screenshots-ipad:
+    name: Screenshots (iPad)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest-stable
+
+      - uses: actions/checkout@v4
+
+      - name: iPad Screenshot Workflow
+        uses: ./.github/actions/screenshot-ipad
+        with:
           IPAD_DEVICE_MODEL: ${{ env.IPAD_DEVICE_MODEL }}

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -7,8 +7,8 @@ on:
 env:
   ANDROID_EMULATOR_API: 34
   ANDROID_EMULATOR_ARCH: x86_64
-  IPHONE_DEVICE_MODEL: iPhone 16
-  IPAD_DEVICE_MODEL: iPad (10th generation)
+  IPHONE_DEVICE_MODEL: iPhone 16 Pro Max
+  IPAD_DEVICE_MODEL: iPad Pro 13-inch (M4)
 
 jobs:
   common:
@@ -202,31 +202,36 @@ jobs:
         with:
           version: ${{ needs.common.outputs.VERSION_NAME }}
 
-  screenshots-android:
-    name: Screenshots (Android)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Android Screenshot Workflow
-        uses: ./.github/actions/screenshot-android
-        with:
-          ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
-          ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
-
-  screenshots-ios:
-    name: Screenshots (iOS)
+  screenshots-iphone:
+    name: Screenshots (iPhone)
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: latest-stable
 
-      - name: iOS Screenshot Workflow
-        uses: ./.github/actions/screenshot-ios
+      - uses: actions/checkout@v4
+
+      - name: iPhone Screenshot Workflow
+        uses: ./.github/actions/screenshot-iphone
         with:
           IPHONE_DEVICE_MODEL: ${{ env.IPHONE_DEVICE_MODEL }}
+  
+  screenshots-ipad:
+    name: Screenshots (iPad)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest-stable
+
+      - uses: actions/checkout@v4
+
+      - name: iPad Screenshot Workflow
+        uses: ./.github/actions/screenshot-ipad
+        with:
           IPAD_DEVICE_MODEL: ${{ env.IPAD_DEVICE_MODEL }}


### PR DESCRIPTION
## Summary by Sourcery

Revamp screenshot workflows by splitting iPhone and iPad capture into separate jobs and actions, updating pull-request comment logic to fetch and display both device artifacts, and adding concurrency control to the PR workflow.

Enhancements:
- Extract iPad screenshot logic into a new composite action and rename the iOS action to an iPhone-specific action
- Update push-event and pull-request workflows to run distinct Android, iPhone, and iPad screenshot jobs with appropriate runners, timeouts, and Xcode setup
- Revise pull-request-comment workflow to download, unzip, and display iPhone and iPad screenshots in collapsible sections under a unified Screenshots header
- Introduce concurrency settings in the pull-request workflow to cancel outdated runs on new commits