### PR TITLE
docs: remove outdated badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,7 @@
 Repository for the PSLab Android App for performing experiments with the [Pocket Science Lab](https://pslab.io) open-hardware platform.
 
 [![Build](https://github.com/fossasia/pslab-android/actions/workflows/pull-request.yml/badge.svg)](https://github.com/fossasia/pslab-android/actions/workflows/pull-request.yml)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/3383ddffb53b4c82a822f3a5991fe0a1)](https://www.codacy.com/gh/fossasia/pslab-android/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fossasia/pslab-android&amp;utm_campaign=Badge_Grade)
 [![Mailing List](https://img.shields.io/badge/Mailing%20List-FOSSASIA-blue.svg)](https://groups.google.com/forum/#!forum/pslab-fossasia)
-![Minimum API Level](https://img.shields.io/badge/Min%20API%20Level-23-green)
-![Maximum API Level](https://img.shields.io/badge/Max%20API%20Level-31-orange)
 ![GitHub repo size](https://img.shields.io/github/repo-size/fossasia/pslab-android)
 [![Gitter](https://badges.gitter.im/fossasia/pslab.svg)](https://gitter.im/fossasia/pslab?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Twitter Follow](https://img.shields.io/twitter/follow/pslabio.svg?style=social&label=Follow&maxAge=2592000?style=flat-square)](https://twitter.com/pslabio)


### PR DESCRIPTION
Fixes #2695 

Changes
- Removed broken "Code Quality" badge (dead link).
- Removed outdated "Min API Level" and "Target API Level" badges.
- Cleaned up README badge section for clarity.

Screenshots / Recordings
(Not applicable — README change only)

Checklist:
- [x] No hard coding: Not applicable for documentation changes.
- [x] No end of file edits: No extra modifications in unrelated files.
- [x] Code reformatting: Not applicable for documentation changes.
- [x] No extra space: Verified README has no unnecessary blank lines.

## Summary by Sourcery

Remove outdated badges from README by deleting the broken Code Quality and API level badges and tidying the badge section

Documentation:
- Remove broken Codacy Code Quality badge
- Remove outdated Minimum and Maximum API Level badges
- Clean up the README badge section for clarity