### PR TITLE
fix: fix data acquisition from ADS1115 sensor

### DIFF
--- a/app/src/main/java/io/pslab/communication/sensors/ADS1115.java
+++ b/app/src/main/java/io/pslab/communication/sensors/ADS1115.java
@@ -1,152 +1,134 @@
 package io.pslab.communication.sensors;
 
-import io.pslab.communication.peripherals.I2C;
-
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import io.pslab.communication.peripherals.I2C;
+
 public class ADS1115 {
-    private int ADDRESS = 0x48;
-    private I2C i2c;
+    private static final int ADDRESS = 0x48;
+    private final I2C i2c;
 
-    private int REG_POINTER_MASK = 0x3;
-    private int REG_POINTER_CONVERT = 0;
-    private int REG_POINTER_CONFIG = 1;
-    private int REG_POINTER_LOWTHRESH = 2;
-    private int REG_POINTER_HITHRESH = 3;
+    private static final int REG_POINTER_MASK = 0x3;
+    private static final int REG_POINTER_CONVERT = 0;
+    private static final int REG_POINTER_CONFIG = 1;
+    private static final int REG_POINTER_LOWTHRESH = 2;
+    private static final int REG_POINTER_HITHRESH = 3;
 
-    private int REG_CONFIG_OS_MASK = 0x8000;
-    private int REG_CONFIG_OS_SINGLE = 0x8000;
-    private int REG_CONFIG_OS_BUSY = 0x0000;
-    private int REG_CONFIG_OS_NOTBUSY = 0x8000;
+    private static final int REG_CONFIG_OS_MASK = 0x8000;
+    private static final int REG_CONFIG_OS_SINGLE = 0x8000;
+    private static final int REG_CONFIG_OS_BUSY = 0x0000;
+    private static final int REG_CONFIG_OS_NOTBUSY = 0x8000;
 
-    private int REG_CONFIG_MUX_MASK = 0x7000;
-    private int REG_CONFIG_MUX_DIFF_0_1 = 0x0000;
-    private int REG_CONFIG_MUX_DIFF_0_3 = 0x1000;
-    private int REG_CONFIG_MUX_DIFF_1_3 = 0x2000;
-    private int REG_CONFIG_MUX_DIFF_2_3 = 0x3000;
-    private int REG_CONFIG_MUX_SINGLE_0 = 0x4000;
-    private int REG_CONFIG_MUX_SINGLE_1 = 0x5000;
-    private int REG_CONFIG_MUX_SINGLE_2 = 0x6000;
-    private int REG_CONFIG_MUX_SINGLE_3 = 0x7000;
+    private static final int REG_CONFIG_MUX_MASK = 0x7000;
+    private static final int REG_CONFIG_MUX_DIFF_0_1 = 0x0000;
+    private static final int REG_CONFIG_MUX_DIFF_0_3 = 0x1000;
+    private static final int REG_CONFIG_MUX_DIFF_1_3 = 0x2000;
+    private static final int REG_CONFIG_MUX_DIFF_2_3 = 0x3000;
+    private static final int REG_CONFIG_MUX_SINGLE_0 = 0x4000;
+    private static final int REG_CONFIG_MUX_SINGLE_1 = 0x5000;
+    private static final int REG_CONFIG_MUX_SINGLE_2 = 0x6000;
+    private static final int REG_CONFIG_MUX_SINGLE_3 = 0x7000;
 
-    private int REG_CONFIG_PGA_MASK = 0x0E00;
-    private int REG_CONFIG_PGA_6_144V = 0 << 9;
-    private int REG_CONFIG_PGA_4_096V = 1 << 9;
-    private int REG_CONFIG_PGA_2_048V = 2 << 9;
-    private int REG_CONFIG_PGA_1_024V = 3 << 9;
-    private int REG_CONFIG_PGA_0_512V = 4 << 9;
-    private int REG_CONFIG_PGA_0_256V = 5 << 9;
+    private static final int REG_CONFIG_PGA_MASK = 0x0E00;
+    private static final int REG_CONFIG_PGA_6_144V = 0 << 9;
+    private static final int REG_CONFIG_PGA_4_096V = 1 << 9;
+    private static final int REG_CONFIG_PGA_2_048V = 2 << 9;
+    private static final int REG_CONFIG_PGA_1_024V = 3 << 9;
+    private static final int REG_CONFIG_PGA_0_512V = 4 << 9;
+    private static final int REG_CONFIG_PGA_0_256V = 5 << 9;
 
-    private int REG_CONFIG_MODE_MASK = 0x0100;
-    private int REG_CONFIG_MODE_CONTIN = 0 << 8;
-    private int REG_CONFIG_MODE_SINGLE = 1 << 8;
+    private static final int REG_CONFIG_MODE_MASK = 0x0100;
+    private static final int REG_CONFIG_MODE_CONTIN = 0 << 8;
+    private static final int REG_CONFIG_MODE_SINGLE = 1 << 8;
 
-    private int REG_CONFIG_DR_MASK = 0x00E0;
-    private int REG_CONFIG_DR_8SPS = 0 << 5;
-    private int REG_CONFIG_DR_16SPS = 1 << 5;
-    private int REG_CONFIG_DR_32SPS = 2 << 5;
-    private int REG_CONFIG_DR_64SPS = 3 << 5;
-    private int REG_CONFIG_DR_128SPS = 4 << 5;
-    private int REG_CONFIG_DR_250SPS = 5 << 5;
-    private int REG_CONFIG_DR_475SPS = 6 << 5;
-    private int REG_CONFIG_DR_860SPS = 7 << 5;
+    private static final int REG_CONFIG_DR_MASK = 0x00E0;
+    private static final int REG_CONFIG_DR_8SPS = 0 << 5;
+    private static final int REG_CONFIG_DR_16SPS = 1 << 5;
+    private static final int REG_CONFIG_DR_32SPS = 2 << 5;
+    private static final int REG_CONFIG_DR_64SPS = 3 << 5;
+    private static final int REG_CONFIG_DR_128SPS = 4 << 5;
+    private static final int REG_CONFIG_DR_250SPS = 5 << 5;
+    private static final int REG_CONFIG_DR_475SPS = 6 << 5;
+    private static final int REG_CONFIG_DR_860SPS = 7 << 5;
 
-    private int REG_CONFIG_CMODE_MASK = 0x0010;
-    private int REG_CONFIG_CMODE_TRAD = 0x0000;
-    private int REG_CONFIG_CMODE_WINDOW = 0x0010;
+    private static final int REG_CONFIG_CMODE_MASK = 0x0010;
+    private static final int REG_CONFIG_CMODE_TRAD = 0x0000;
+    private static final int REG_CONFIG_CMODE_WINDOW = 0x0010;
 
-    private int REG_CONFIG_CPOL_MASK = 0x0008;
-    private int REG_CONFIG_CPOL_ACTVLOW = 0x0000;
-    private int REG_CONFIG_CPOL_ACTVHI = 0x0008;
+    private static final int REG_CONFIG_CPOL_MASK = 0x0008;
+    private static final int REG_CONFIG_CPOL_ACTVLOW = 0x0000;
+    private static final int REG_CONFIG_CPOL_ACTVHI = 0x0008;
 
-    private int REG_CONFIG_CLAT_MASK = 0x0004;
-    private int REG_CONFIG_CLAT_NONLAT = 0x0000;
-    private int REG_CONFIG_CLAT_LATCH = 0x0004;
+    private static final int REG_CONFIG_CLAT_MASK = 0x0004;
+    private static final int REG_CONFIG_CLAT_NONLAT = 0x0000;
+    private static final int REG_CONFIG_CLAT_LATCH = 0x0004;
 
-    private int REG_CONFIG_CQUE_MASK = 0x0003;
-    private int REG_CONFIG_CQUE_1CONV = 0x0000;
-    private int REG_CONFIG_CQUE_2CONV = 0x0001;
-    private int REG_CONFIG_CQUE_4CONV = 0x0002;
-    private int REG_CONFIG_CQUE_NONE = 0x0003;
+    private static final int REG_CONFIG_CQUE_MASK = 0x0003;
+    private static final int REG_CONFIG_CQUE_1CONV = 0x0000;
+    private static final int REG_CONFIG_CQUE_2CONV = 0x0001;
+    private static final int REG_CONFIG_CQUE_4CONV = 0x0002;
+    private static final int REG_CONFIG_CQUE_NONE = 0x0003;
 
-    private HashMap<String, Integer> gains = new HashMap<String, Integer>();
-    private HashMap<String, Double> gainScaling = new HashMap<String, Double>();
-    private HashMap<String, String> typeSelection = new HashMap<String, String>();
-    private HashMap<Integer, Integer> sdrSelection = new HashMap<Integer, Integer>();
+    private static final Map<String, Integer> GAINS = new HashMap<>() {{
+        put("GAIN_TWOTHIRDS", REG_CONFIG_PGA_6_144V);
+        put("GAIN_ONE", REG_CONFIG_PGA_4_096V);
+        put("GAIN_TWO", REG_CONFIG_PGA_2_048V);
+        put("GAIN_FOUR", REG_CONFIG_PGA_1_024V);
+        put("GAIN_EIGHT", REG_CONFIG_PGA_0_512V);
+        put("GAIN_SIXTEEN", REG_CONFIG_PGA_0_256V);
+    }};
+
+    private static final Map<String, Double> GAIN_SCALING = new HashMap<>() {{
+        put("GAIN_TWOTHIRDS", 0.1875);
+        put("GAIN_ONE", 0.125);
+        put("GAIN_TWO", 0.0625);
+        put("GAIN_FOUR", 0.03125);
+        put("GAIN_EIGHT", 0.015625);
+        put("GAIN_SIXTEEN", 0.0078125);
+    }};
+
+    private static final Map<String, String> TYPE_SELECTION = new HashMap<>() {{
+        put("UNI_0", "0");
+        put("UNI_1", "1");
+        put("UNI_2", "2");
+        put("UNI_3", "3");
+        put("DIFF_01", "01");
+        put("DIFF_23", "23");
+    }};
+
+    private static final Map<Integer, Integer> SDR_SELECTION = new HashMap<>() {{
+        put(8, REG_CONFIG_DR_8SPS);
+        put(16, REG_CONFIG_DR_16SPS);
+        put(32, REG_CONFIG_DR_32SPS);
+        put(64, REG_CONFIG_DR_64SPS);
+        put(128, REG_CONFIG_DR_128SPS);
+        put(250, REG_CONFIG_DR_250SPS);
+        put(475, REG_CONFIG_DR_475SPS);
+        put(860, REG_CONFIG_DR_860SPS);
+    }};
 
     private String channel;
     private String gain;
     private int rate;
-
-    public int NUMPLOTS = 1;
-    public String[] PLOTNAMES = {"mV"};
 
     public ADS1115(I2C i2c) throws IOException, InterruptedException {
         this.i2c = i2c;
         channel = "UNI_0";
         gain = "GAIN_ONE";
         rate = 128;
-
-        setGain("GAIN_ONE");
-        setChannel("UNI_0");
-        setDataRate(128);
-
-        int conversionDelay = 8;
-        String name = "ADS1115 16-bit ADC";
-
-        gains.put("GAIN_TWOTHIRDS", REG_CONFIG_PGA_6_144V);
-        gains.put("GAIN_ONE", REG_CONFIG_PGA_4_096V);
-        gains.put("GAIN_TWO", REG_CONFIG_PGA_2_048V);
-        gains.put("GAIN_FOUR", REG_CONFIG_PGA_1_024V);
-        gains.put("GAIN_EIGHT", REG_CONFIG_PGA_0_512V);
-        gains.put("GAIN_SIXTEEN", REG_CONFIG_PGA_0_256V);
-
-        gainScaling.put("GAIN_TWOTHIRDS", 0.1875);
-        gainScaling.put("GAIN_ONE", 0.125);
-        gainScaling.put("GAIN_TWO", 0.0625);
-        gainScaling.put("GAIN_FOUR", 0.03125);
-        gainScaling.put("GAIN_EIGHT", 0.015625);
-        gainScaling.put("GAIN_SIXTEEN", 0.0078125);
-
-        typeSelection.put("UNI_0", "0");
-        typeSelection.put("UNI_1", "1");
-        typeSelection.put("UNI_2", "2");
-        typeSelection.put("UNI_3", "3");
-        typeSelection.put("DIFF_01", "01");
-        typeSelection.put("DIFF_23", "23");
-
-        sdrSelection.put(8, REG_CONFIG_DR_8SPS);
-        sdrSelection.put(16, REG_CONFIG_DR_16SPS);
-        sdrSelection.put(32, REG_CONFIG_DR_32SPS);
-        sdrSelection.put(64, REG_CONFIG_DR_64SPS);
-        sdrSelection.put(128, REG_CONFIG_DR_128SPS);
-        sdrSelection.put(250, REG_CONFIG_DR_250SPS);
-        sdrSelection.put(475, REG_CONFIG_DR_475SPS);
-        sdrSelection.put(860, REG_CONFIG_DR_860SPS);
-
-    }
-
-    public int readInt(int addr) throws IOException, InterruptedException {
-        ArrayList<Integer> vals = i2c.readBulk(ADDRESS, addr, 2);
-        int v = (int) (1. * ((vals.get(0) << 8) | vals.get(1)));
-        return v;
-    }
-
-    public void initTemperature() throws IOException, InterruptedException {
-        i2c.writeBulk(ADDRESS, new int[]{ADDRESS});
-        TimeUnit.SECONDS.sleep((long) 0.005);
     }
 
     private int readRegister(int register) throws IOException {
-        ArrayList<Integer> vals = i2c.readBulk(ADDRESS, register, 2);
-        return (vals.get(0) << 8) | vals.get(1);
+        List<Integer> vals = i2c.readBulk(ADDRESS, register, 2);
+        return ((vals.get(0) & 0xFF) << 8) | vals.get(1) & 0xFF;
     }
 
-    private void writeRegister(int reg, int value) throws IOException {
-        i2c.writeBulk(ADDRESS, new int[]{ADDRESS, (value >> 8) & 0xFF, value & 0xFF});
+    private void writeRegister(int register, int value) throws IOException {
+        i2c.writeBulk(ADDRESS, new int[]{register, (value >> 8) & 0xFF, value & 0xFF});
     }
 
     public void setGain(String gain) {
@@ -174,10 +156,10 @@ public class ADS1115 {
                 | REG_CONFIG_CPOL_ACTVLOW             //Alert/Rdy active low   (default val)
                 | REG_CONFIG_CMODE_TRAD               // Traditional comparator (default val)
                 | REG_CONFIG_MODE_SINGLE              // Single-shot mode (default)
-                | sdrSelection.get(rate);            //1600 samples per second (default)
+                | SDR_SELECTION.get(rate);            //1600 samples per second (default)
 
         //Set PGA/voltage range
-        config = config | gains.get(gain);
+        config = config | GAINS.get(gain);
 
         if (chan == 0)
             config = config | REG_CONFIG_MUX_SINGLE_0;
@@ -192,7 +174,7 @@ public class ADS1115 {
         config = config | REG_CONFIG_OS_SINGLE;
         writeRegister(REG_POINTER_CONFIG, config);
         TimeUnit.MILLISECONDS.sleep((long) ((1. / rate + 0.002) * 1000));       //convert to mS to S
-        return readRegister(REG_POINTER_CONVERT) * gainScaling.get(gain);
+        return readRegister(REG_POINTER_CONVERT) * GAIN_SCALING.get(gain);
     }
 
     private short readADCDifferential(String chan) throws IOException, InterruptedException {
@@ -202,10 +184,10 @@ public class ADS1115 {
                 | REG_CONFIG_CPOL_ACTVLOW              //Alert/Rdy active low   (default val)
                 | REG_CONFIG_CMODE_TRAD                // Traditional comparator (default val)
                 | REG_CONFIG_MODE_SINGLE               // Single-shot mode (default)
-                | sdrSelection.get(rate);             //1600 samples per second (default)
+                | SDR_SELECTION.get(rate);             //1600 samples per second (default)
 
         //Set PGA/voltage range
-        config = config | gains.get(gain);
+        config = config | GAINS.get(gain);
 
         if (chan.equals("01"))
             config = config | REG_CONFIG_MUX_DIFF_0_1;
@@ -217,16 +199,12 @@ public class ADS1115 {
         writeRegister(REG_POINTER_CONFIG, config);
         TimeUnit.MILLISECONDS.sleep((long) ((1. / rate + 0.002) * 1000));       //convert to mS to S
 
-        return (short) (readRegister(REG_POINTER_CONVERT) * gainScaling.get(gain));
-    }
-
-    public short getLastResults() throws IOException {
-        return (short) (readRegister(REG_POINTER_CONVERT) * gainScaling.get(gain));
+        return (short) (readRegister(REG_POINTER_CONVERT) * GAIN_SCALING.get(gain));
     }
 
     public int getRaw() throws IOException, InterruptedException {
         //return values in mV
-        String chan = typeSelection.get(channel);
+        String chan = TYPE_SELECTION.get(channel);
         if (channel.contains("UNI"))
             return (int) readADCSingleEnded(Integer.parseInt(chan));
         else if (channel.contains("DIF"))

--- a/app/src/main/java/io/pslab/communication/sensors/ADS1115.java
+++ b/app/src/main/java/io/pslab/communication/sensors/ADS1115.java
@@ -124,7 +124,7 @@ public class ADS1115 {
 
     private int readRegister(int register) throws IOException {
         List<Integer> vals = i2c.readBulk(ADDRESS, register, 2);
-        return ((vals.get(0) & 0xFF) << 8) | vals.get(1) & 0xFF;
+        return ((vals.get(0) & 0xFF) << 8) | (vals.get(1) & 0xFF);
     }
 
     private void writeRegister(int register, int value) throws IOException {

--- a/app/src/main/java/io/pslab/sensors/SensorADS1115.java
+++ b/app/src/main/java/io/pslab/sensors/SensorADS1115.java
@@ -33,6 +33,10 @@ public class SensorADS1115 extends AbstractSensorActivity {
     private LineChart mChart;
     private TextView tvSensorADS1115;
 
+    private Spinner spinnerSensorADS1115Gain;
+    private Spinner spinnerSensorADS1115Channel;
+    private Spinner spinnerSensorADS1115Rate;
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -49,9 +53,9 @@ public class SensorADS1115 extends AbstractSensorActivity {
         tvSensorADS1115 = findViewById(R.id.tv_sensor_ads1115);
         mChart = findViewById(R.id.chart_sensor_ads);
 
-        Spinner spinnerSensorADS1115Gain = findViewById(R.id.spinner_sensor_ads1115_gain);
-        Spinner spinnerSensorADS1115Channel = findViewById(R.id.spinner_sensor_ads1115_channel);
-        Spinner spinnerSensorADS1115Rate = findViewById(R.id.spinner_sensor_ads1115_rate);
+        spinnerSensorADS1115Gain = findViewById(R.id.spinner_sensor_ads1115_gain);
+        spinnerSensorADS1115Channel = findViewById(R.id.spinner_sensor_ads1115_channel);
+        spinnerSensorADS1115Rate = findViewById(R.id.spinner_sensor_ads1115_rate);
 
         if (sensorADS1115 != null) {
             sensorADS1115.setGain(spinnerSensorADS1115Gain.getSelectedItem().toString());
@@ -97,6 +101,9 @@ public class SensorADS1115 extends AbstractSensorActivity {
 
             try {
                 if (sensorADS1115 != null) {
+                    sensorADS1115.setChannel(spinnerSensorADS1115Channel.getSelectedItem().toString());
+                    sensorADS1115.setDataRate(Integer.parseInt(spinnerSensorADS1115Rate.getSelectedItem().toString()));
+                    sensorADS1115.setGain(spinnerSensorADS1115Gain.getSelectedItem().toString());
                     dataADS1115 = sensorADS1115.getRaw();
                     success = true;
                 }


### PR DESCRIPTION
Fixes: https://github.com/fossasia/pslab-app/issues/2884

## Summary by Sourcery

Fix data acquisition from ADS1115 by refactoring constant definitions, correcting I2C register operations, and updating UI component usage to apply sensor settings consistently.

Bug Fixes:
- Correct readRegister and writeRegister to mask byte values properly and use the correct register address in I2C calls
- Ensure gain, channel, and data rate mappings are retrieved from the updated static maps before reading raw sensor data

Enhancements:
- Refactor ADS1115 class to define register constants and configuration maps (gains, scaling factors, channel types, data rates) as static final fields
- Remove dynamic initialization of configuration maps in the constructor and clean up redundant code

Chores:
- Remove unused imports and methods in ADS1115
- Update SensorADS1115 activity to use instance-level spinner fields and reapply spinner selections before each data fetch