### PR TITLE
feat: added csv playback for luxmeter instrument.

### DIFF
--- a/lib/providers/luxmeter_state_provider.dart
+++ b/lib/providers/luxmeter_state_provider.dart
@@ -28,11 +28,19 @@ class LuxMeterStateProvider extends ChangeNotifier {
   bool _sensorAvailable = false;
   bool _isRecording = false;
   List<List<dynamic>> _recordedData = [];
+  bool _isPlayingBack = false;
+  List<List<dynamic>>? _playbackData;
+  int _playbackIndex = 0;
+  Timer? _playbackTimer;
+  bool _isPlaybackPaused = false;
+  bool get isPlayingBack => _isPlayingBack;
+  bool get isPlaybackPaused => _isPlaybackPaused;
   bool get isRecording => _isRecording;
 
   LuxMeterConfigProvider? _configProvider;
 
   Function(String)? onSensorError;
+  Function? onPlaybackEnd;
 
   void setConfigProvider(LuxMeterConfigProvider configProvider) {
     _configProvider = configProvider;
@@ -99,15 +107,123 @@ class LuxMeterStateProvider extends ChangeNotifier {
     _timeTimer?.cancel();
   }
 
+  void startPlayback(List<List<dynamic>> data) {
+    if (data.length <= 1) return;
+
+    _isPlayingBack = true;
+    _isPlaybackPaused = false;
+    _playbackData = data;
+    _playbackIndex = 1;
+
+    _timeTimer?.cancel();
+    _lightSubscription?.cancel();
+
+    _luxData.clear();
+    luxChartData.clear();
+    _timeData.clear();
+    _startTime = DateTime.now().millisecondsSinceEpoch / 1000.0;
+    _currentTime = 0;
+    _luxSum = 0;
+    _dataCount = 0;
+
+    _startPlaybackTimer();
+    notifyListeners();
+  }
+
+  void _startPlaybackTimer() {
+    if (_playbackIndex >= _playbackData!.length) {
+      stopPlayback();
+      return;
+    }
+
+    final currentRow = _playbackData![_playbackIndex];
+    if (currentRow.length > 2) {
+      _currentLux = double.tryParse(currentRow[2].toString()) ?? 0.0;
+      _currentTime = (_playbackIndex - 1).toDouble();
+      _updateData();
+      _playbackIndex++;
+      notifyListeners();
+    } else {
+      logger.e(
+          'Skipping playback row at index $_playbackIndex due to insufficient columns (found ${currentRow.length}, expected at least 3');
+      _playbackIndex++;
+      notifyListeners();
+    }
+
+    Duration interval = const Duration(seconds: 1);
+
+    if (_playbackIndex < _playbackData!.length && _playbackIndex > 1) {
+      try {
+        final currentTimestamp =
+            int.tryParse(_playbackData![_playbackIndex - 1][0].toString());
+        final nextTimestamp =
+            int.tryParse(_playbackData![_playbackIndex][0].toString());
+
+        if (currentTimestamp != null && nextTimestamp != null) {
+          final timeDiff = nextTimestamp - currentTimestamp;
+          interval = Duration(milliseconds: timeDiff);
+          if (interval.inMilliseconds < 100) {
+            interval = const Duration(milliseconds: 100);
+          } else if (interval.inMilliseconds > 10000) {
+            interval = const Duration(seconds: 10);
+          }
+        }
+      } catch (e) {
+        interval = const Duration(seconds: 1);
+      }
+    }
+
+    _playbackTimer = Timer(interval, () {
+      if (_isPlayingBack && !_isPlaybackPaused) {
+        _startPlaybackTimer();
+      }
+    });
+  }
+
+  Future<void> stopPlayback() async {
+    _isPlayingBack = false;
+    _isPlaybackPaused = false;
+    _playbackTimer?.cancel();
+    _playbackData = null;
+    _playbackIndex = 0;
+
+    _luxData.clear();
+    luxChartData.clear();
+    _timeData.clear();
+    _luxSum = 0;
+    _dataCount = 0;
+    _currentLux = 0.0;
+    _currentTime = 0;
+    notifyListeners();
+    onPlaybackEnd?.call();
+  }
+
+  void pausePlayback() {
+    if (_isPlayingBack) {
+      _isPlaybackPaused = true;
+      _playbackTimer?.cancel();
+      notifyListeners();
+    }
+  }
+
+  void resumePlayback() {
+    if (_isPlayingBack && _isPlaybackPaused) {
+      _isPlaybackPaused = false;
+      _startPlaybackTimer();
+      notifyListeners();
+    }
+  }
+
   @override
   void dispose() {
     _configProvider?.removeListener(_onConfigChanged);
+    _playbackTimer?.cancel();
     disposeSensors();
     super.dispose();
   }
 
   void _updateData() {
-    final lux = _sensorAvailable ? _currentLux : null;
+    final lux = _sensorAvailable || _isPlayingBack ? _currentLux : null;
     final time = _currentTime;
     if (lux != null) {
       if (_isRecording) {

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/theme/colors.dart';
 import 'package:pslab/view/logged_data_chart_screen.dart';
+import 'package:pslab/view/luxmeter_screen.dart';
 import 'package:pslab/view/soundmeter_screen.dart';
 import '../l10n/app_localizations.dart';
 import '../providers/locator.dart';
@@ -176,6 +177,14 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
             ),
           );
           break;
+        case 'luxmeter':
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => LuxMeterScreen(playbackData: data),
+            ),
+          );
+          break;
       }
     }
   }
@@ -304,7 +313,8 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                             mainAxisAlignment: MainAxisAlignment.center,
                             mainAxisSize: MainAxisSize.min,
                             children: [
-                              if (widget.instrumentName == "soundmeter")
+                              if (widget.instrumentName == "soundmeter" ||
+                                  widget.instrumentName == "luxmeter")
                                 IconButton(
                                   icon:
                                       Icon(Icons.play_arrow, color: primaryRed),

--- a/lib/view/luxmeter_screen.dart
+++ b/lib/view/luxmeter_screen.dart
@@ -19,10 +19,12 @@ import '../theme/colors.dart';
 
 class LuxMeterScreen extends StatefulWidget {
   final bool isExperiment;
+  final List<List<dynamic>>? playbackData;
 
   const LuxMeterScreen({
     super.key,
     this.isExperiment = false,
+    this.playbackData,
   });
   @override
   State<StatefulWidget> createState() => _LuxMeterScreenState();
@@ -35,6 +37,7 @@ class _LuxMeterScreenState extends State<LuxMeterScreen> {
   bool _showGuide = false;
   static const imagePath = 'assets/images/bh1750_schematic.png';
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
   void _showInstrumentGuide() {
     setState(() {
       _showGuide = true;
@@ -210,10 +213,22 @@ class _LuxMeterScreenState extends State<LuxMeterScreen> {
     super.initState();
     _provider = LuxMeterStateProvider();
     _configProvider = LuxMeterConfigProvider();
+
+    _provider.onPlaybackEnd = () {
+      if (mounted && Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
+    };
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         _provider.setConfigProvider(_configProvider);
-        _provider.initializeSensors(onError: _showSensorErrorSnackbar);
+
+        if (widget.playbackData != null) {
+          _provider.startPlayback(widget.playbackData!);
+        } else {
+          _provider.initializeSensors(onError: _showSensorErrorSnackbar);
+        }
       }
     });
     if (widget.isExperiment) {
@@ -276,11 +291,26 @@ class _LuxMeterScreenState extends State<LuxMeterScreen> {
         Consumer<LuxMeterStateProvider>(
           builder: (context, provider, child) {
             return CommonScaffold(
-              title: appLocalizations.luxMeterTitle,
-              onOptionsPressed: _showOptionsMenu,
+              title: provider.isPlayingBack
+                  ? '${appLocalizations.luxMeterTitle} - ${appLocalizations.playback}'
+                  : appLocalizations.luxMeterTitle,
+              onOptionsPressed:
+                  provider.isPlayingBack ? null : _showOptionsMenu,
               onGuidePressed: _showInstrumentGuide,
-              onRecordPressed: _toggleRecording,
+              onRecordPressed: provider.isPlayingBack ? null : _toggleRecording,
               isRecording: provider.isRecording,
+              isPlayingBack: provider.isPlayingBack,
+              isPlaybackPaused: provider.isPlaybackPaused,
+              onPlaybackPauseResume: provider.isPlayingBack
+                  ? (provider.isPlaybackPaused
+                      ? _provider.resumePlayback
+                      : _provider.pausePlayback)
+                  : null,
+              onPlaybackStop: provider.isPlayingBack
+                  ? () async {
+                      await _provider.stopPlayback();
+                    }
+                  : null,
               body: SafeArea(
                   child: LayoutBuilder(builder: (context, constraints) {
                 final isLargeScreen = constraints.maxWidth > 900;


### PR DESCRIPTION
Fixes #2888

<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- Added csv playback functionality for the luxmeter instrument.
<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  

https://github.com/user-attachments/assets/fce73d90-6886-412e-8468-7cad8abfad1d


<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Implement CSV playback for the luxmeter instrument by adding playback state and control methods in the provider, updating the LuxMeterScreen UI to support playback mode, and enabling navigation from the logged data screen to replay CSV recordings.

New Features:
- Add CSV playback state and control methods (start, pause, resume, stop) in LuxMeterStateProvider for timed row processing.
- Update LuxMeterScreen to accept playbackData and present playback-specific UI (title, disabled options/recording, pause/resume/stop buttons).
- Enable navigation from LoggedDataScreen to LuxMeterScreen with CSV data to replay logged luxmeter sessions.

Enhancements:
- Extend the data update logic to include playback mode alongside live sensor readings.