### PR TITLE
chore: prepare for release

### DIFF
--- a/.github/actions/screenshot-ipad/action.yml
+++ b/.github/actions/screenshot-ipad/action.yml
@@ -44,7 +44,7 @@ runs:
         git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
         cd fastlane
         
-        rm -rf screenshots/*
+        rm -rf screenshots/iPad*
         cp -r ../../screenshots/. screenshots/
         
         # Force push to fastlane branch

--- a/.github/actions/screenshot-iphone/action.yml
+++ b/.github/actions/screenshot-iphone/action.yml
@@ -44,7 +44,7 @@ runs:
         git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
         cd fastlane
         
-        rm -rf screenshots/*
+        rm -rf screenshots/iPhone*
         cp -r ../../screenshots/. screenshots/
         
         # Force push to fastlane branch

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -62,7 +62,7 @@ jobs:
   screenshots-android:
     name: Screenshots (Android)
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -133,11 +133,11 @@ jobs:
           git branch -m apk
           git push --force origin apk
 
-      - name: Update app in Closed Testing track
+      - name: Update app in Open Testing track
         if: ${{ github.repository == 'fossasia/pslab-app' }}
         run: |
           git clone --branch=fastlane-android --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
-          fastlane uploadToClosedTesting
+          fastlane uploadToOpenTesting
           if [[ $? -ne 0 ]]; then
               exit 1
           fi
@@ -201,6 +201,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           version: ${{ needs.common.outputs.VERSION_NAME }}
+
+  screenshots-android:
+    name: Screenshots (Android)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Android Screenshot Workflow
+        uses: ./.github/actions/screenshot-android
+        with:
+          ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
+          ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
 
   screenshots-iphone:
     name: Screenshots (iPhone)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,93 @@
+name: Release
+
+on:
+  release:
+    types: [ published ]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release:
+    name: Release
+    if: ${{ github.repository == 'fossasia/pslab-app' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download repository
+        uses: actions/checkout@v4
+
+      - name: Prepare Secrets (Android)
+        env:
+          ENCRYPTED_F10B5E0E5262_IV: ${{ secrets.ENCRYPTED_F10B5E0E5262_IV }}
+          ENCRYPTED_F10B5E0E5262_KEY: ${{ secrets.ENCRYPTED_F10B5E0E5262_KEY }}
+        run: |
+          bash scripts/prep-android-key.sh
+
+      - name: Prepare Secrets (iOS)
+        if: ${{ github.repository == 'fossasia/pslab-app' }}
+        env:
+          ENCRYPTED_IOS_IV: ${{ secrets.ENCRYPTED_IOS_IV }}
+          ENCRYPTED_IOS_KEY: ${{ secrets.ENCRYPTED_IOS_KEY }}
+        run: |
+          bash scripts/prep-ios-key.sh
+
+      - name: Download Assets
+        id: download-assets
+        run: |
+          gh release download ${{ github.event.release.tag_name }} --pattern '*.txt'
+          read -r version_code < versionCode.txt
+          echo "VERSION_CODE=$version_code" >> $GITHUB_OUTPUT
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update Fastlane Metadata (Android)
+        run: |
+          cd ./android
+          git clone --branch=fastlane-android --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+          cd fastlane
+          
+          printf "%s" "${{ github.event.release.body }}" > "metadata/android/en-US/changelogs/${{ steps.download-assets.outputs.VERSION_CODE }}.txt"
+          
+          # Force push to fastlane branch
+          git checkout --orphan temporary
+          git add --all .
+          git commit -am "[Auto] Update changelogs for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+          git branch -D fastlane-android
+          git branch -m fastlane-android
+          git push --force origin fastlane-android
+
+      - name: Push version to production (Android)
+        run: |
+          cd ./android
+          fastlane promoteToProduction version_code:${{ steps.download-assets.outputs.VERSION_CODE }}
+          if [[ $? -ne 0 ]]; then
+              exit 1
+          fi
+
+      - name: Update Fastlane Metadata (iOS)
+        run: |
+          cd ./iOS
+          git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+          cd fastlane
+          
+          printf "%s" "${{ github.event.release.body }}" > "metadata/en-US/release_notes.txt"
+          
+          # Force push to fastlane branch
+          git checkout --orphan temporary
+          git add --all .
+          git commit -am "[Auto] Update changelogs for versionCode: ${{ steps.download-assets.outputs.VERSION_CODE }} ($(date +%Y-%m-%d.%H:%M:%S))"
+          git branch -D fastlane-ios
+          git branch -m fastlane-ios
+          git push --force origin fastlane-ios
+
+      - name: Push version to production (iOS)
+        run: |
+          cd ./iOS
+          VERSION_TAG="${{ github.event.release.tag_name }}"
+          CLEAN_VERSION="${VERSION_TAG#v}"
+          fastlane promoteToProduction build_number:${{ steps.download-assets.outputs.VERSION_CODE }} version_name:${CLEAN_VERSION}
+          if [[ $? -ne 0 ]]; then
+              exit 1
+          fi    

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -66,7 +66,11 @@ void main() async {
 
       final infoIcon = find.byIcon(Icons.info);
       await tester.tap(infoIcon);
-      await tester.pump(const Duration(seconds: 5));
+      int i = 0;
+      while (i < 10) {
+        await tester.pump(const Duration(seconds: 1));
+        i++;
+      }
       await binding.takeScreenshot('3_accelerometer');
 
       final hideGuideText = find.text('Hide Guide');


### PR DESCRIPTION
This PR does the following:

1. We start pushing the _flutter_ app to beta track on the Play Store on every push, replacing the native Android app in the beta track.
2. Add a release workflow to our repository.

## Summary by Sourcery

Automate release process by adding a dedicated GitHub Actions workflow triggered on release publishes and switch beta distribution to open testing.

Enhancements:
- Deploy the Flutter app to the Play Store open testing track instead of closed testing via fastlane
- Automatically update Fastlane metadata and changelogs for Android and iOS based on GitHub release notes

CI:
- Add release.yml workflow that decrypts keys, downloads release assets, updates metadata branches, and promotes builds on release events

Deployment:
- Automatically promote new Android and iOS versions to production tracks using fastlane