### PR TITLE
fix: changed arrow icon color in luxmeter config to white.

### DIFF
--- a/lib/view/luxmeter_config_screen.dart
+++ b/lib/view/luxmeter_config_screen.dart
@@ -47,6 +47,7 @@ class _LuxMeterConfigScreenState extends State<LuxMeterConfigScreen> {
       backgroundColor: Theme.of(context).colorScheme.surface,
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
+        iconTheme: IconThemeData(color: appBarContentColor),
         systemOverlayStyle: SystemUiOverlayStyle(statusBarColor: appBarColor),
         backgroundColor: primaryRed,
         title: Text(


### PR DESCRIPTION
Part of issue #2909

Issue : The Lux Meter Configurations shows a Black Arrow instead of a white one.

<!-- Add issue number here. This will automatically closes the issue. If you do not solve the issue entirely, please change the message to e.g. "First steps for issues #IssueNumber" -->

## Changes 
- Added csv playback functionality for the barometer instrument.
<!-- Add here what changes were made in this pull request and if possible provide links. -->

## Screenshots / Recordings  
<img width="250" height="2298" alt="Screenshot_20250911-005319" src="https://github.com/user-attachments/assets/cbc114f3-28ba-492a-9aff-653ad15316de" />



<!-- Add screen shots/screen recordings of the layout where you made changes or a `*.gif` containing a demonstration. Fill "> N/A" if the change is not a UI fix. -->

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used resources from `strings.xml`, `dimens.xml` and `colors.xml` without hard coding any value.
- [x] **No end of file edits**: No modifications done at end of resource files `strings.xml`, `dimens.xml` or `colors.xml`.
- [x] **Code reformatting**: I have reformatted code and fixed indentation in every file included in this pull request.
- [x] **No extra space**: My code does not contain any extra lines or extra spaces than the ones that are necessary.

## Summary by Sourcery

Bug Fixes:
- Apply appBarContentColor to the AppBar’s iconTheme to render the arrow icon in white