### PR TITLE
fix: prevent segfault on Linux if device isn't opened

### DIFF
--- a/lib/communication/handler/desktop_comms_handler.dart
+++ b/lib/communication/handler/desktop_comms_handler.dart
@@ -61,7 +61,10 @@ class DesktopUSBCommunicationHandler implements CommunicationHandler {
       throw Exception("Device not connected");
     }
     UsbSerialDevice.setAutoDetachKernelDriver(true);
-    await mDevice?.open();
+    if (await mDevice?.open() == false) {
+      logger.e("Failed to open device");
+      return;
+    }
     await mDevice?.setBaudRate(1000000);
     await mDevice?.setDataBits(UsbSerialInterface.dataBits8);
     await mDevice?.setStopBits(UsbSerialInterface.stopBits1);


### PR DESCRIPTION
Fixes #2926

## Summary by Sourcery

Prevent segmentation fault on Linux by verifying that the USB device opens successfully before configuring it

Bug Fixes:
- Check the result of mDevice.open() in DesktopUSBCommunicationHandler and return early if it fails to prevent segfault on Linux
- Log an error when opening the USB device fails