### PR TITLE
feat: fix flutter version

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -36,6 +36,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         cache: true
+        flutter-version-file: pubspec.yaml
 
     - name: Build Android APK/AAB
       shell: bash

--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -7,6 +7,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         cache: true
+        flutter-version-file: pubspec.yaml
 
     - name: Fetch Flutter Dependencies
       shell: bash

--- a/.github/actions/ios/action.yml
+++ b/.github/actions/ios/action.yml
@@ -17,6 +17,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         cache: true
+        flutter-version-file: pubspec.yaml
 
     - name: Update Podfile
       shell: bash

--- a/.github/actions/screenshot-android/action.yml
+++ b/.github/actions/screenshot-android/action.yml
@@ -53,6 +53,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         cache: true
+        flutter-version-file: pubspec.yaml
 
     - name: Create Android Screenshots
       uses: reactivecircus/android-emulator-runner@v2

--- a/.github/actions/screenshot-ipad/action.yml
+++ b/.github/actions/screenshot-ipad/action.yml
@@ -13,6 +13,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         cache: true
+        flutter-version-file: pubspec.yaml
 
     - name: Update Podfile
       shell: bash

--- a/.github/actions/screenshot-iphone/action.yml
+++ b/.github/actions/screenshot-iphone/action.yml
@@ -13,6 +13,7 @@ runs:
       uses: subosito/flutter-action@v2
       with:
         cache: true
+        flutter-version-file: pubspec.yaml
 
     - name: Update Podfile
       shell: bash

--- a/.github/workflows/flutter_upgrade.yml
+++ b/.github/workflows/flutter_upgrade.yml
@@ -1,0 +1,60 @@
+name: Flutter Upgrade Check
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  check-flutter-upgrade:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Read Flutter version from pubspec.yaml
+        id: read-version
+        run: |
+          FLUTTER_VERSION=$(yq '.environment.flutter' pubspec.yaml)
+          echo "Current Flutter version: $FLUTTER_VERSION"
+          echo "flutter_version=$FLUTTER_VERSION" >> $GITHUB_ENV
+
+      - name: Get latest stable Flutter version
+        id: check-latest
+        run: |
+          LATEST_VERSION=$(curl -s https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json | jq -r '.releases[] | select(.channel == "stable") | .version' | head -n 1)
+          echo "Latest stable Flutter version: $LATEST_VERSION"
+          echo "latest_flutter_version=$LATEST_VERSION" >> $GITHUB_ENV
+
+      - name: Compare versions and update pubspec.yaml if needed
+        id: update-version
+        run: |
+          if [ "$flutter_version" != "$latest_flutter_version" ]; then
+            echo "Updating Flutter version in pubspec.yaml..."
+            sed -i "s/flutter:\s*'${flutter_version}'/flutter: '${latest_flutter_version}'/" pubspec.yaml
+            git --no-pager diff
+            echo "update_needed=true" >> $GITHUB_ENV
+          else
+            echo "Flutter is up to date."
+            echo "update_needed=false" >> $GITHUB_ENV
+          fi
+
+      - name: Commit and create PR if update is needed
+        if: env.update_needed == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |          
+          git config --global user.name "dependabot[bot]"
+          git config --global user.email "49699333+dependabot[bot]@users.noreply.github.com"
+
+          BRANCH_NAME="flutter-upgrade-${{ env.latest_flutter_version }}"
+          git checkout -b $BRANCH_NAME
+          git add pubspec.yaml
+          git commit -m "chore: Upgrade Flutter to ${{ env.latest_flutter_version }}"
+          git push origin -f $BRANCH_NAME
+
+          PR_URL=$(gh pr create --title "chore(deps): upgrade Flutter to ${{ env.latest_flutter_version }}" \
+                       --body "This PR updates Flutter version in pubspec.yaml to the latest stable release." \
+                       --base development \
+                       --head $BRANCH_NAME)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ version: 1.0.0+1
 
 environment:
   sdk: ^3.5.4
+  flutter: '3.35.3'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
Prerequisite for pushing the app to production.

 ## Changes:

- Use a fixed version of flutter while building the app (specified in _pubspec.yaml_).
- Create an automated workflow to create PRs to upgrade the flutter version in the pubspec file whenever a new flutter stable release is made.

## Summary by Sourcery

Pin Flutter SDK version from pubspec.yaml in CI builds and introduce a scheduled workflow to automatically bump the Flutter version via pull requests when new stable releases are available.

Enhancements:
- Pin Flutter SDK version in pubspec.yaml to ensure consistent builds
- Configure all GitHub Actions workflows to read the Flutter version from pubspec.yaml

CI:
- Add a weekly scheduled workflow that checks for new stable Flutter releases and opens a PR to update pubspec.yaml