### PR TITLE
chore(deps): bump flusbserial to 0.2.2

### DIFF
--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
 </dict>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.device.usb</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: flusbserial
-      sha256: "11b568cf0d43b90d0459795f0965d0faf31fc1a0ef66a7a1d28c3c109a2bfb9e"
+      sha256: "82d8201e11e648bd1e6213144dca2bab0a4388dc4d2e65d6698140ad3b0ace80"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
   path_provider: ^2.1.5
   file_picker: ^10.3.2
   flutter_screenutil: ^5.9.3
-  flusbserial: ^0.2.1
+  flusbserial: ^0.2.2
   inno_bundle: ^0.4.0
 
 dependency_overrides:
@@ -145,7 +145,6 @@ flutter:
 inno_bundle:
   id: b633ddbf-a022-4cbb-a459-4ba9fec0da51
   publisher: FOSSASIA
-  name: PSLab
   url: https://pslab.io
   support_url: https://github.com/fossasia/pslab-app/issues
   updates_url: https://github.com/fossasia/pslab-app/releases

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -144,6 +144,7 @@ flutter:
   # see https://flutter.dev/to/font-from-package
 inno_bundle:
   id: b633ddbf-a022-4cbb-a459-4ba9fec0da51
+  name: pslab
   publisher: FOSSASIA
   url: https://pslab.io
   support_url: https://github.com/fossasia/pslab-app/issues

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(pslab LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "PSLab")
+set(BINARY_NAME "pslab")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.


### PR DESCRIPTION
Required for enabling USB support on _Linux_ and _macOS_.

## Summary by Sourcery

Bump flusbserial to 0.2.2 to enable USB support on Linux and macOS, adjust Windows build configuration, and clean up inno_bundle settings

Enhancements:
- Enable USB support on Linux and macOS via flusbserial update

Build:
- Rename Windows executable to lowercase “pslab” in CMakeLists

Chores:
- Remove redundant “name” field from inno_bundle configuration
- Update pubspec lock file after dependency bump