### PR TITLE
chore: selectively update versioning data

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -34,12 +34,24 @@ jobs:
 
           # Read and increment version name
           IFS='.' read -r major minor patch < versionName.txt
-          current_patch_version_name="$major.$minor.$patch"
-          echo "VERSION_NAME=$current_patch_version_name" >> $GITHUB_OUTPUT
+
+          if [[ "$commit_message" =~ ^feat: ]]; then
+            next_minor=$((minor + 1))
+            next_patch=0
+          else
+            next_minor=$((minor))
+            next_patch=$((patch + 1))
+          fi
+          next_version_name="$major.$next_minor.$next_patch"
+          echo "VERSION_NAME=$next_version_name" >> $GITHUB_OUTPUT
+          echo "$next_version_name" > versionName.txt
+
+          # Read and increment version code
+          read -r version_code < versionCode.txt
           
-          next_patch=$((patch + 1))
-          next_patch_version_name="$major.$minor.$next_patch"
-          echo "$next_patch_version_name" > versionName.txt
+          new_version_code=$((version_code + 1))
+          echo "VERSION_CODE=$new_version_code" >> $GITHUB_OUTPUT
+          echo "$new_version_code" > versionCode.txt
 
           # Read and increment version code
           read -r version_code < versionCode.txt


### PR DESCRIPTION
Update the `versionName` selectively according to the following rules:
1. For feature additions (commit message contains "feat:"), we update the minor version and reset the patch version to 0.
2. For all other commit messages, we just update the patch version.

[badgemagic-app](https://github.com/fossasia/badgemagic-app) follows these same rules.

## Summary by Sourcery

Implement selective version bumping in the GitHub Actions push-event workflow by applying semantic versioning rules to versionName and always incrementing versionCode.

CI:
- Bump minor and reset patch on commits starting with "feat:", otherwise increment patch in versionName during push events
- Always increment versionCode and persist updated values to versionCode.txt and versionName.txt