### PR TITLE
fix: bug fixes & enhancements

### DIFF
--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -359,6 +359,7 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                               crossAxisCount: 2,
                               childAspectRatio: 2.5,
                             ),
+                            itemCount: _filteredIndices.length,
                             itemBuilder: (context, index) {
                               final int originalIndex = _filteredIndices[index];
                               return GestureDetector(

--- a/lib/view/widgets/guide_widget.dart
+++ b/lib/view/widgets/guide_widget.dart
@@ -140,8 +140,11 @@ class _InstrumentOverviewDrawerState extends State<InstrumentOverviewDrawer>
                         ),
                       ),
                       Flexible(
-                        child: LayoutBuilder(builder: (context, constraints) {
-                          return SingleChildScrollView(
+                        child: InteractiveViewer(
+                          boundaryMargin: EdgeInsets.zero,
+                          minScale: 1.0,
+                          maxScale: 4.0,
+                          child: SingleChildScrollView(
                             padding: const EdgeInsets.all(16.0),
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
@@ -159,8 +162,8 @@ class _InstrumentOverviewDrawerState extends State<InstrumentOverviewDrawer>
                                 const SizedBox(height: 20.0),
                               ],
                             ),
-                          );
-                        }),
+                          ),
+                        ),
                       ),
                     ],
                   ),

--- a/lib/view/widgets/robotic_arm_summary.dart
+++ b/lib/view/widgets/robotic_arm_summary.dart
@@ -100,7 +100,7 @@ class _PlaybackSummaryDialogState extends State<PlaybackSummaryDialog> {
                                   return DropdownMenuItem(
                                     value: i,
                                     child: Text(
-                                        '$appLocalizations.servo ${i + 1}',
+                                        '${appLocalizations.servo} ${i + 1}',
                                         style: const TextStyle(fontSize: 10)),
                                   );
                                 }),
@@ -118,17 +118,17 @@ class _PlaybackSummaryDialogState extends State<PlaybackSummaryDialog> {
                                 icon: Icons.show_chart,
                                 label: appLocalizations.avgAngleLabel,
                                 value:
-                                    '${avg.toStringAsFixed(1)}$appLocalizations.degreeSymbol'),
+                                    '${avg.toStringAsFixed(1)}${appLocalizations.degreeSymbol}'),
                             _StatCard(
                                 icon: Icons.arrow_upward,
                                 label: appLocalizations.maxAngleLabel,
                                 value:
-                                    '${max.toStringAsFixed(1)}$appLocalizations.degreeSymbol'),
+                                    '${max.toStringAsFixed(1)}${appLocalizations.degreeSymbol}'),
                             _StatCard(
                                 icon: Icons.arrow_downward,
                                 label: appLocalizations.minAngleLabel,
                                 value:
-                                    '${min.toStringAsFixed(1)}$appLocalizations.degreeSymbol'),
+                                    '${min.toStringAsFixed(1)}${appLocalizations.degreeSymbol}'),
                           ],
                         ),
                         const SizedBox(height: 8),
@@ -139,17 +139,17 @@ class _PlaybackSummaryDialogState extends State<PlaybackSummaryDialog> {
                                 icon: Icons.timeline,
                                 label: appLocalizations.avgDutyLabel,
                                 value:
-                                    '${avgDuty.toStringAsFixed(1)}$appLocalizations.percentage'),
+                                    '${avgDuty.toStringAsFixed(1)}${appLocalizations.percentage}'),
                             _StatCard(
                                 icon: Icons.trending_up,
                                 label: appLocalizations.maxDutyLabel,
                                 value:
-                                    '${maxDuty.toStringAsFixed(1)}$appLocalizations.percentage'),
+                                    '${maxDuty.toStringAsFixed(1)}${appLocalizations.percentage}'),
                             _StatCard(
                                 icon: Icons.low_priority,
                                 label: appLocalizations.minDutyLabel,
                                 value:
-                                    '${minDuty.toStringAsFixed(1)}$appLocalizations.percentage'),
+                                    '${minDuty.toStringAsFixed(1)}${appLocalizations.percentage}'),
                           ],
                         ),
                       ],


### PR DESCRIPTION
### Changes
- Added zooming support in the in-app instrument guide (similar to the previous app).  
- Added item count handling to prevent out-of-bound index crash in the Windows app.  
- Corrected minor string interpolation issue.

### Screenshots/Recording
1.Crash

<img width="1919" height="1015" alt="Screenshot 2025-08-24 163515" src="https://github.com/user-attachments/assets/e0eeabcd-869f-47dc-b4da-03f67d5e151a" />

2.Zoom
[Zooming.webm](https://github.com/user-attachments/assets/5bf81f13-4ae2-4370-b2a1-0e2b6ff10396)

## Summary by Sourcery

Enable zooming in the instrument guide, enforce itemCount to avoid index errors in the instruments grid, and fix string interpolation in the playback summary dialog.

New Features:
- Add zoom support to the in-app instrument guide via InteractiveViewer

Bug Fixes:
- Prevent out-of-bound index crash in instruments screen by specifying itemCount in GridView

Enhancements:
- Correct minor string interpolation issues in robotic arm summary stats labels