### PR TITLE
fix: copy changes for Instruments screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -29,7 +29,7 @@
     "gyroscopeDesc": "Measures rate of rotation about XYZ axis",
     "thermometerDesc": "To measure the ambient temperature",
     "roboticArmDesc": "Controls servos of a robotic arm",
-    "gasSensorDesc": "Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2",
+    "gasSensorDesc": "Air quality sensor for detecting a wide range of gases",
     "dustSensorDesc": "Dust sensor is used to measure air quality in terms of particles per square meter",
     "soundMeterDesc": "To measure the loudness in the environment in decibel(dB)",
     "yAxisRange16V": "+/-16V",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -303,7 +303,7 @@ abstract class AppLocalizations {
   /// No description provided for @gasSensorDesc.
   ///
   /// In en, this message translates to:
-  /// **'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2'**
+  /// **'Air quality sensor for detecting a wide range of gases'**
   String get gasSensorDesc;
 
   /// No description provided for @dustSensorDesc.
@@ -2796,6 +2796,36 @@ abstract class AppLocalizations {
   /// **'Data'**
   String get data;
 
+  /// No description provided for @configure.
+  ///
+  /// In en, this message translates to:
+  /// **'Configure'**
+  String get configure;
+
+  /// No description provided for @setGain.
+  ///
+  /// In en, this message translates to:
+  /// **'Set Gain'**
+  String get setGain;
+
+  /// No description provided for @setChannel.
+  ///
+  /// In en, this message translates to:
+  /// **'Set Channel'**
+  String get setChannel;
+
+  /// No description provided for @setRate.
+  ///
+  /// In en, this message translates to:
+  /// **'Set Rate'**
+  String get setRate;
+
+  /// No description provided for @millivolts.
+  ///
+  /// In en, this message translates to:
+  /// **'mV'**
+  String get millivolts;
+
   /// No description provided for @experiments.
   ///
   /// In en, this message translates to:
@@ -2951,36 +2981,6 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Mode'**
   String get mode;
-
-  /// No description provided for @configure.
-  ///
-  /// In en, this message translates to:
-  /// **'Configure'**
-  String get configure;
-
-  /// No description provided for @setGain.
-  ///
-  /// In en, this message translates to:
-  /// **'Set Gain'**
-  String get setGain;
-
-  /// No description provided for @setChannel.
-  ///
-  /// In en, this message translates to:
-  /// **'Set Channel'**
-  String get setChannel;
-
-  /// No description provided for @setRate.
-  ///
-  /// In en, this message translates to:
-  /// **'Set Rate'**
-  String get setRate;
-
-  /// No description provided for @millivolts.
-  ///
-  /// In en, this message translates to:
-  /// **'mV'**
-  String get millivolts;
 
   /// No description provided for @proximity.
   ///

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -104,7 +104,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsDe extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsDe extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -104,7 +104,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1448,6 +1448,22 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get data => 'Data';
 
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1531,20 +1547,6 @@ class AppLocalizationsEn extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
-  String get setGain => 'Set Gain';
-
-  @override
-  String get setChannel => 'Set Channel';
-
-  @override
-  String get setRate => 'Set Rate';
-
-  @override
-  String get millivolts => 'mV';
-
   String get proximity => 'Proximity';
 
   @override
@@ -1595,6 +1597,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get barometerExperimentInstructionContent =>
       'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
 
+  @override
   String get playbackStarted => 'Playback started';
 
   @override

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -104,7 +104,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsEs extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsEs extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -104,7 +104,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsFr extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsFr extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -104,7 +104,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsHe extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsHe extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -104,7 +104,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsHi extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsHi extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -104,7 +104,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsId extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsId extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -104,7 +104,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsJa extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsJa extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -104,7 +104,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsNb extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsNb extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,6 +1567,50 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }
 
 /// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -104,7 +104,7 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsPt extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsPt extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,6 +1567,50 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -104,7 +104,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsRu extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsRu extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -104,7 +104,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsUk extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsUk extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -104,7 +104,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsVi extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsVi extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,4 +1567,48 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -104,7 +104,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get gasSensorDesc =>
-      'Air quality sensor for detecting a wide range of gases, including NH3, NOx, alcohol, benzene, smoke and CO2';
+      'Air quality sensor for detecting a wide range of gases';
 
   @override
   String get dustSensorDesc =>
@@ -1446,6 +1446,24 @@ class AppLocalizationsZh extends AppLocalizations {
   String get estimated => 'Estimated';
 
   @override
+  String get data => 'Data';
+
+  @override
+  String get configure => 'Configure';
+
+  @override
+  String get setGain => 'Set Gain';
+
+  @override
+  String get setChannel => 'Set Channel';
+
+  @override
+  String get setRate => 'Set Rate';
+
+  @override
+  String get millivolts => 'mV';
+
+  @override
   String get experiments => 'Experiments';
 
   @override
@@ -1529,9 +1547,6 @@ class AppLocalizationsZh extends AppLocalizations {
   String get mode => 'Mode';
 
   @override
-  String get configure => 'Configure';
-
-  @override
   String get proximity => 'Proximity';
 
   @override
@@ -1552,6 +1567,50 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get legacyFirmwareAlertMessage =>
       'We have detected that your PSLab device is running legacy firmware. Please note that support for this firmware has ended. For the best experience and continued support, please update your device to the latest firmware version.';
+
+  @override
+  String get holdPositionForPressure =>
+      'Hold position steady for stable pressure reading';
+
+  @override
+  String get moveToHigherAltitude => 'Move to a higher altitude or floor';
+
+  @override
+  String get moveToLowerAltitude => 'Move to a lower altitude or floor';
+
+  @override
+  String get pressureVsAltitude => 'Pressure vs Altitude';
+
+  @override
+  String get pressureVsAltitudeDesc =>
+      'Observe how atmospheric pressure changes with altitude';
+
+  @override
+  String get barometerExperimentSetUpContent =>
+      'Ensure your device has a working barometer sensor, or connect a BMP180 sensor using PSLab to complete the experiment.';
+
+  @override
+  String get barometerExperimentPreparationContent =>
+      'Start the experiment in a stable position. Pressure decreases as altitude increases, and pressure increases as altitude decreases.';
+
+  @override
+  String get barometerExperimentInstructionContent =>
+      'Follow the on-screen instructions to move between different altitudes. The experiment will automatically detect pressure changes.';
+
+  @override
+  String get playbackStarted => 'Playback started';
+
+  @override
+  String get playback => 'Playback';
+
+  @override
+  String get stopPlayback => 'Stop Playback';
+
+  @override
+  String get resumePlayback => 'Resume Playback';
+
+  @override
+  String get pausePlayback => 'Pause Playback';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).


### PR DESCRIPTION
Fixes #2901.
Copy changes to avoid overlap of text and design elements on the _Instruments_ screen.

## Screenshots / Recordings
<img width="1080" height="2400" alt="Screenshot_1757953179" src="https://github.com/user-attachments/assets/e449a785-86c7-4bb4-a780-8e72c3421307" />

## Summary by Sourcery

Update localization strings on the Instruments screen to prevent text overlap and support new UI elements for data controls, barometer experiments, and playback functionality.

Enhancements:
- Shorten the gas sensor description across all locales to avoid overlapping text and design elements
- Add new labels for data controls including “Data”, “Configure”, “Set Gain”, “Set Channel”, “Set Rate”, and “mV”
- Introduce barometer experiment guidance and instruction copy for setup, preparation, and pressure-vs-altitude observations
- Add playback control strings such as “Playback started”, “Playback”, “Stop Playback”, “Resume Playback”, and “Pause Playback”