### PR TITLE
fix: windows installer upload

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -272,12 +272,15 @@ jobs:
 
       - name: Upload installer to apk branch
         if: ${{ github.repository == 'fossasia/pslab-app' }}
+        shell: bash
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git clone --branch=apk https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} apk
           cd apk
+          
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
           echo "Removing previous files from branch"
 
@@ -317,6 +320,8 @@ jobs:
 
           git clone --branch=apk https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} apk
           cd apk
+          
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
 
           echo "Removing previous files from branch"
 


### PR DESCRIPTION
## Summary by Sourcery

Fix the installer upload workflow by forcing bash as the shell in the upload steps and by introducing a branch variable for consistent branch resolution across all runners.

Bug Fixes:
- Specify bash as the shell for the installer upload steps to support Windows runners
- Add a branch variable assignment to correctly resolve the target branch in both upload sections