### PR TITLE
fix: USB communication on Linux

### DIFF
--- a/lib/communication/handler/desktop_comms_handler.dart
+++ b/lib/communication/handler/desktop_comms_handler.dart
@@ -60,6 +60,7 @@ class DesktopUSBCommunicationHandler implements CommunicationHandler {
     if (!deviceFound) {
       throw Exception("Device not connected");
     }
+    UsbSerialDevice.setAutoDetachKernelDriver(true);
     await mDevice?.open();
     await mDevice?.setBaudRate(1000000);
     await mDevice?.setDataBits(UsbSerialInterface.dataBits8);


### PR DESCRIPTION
Uses the newly added features in flusbserial 0.2.2, to fix USB communication on Linux.

## Summary by Sourcery

Bug Fixes:
- Enable UsbSerialDevice.setAutoDetachKernelDriver(true) in DesktopUSBCommunicationHandler to fix USB communication on Linux