### PR TITLE
feat: optimize Oscilloscope layout

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -82,7 +82,7 @@ List<String> instrumentNames = [
   appLocalizations.compass.toLowerCase(),
   appLocalizations.gyroscope.toLowerCase(),
   appLocalizations.thermometer.toLowerCase(),
-  appLocalizations.roboticArm.toLowerCase(),
+  appLocalizations.roboticArmTitle.toLowerCase(),
   appLocalizations.gasSensor.toLowerCase(),
   appLocalizations.dustSensor.toLowerCase(),
   appLocalizations.soundMeter.toLowerCase()

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -501,5 +501,7 @@
     "location": "Location",
     "noLocationDataAvailable": "No location data available",
     "share": "Share",
-    "loggedData": "Logged Data"
+    "loggedData": "Logged Data",
+    "oscilloscopeConfigs": "Oscilloscope Configurations",
+    "automatedMeasurementsInfo": "Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc."
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3131,6 +3131,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Logged Data'**
   String get loggedData;
+
+  /// No description provided for @oscilloscopeConfigs.
+  ///
+  /// In en, this message translates to:
+  /// **'Oscilloscope Configurations'**
+  String get oscilloscopeConfigs;
+
+  /// No description provided for @automatedMeasurementsInfo.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.'**
+  String get automatedMeasurementsInfo;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1626,6 +1626,13 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }
 
 /// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1626,6 +1626,13 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1626,4 +1626,11 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1626,6 +1626,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get loggedData => 'Logged Data';
+
+  @override
+  String get oscilloscopeConfigs => 'Oscilloscope Configurations';
+
+  @override
+  String get automatedMeasurementsInfo =>
+      'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/models/oscilloscope_config.dart
+++ b/lib/models/oscilloscope_config.dart
@@ -1,0 +1,27 @@
+class OscilloscopeConfig {
+  final bool includeLocationData;
+
+  const OscilloscopeConfig({
+    this.includeLocationData = true,
+  });
+
+  OscilloscopeConfig copyWith({
+    bool? includeLocationData,
+  }) {
+    return OscilloscopeConfig(
+      includeLocationData: includeLocationData ?? this.includeLocationData,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'includeLocationData': includeLocationData,
+    };
+  }
+
+  factory OscilloscopeConfig.fromJson(Map<String, dynamic> json) {
+    return OscilloscopeConfig(
+      includeLocationData: json['includeLocationData'] ?? true,
+    );
+  }
+}

--- a/lib/providers/oscilloscope_config_provider.dart
+++ b/lib/providers/oscilloscope_config_provider.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/foundation.dart';
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:pslab/models/oscilloscope_config.dart';
+
+class OscilloscopeConfigProvider extends ChangeNotifier {
+  OscilloscopeConfig _config = const OscilloscopeConfig();
+
+  OscilloscopeConfig get config => _config;
+
+  OscilloscopeConfigProvider() {
+    _loadConfigFromPrefs();
+  }
+
+  Future<void> _loadConfigFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString('oscilloscope_config');
+    if (jsonString != null) {
+      final Map<String, dynamic> jsonMap = json.decode(jsonString);
+      _config = OscilloscopeConfig.fromJson(jsonMap);
+      notifyListeners();
+    }
+  }
+
+  Future<void> _saveConfigToPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('oscilloscope_config', json.encode(_config.toJson()));
+  }
+
+  void updateConfig(OscilloscopeConfig newConfig) {
+    _config = newConfig;
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateIncludeLocationData(bool includeLocationData) {
+    _config = _config.copyWith(includeLocationData: includeLocationData);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void resetToDefaults() {
+    _config = const OscilloscopeConfig();
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+}

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -5,10 +5,13 @@ import 'dart:math';
 import 'package:data/data.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:intl/intl.dart';
 import 'package:pslab/models/oscilloscope_measurements.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/others/oscilloscope_axes_scale.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/oscilloscope_config_provider.dart';
 
 import '../communication/analytics_class.dart';
 import '../communication/science_lab.dart';
@@ -32,6 +35,7 @@ List<Color> colors = [
 ];
 
 class OscilloscopeStateProvider extends ChangeNotifier {
+  late OscilloscopeConfigProvider _configProvider;
   late AudioJack _audioJack;
   late int _selectedIndex;
   late String selectedChannelOffset;
@@ -71,8 +75,17 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   late bool _monitor;
   late double _maxAmp;
   late double _maxFreq;
-  late bool _isRecording;
   late bool isRunning;
+  bool _isPlayingBack = false;
+  bool get isPlayingBack => _isPlayingBack;
+  bool _isPlaybackPaused = false;
+  bool get isPlaybackPaused => _isPlaybackPaused;
+  List<List<dynamic>>? _playbackData;
+  int _playbackIndex = 0;
+  Timer? _playbackTimer;
+  Function? onPlaybackEnd;
+  late bool _isRecording;
+  bool get isRecording => _isRecording;
   bool isMeasurementsChecked = false;
   late Map<String, int> _channelIndexMap;
   late String xyPlotAxis1;
@@ -81,6 +94,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   late List<List<FlSpot>> dataEntriesXYPlot;
   late List<List<FlSpot>> dataEntriesCurveFit;
   late List<String> dataParamsChannels;
+  List<List<dynamic>> _recordedData = [];
   late int _timebaseDivisions;
   int get timebaseDivisions => _timebaseDivisions;
 
@@ -93,6 +107,9 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   late Timer _timer;
 
   late OscilloscopeAxesScale oscilloscopeAxesScale;
+
+  Position? currentPosition;
+  StreamSubscription? _locationStream;
 
   OscilloscopeStateProvider() {
     _audioJack = AudioJack();
@@ -160,6 +177,45 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     oscilloscopeAxesScale = OscilloscopeAxesScale();
 
     monitor();
+  }
+
+  void setConfigProvider(
+      OscilloscopeConfigProvider oscilloscopeConfigProvider) {
+    _configProvider = oscilloscopeConfigProvider;
+  }
+
+  Future<void> _startGeoLocationUpdates() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      logger.w('Location services are disabled.');
+      return;
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        logger.w('Location permissions are denied');
+        return;
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      logger.w(
+          'Location permissions are permanently denied, we cannot request permissions.');
+      return;
+    }
+
+    _locationStream = Geolocator.getPositionStream(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+      ),
+    ).listen((Position position) {
+      currentPosition = position;
+    });
   }
 
   Future<void> monitor() async {
@@ -495,8 +551,6 @@ class OscilloscopeStateProvider extends ChangeNotifier {
         }
       }
 
-      if (_isRecording) {}
-
       if (!isFourierTransformSelected) {
         for (int i = 0; i < min(entries.length, paramsChannels.length); i++) {
           String channel = paramsChannels[i];
@@ -552,6 +606,26 @@ class OscilloscopeStateProvider extends ChangeNotifier {
       dataEntries = List.from(entries);
       dataEntriesCurveFit = List.from(curveFitEntries);
       dataParamsChannels = List.from(paramsChannels);
+      if (_isRecording) {
+        final now = DateTime.now();
+        final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
+        _recordedData.add(
+          [
+            now.millisecondsSinceEpoch.toString(),
+            dateFormat.format(now),
+            dataEntries,
+            dataParamsChannels,
+            oscilloscopeAxesScale.xAxisScale,
+            oscilloscopeAxesScale.yAxisScale,
+            _configProvider.config.includeLocationData
+                ? currentPosition?.latitude.toString() ?? 0
+                : 0,
+            _configProvider.config.includeLocationData
+                ? currentPosition?.longitude.toString() ?? 0
+                : 0
+          ],
+        );
+      }
       if (isFourierTransformSelected) {
         oscilloscopeAxesScale.setYAxisScaleMax(_maxAmp);
         oscilloscopeAxesScale.setYAxisScaleMin(0);
@@ -561,6 +635,168 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     } catch (e) {
       logger.e(e);
     }
+  }
+
+  List<List<FlSpot>> parseFlSpotList(String data) {
+    String clean = data.trim();
+    if (clean.startsWith('[[') && clean.endsWith(']]')) {
+      clean = clean.substring(2, clean.length - 2);
+    }
+
+    List<String> groups = clean.split('], [');
+
+    return groups.map((group) {
+      List<String> tuples = group.split('), (');
+      return tuples.map((tuple) {
+        String cleaned = tuple.replaceAll('(', '').replaceAll(')', '');
+        List<String> parts = cleaned.split(',');
+        if (parts.length <= 2) {
+          return FlSpot(0.0, 0.0);
+        }
+        double x = double.tryParse(parts[0].trim()) ?? 0.0;
+        double y = double.tryParse(parts[1].trim()) ?? 0.0;
+
+        return FlSpot(x, y);
+      }).toList();
+    }).toList();
+  }
+
+  List<String> parseChannelsList(String input) {
+    String clean = input.trim();
+    if (clean.startsWith('[') && clean.endsWith(']')) {
+      clean = clean.substring(1, clean.length - 1);
+    }
+
+    return clean.split(',').map((s) => s.trim()).toList();
+  }
+
+  void _startPlaybackTimer() {
+    if (_playbackIndex >= _playbackData!.length) {
+      stopPlayback();
+      return;
+    }
+
+    final currentRow = _playbackData![_playbackIndex];
+    if (currentRow.length > 2) {
+      dataEntries = parseFlSpotList(currentRow[2]);
+      dataParamsChannels = parseChannelsList(currentRow[3]);
+      oscilloscopeAxesScale
+          .setXAxisScale(double.tryParse(currentRow[4].toString()) ?? 875.0);
+      oscilloscopeAxesScale
+          .setYAxisScale(double.tryParse(currentRow[5].toString()) ?? 16.0);
+      _playbackIndex++;
+      notifyListeners();
+    } else {
+      logger.e(
+          'Skipping playback row at index $_playbackIndex due to insufficient columns (found ${currentRow.length}, expected at least 3');
+      _playbackIndex++;
+      notifyListeners();
+    }
+
+    Duration interval = const Duration(seconds: 1);
+
+    if (_playbackIndex < _playbackData!.length && _playbackIndex > 1) {
+      try {
+        final currentTimestamp =
+            int.tryParse(_playbackData![_playbackIndex - 1][0].toString());
+        final nextTimestamp =
+            int.tryParse(_playbackData![_playbackIndex][0].toString());
+
+        if (currentTimestamp != null && nextTimestamp != null) {
+          final timeDiff = nextTimestamp - currentTimestamp;
+          interval = Duration(milliseconds: timeDiff);
+          if (interval.inMilliseconds < 100) {
+            interval = const Duration(milliseconds: 100);
+          } else if (interval.inMilliseconds > 10000) {
+            interval = const Duration(seconds: 10);
+          }
+        }
+      } catch (e) {
+        interval = const Duration(seconds: 1);
+      }
+    }
+
+    _playbackTimer = Timer(interval, () {
+      if (_isPlayingBack && !_isPlaybackPaused) {
+        _startPlaybackTimer();
+      }
+    });
+  }
+
+  Future<void> stopPlayback() async {
+    _isPlayingBack = false;
+    _isPlaybackPaused = false;
+    _playbackTimer?.cancel();
+    _playbackData = null;
+    _playbackIndex = 0;
+
+    dataEntries.clear();
+    notifyListeners();
+    onPlaybackEnd?.call();
+  }
+
+  void startPlayback(List<List<dynamic>> data) {
+    if (data.length <= 1) return;
+
+    _isPlayingBack = true;
+    _isPlaybackPaused = false;
+    _playbackData = data;
+    _playbackIndex = 1;
+
+    _timer.cancel();
+
+    dataEntries.clear();
+    _startPlaybackTimer();
+    notifyListeners();
+  }
+
+  void pausePlayback() {
+    if (_isPlayingBack) {
+      _isPlaybackPaused = true;
+      _playbackTimer?.cancel();
+      notifyListeners();
+    }
+  }
+
+  void resumePlayback() {
+    if (_isPlayingBack && _isPlaybackPaused) {
+      _isPlaybackPaused = false;
+      _startPlaybackTimer();
+      notifyListeners();
+    }
+  }
+
+  Future<bool> startRecording() async {
+    if (!_scienceLab.isConnected()) {
+      return false;
+    }
+    if (_configProvider.config.includeLocationData) {
+      await _startGeoLocationUpdates();
+    }
+    _isRecording = true;
+    _recordedData = [
+      [
+        'Timestamp',
+        'DateTime',
+        'Readings',
+        'Channels',
+        'XAxisScale',
+        'YAxisScale',
+        'Latitude',
+        'Longitude'
+      ]
+    ];
+    notifyListeners();
+    return true;
+  }
+
+  List<List<dynamic>> stopRecording() {
+    if (_locationStream != null) {
+      _locationStream!.cancel();
+    }
+    _isRecording = false;
+    notifyListeners();
+    return _recordedData;
   }
 
   void setTimebaseDivisions(int divisions) {

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -8,6 +8,7 @@ import 'package:pslab/view/gyroscope_screen.dart';
 import 'package:pslab/view/logged_data_chart_screen.dart';
 import 'package:pslab/view/luxmeter_screen.dart';
 import 'package:pslab/view/map_screen.dart';
+import 'package:pslab/view/oscilloscope_screen.dart';
 import 'package:pslab/view/soundmeter_screen.dart';
 import '../l10n/app_localizations.dart';
 import '../providers/locator.dart';
@@ -218,6 +219,14 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
             ),
           );
           break;
+        case 'oscilloscope':
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => OscilloscopeScreen(playbackData: data),
+            ),
+          );
+          break;
       }
     }
   }
@@ -404,7 +413,10 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                                       appLocalizations.gyroscope
                                           .toLowerCase() ||
                                   instrumentName ==
-                                      appLocalizations.luxMeter.toLowerCase())
+                                      appLocalizations.luxMeter.toLowerCase() ||
+                                  instrumentName ==
+                                      appLocalizations.oscilloscope
+                                          .toLowerCase())
                                 PopupMenuItem<String>(
                                   value: appLocalizations.play,
                                   child: ListTile(

--- a/lib/view/oscilloscope_config_screen.dart
+++ b/lib/view/oscilloscope_config_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/oscilloscope_config_provider.dart';
+import 'package:pslab/view/widgets/config_widgets.dart';
+
+import '../theme/colors.dart';
+
+class OscilloscopeConfigScreen extends StatefulWidget {
+  const OscilloscopeConfigScreen({super.key});
+
+  @override
+  State<OscilloscopeConfigScreen> createState() =>
+      _OscilloscopeConfigScreenState();
+}
+
+class _OscilloscopeConfigScreenState extends State<OscilloscopeConfigScreen> {
+  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      resizeToAvoidBottomInset: true,
+      appBar: AppBar(
+        iconTheme: IconThemeData(color: appBarContentColor),
+        systemOverlayStyle: SystemUiOverlayStyle(statusBarColor: appBarColor),
+        backgroundColor: primaryRed,
+        title: Text(
+          appLocalizations.oscilloscopeConfigs,
+          style: TextStyle(
+            color: appBarContentColor,
+            fontSize: 15,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Consumer<OscilloscopeConfigProvider>(
+            builder: (context, provider, child) {
+              return SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ConfigCheckboxItem(
+                      title: appLocalizations.locationData,
+                      subtitle: appLocalizations.locationDataHint,
+                      value: provider.config.includeLocationData,
+                      onChanged: (value) {
+                        provider.updateIncludeLocationData(value);
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -128,7 +128,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                         child: Row(
                           children: [
                             Expanded(
-                              flex: 87,
+                              flex: 89,
                               child: Container(
                                 margin: const EdgeInsets.only(right: 5),
                                 child: Stack(
@@ -189,7 +189,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                               ),
                             ),
                             const Expanded(
-                              flex: 13,
+                              flex: 11,
                               child: OscilloscopeScreenTabs(),
                             )
                           ],

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -137,7 +137,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                       children: [
                                         Expanded(
                                           flex: constraints.maxHeight < 600
-                                              ? 66
+                                              ? 69
                                               : 80,
                                           child: Container(
                                             padding: const EdgeInsets.only(
@@ -148,7 +148,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                         ),
                                         Expanded(
                                           flex: constraints.maxHeight < 600
-                                              ? 34
+                                              ? 31
                                               : 20,
                                           child: Selector<
                                               OscilloscopeStateProvider, int>(

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/oscilloscope_config_provider.dart';
+import 'package:pslab/theme/colors.dart';
+import 'package:pslab/view/logged_data_screen.dart';
+import 'package:pslab/view/oscilloscope_config_screen.dart';
 import 'package:pslab/view/widgets/channel_parameters_widget.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/data_analysis_widget.dart';
@@ -25,22 +31,146 @@ class OscilloscopeScreen extends StatefulWidget {
   final String timebaseView = 'assets/images/timebase_view.png';
   final String dataAnalysisView = 'assets/images/data_analysis_view.png';
   final String xyPlotView = 'assets/images/xy_plot_view.png';
-  const OscilloscopeScreen({super.key});
+  final List<List<dynamic>>? playbackData;
+  const OscilloscopeScreen({super.key, this.playbackData});
 
   @override
   State<StatefulWidget> createState() => _OscilloscopeScreenState();
 }
 
 class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
+  late OscilloscopeStateProvider _provider;
+  late OscilloscopeConfigProvider? _configProvider;
+  final CsvService _csvService = CsvService();
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
   bool _showGuide = false;
   @override
   void initState() {
+    _provider = OscilloscopeStateProvider();
+    _configProvider = OscilloscopeConfigProvider();
+    _provider.setConfigProvider(_configProvider!);
+
+    _provider.onPlaybackEnd = () {
+      if (mounted && Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
+    };
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setLandscapeOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+      if (widget.playbackData != null) {
+        _provider.startPlayback(widget.playbackData!);
+      }
     });
     super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    _setLandscapeOrientation();
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+    super.didChangeDependencies();
+  }
+
+  void _showOptionsMenu() {
+    showMenu(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        MediaQuery.of(context).size.width,
+        0,
+        0,
+        MediaQuery.of(context).size.height,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'show_logged_data',
+          child: Text(appLocalizations.showLoggedData),
+        ),
+        PopupMenuItem(
+          value: 'oscilloscope_config',
+          child: Text(appLocalizations.oscilloscopeConfigs),
+        ),
+        PopupMenuItem<CheckboxListTile>(
+          child: CheckboxListTile(
+            title: Text(appLocalizations.automatedMeasurements),
+            secondary: IconButton(
+                icon: Icon(Icons.info_outline),
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Text(appLocalizations.automatedMeasurements),
+                        content:
+                            Text(appLocalizations.automatedMeasurementsInfo),
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                            child: Text(appLocalizations.ok),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                }),
+            value: _provider.isMeasurementsChecked,
+            onChanged: (bool? newValue) {
+              setState(() {
+                _provider.isMeasurementsChecked = newValue ?? false;
+              });
+              Navigator.pop(context);
+            },
+          ),
+        ),
+      ],
+      elevation: 8,
+    ).then((value) {
+      if (value != null) {
+        switch (value) {
+          case 'show_logged_data':
+            _navigateToLoggedData();
+            break;
+          case 'oscilloscope_config':
+            _navigateToConfig();
+            break;
+        }
+      }
+    });
+  }
+
+  void _navigateToConfig() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) =>
+            ChangeNotifierProvider<OscilloscopeConfigProvider>.value(
+          value: _configProvider!,
+          child: const OscilloscopeConfigScreen(),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _navigateToLoggedData() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => LoggedDataScreen(
+          instrumentNames: [appLocalizations.oscilloscope.toLowerCase()],
+          appBarName: appLocalizations.oscilloscope,
+          instrumentIcons: [instrumentIcons[0]],
+        ),
+      ),
+    );
+  }
+
+  void _showInstrumentGuide() {
+    setState(() {
+      _showGuide = true;
+    });
   }
 
   void _setPortraitOrientation() {
@@ -104,12 +234,108 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
     super.dispose();
   }
 
+  Future<void> _toggleRecording() async {
+    if (_provider.isRecording) {
+      final data = _provider.stopRecording();
+      await _showSaveFileDialog(data);
+    } else {
+      bool hasStarted = await _provider.startRecording();
+      if (!mounted) return;
+      if (hasStarted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '${appLocalizations.recordingStarted}...',
+              style: TextStyle(color: snackBarContentColor),
+            ),
+            backgroundColor: snackBarBackgroundColor,
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              appLocalizations.notConnected,
+              style: TextStyle(color: snackBarContentColor),
+            ),
+            backgroundColor: snackBarBackgroundColor,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
+    final TextEditingController filenameController = TextEditingController();
+    final String defaultFilename =
+        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
+    filenameController.text = defaultFilename;
+
+    final String? fileName = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.saveRecording),
+          content: TextField(
+            controller: filenameController,
+            decoration: InputDecoration(
+              hintText: appLocalizations.enterFileName,
+              labelText: appLocalizations.fileName,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel.toUpperCase()),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, filenameController.text);
+              },
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (fileName != null) {
+      _csvService.writeMetaData(
+          appLocalizations.oscilloscope.toLowerCase(), data);
+      final file = await _csvService.saveCsvFile(
+          appLocalizations.oscilloscope.toLowerCase(), fileName, data);
+      if (mounted) {
+        if (file != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                '${appLocalizations.fileSaved}: ${file.path.split('/').last}',
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                appLocalizations.failedToSave,
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        }
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<OscilloscopeStateProvider>(
-          create: (_) => OscilloscopeStateProvider(),
+          create: (_) => _provider,
         ),
       ],
       child: Consumer<OscilloscopeStateProvider>(
@@ -119,81 +345,114 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
               CommonScaffold(
                 title: appLocalizations.oscilloscope,
                 key: const Key(oscilloscopeScreenTitleKey),
+                onOptionsPressed:
+                    provider.isPlayingBack ? null : _showOptionsMenu,
+                onGuidePressed: _showInstrumentGuide,
+                onRecordPressed:
+                    provider.isPlayingBack ? null : _toggleRecording,
+                isRecording: provider.isRecording,
+                isPlayingBack: provider.isPlayingBack,
+                isPlaybackPaused: provider.isPlaybackPaused,
+                onPlaybackPauseResume: provider.isPlayingBack
+                    ? (provider.isPlaybackPaused
+                        ? _provider.resumePlayback
+                        : _provider.pausePlayback)
+                    : null,
+                onPlaybackStop: provider.isPlayingBack
+                    ? () async {
+                        await _provider.stopPlayback();
+                      }
+                    : null,
                 body: SafeArea(
                   minimum: const EdgeInsets.only(right: 0, bottom: 0),
                   child: LayoutBuilder(
                     builder: (context, constraints) {
                       return Container(
                         margin: const EdgeInsets.only(left: 5, top: 5),
-                        child: Row(
-                          children: [
-                            Expanded(
-                              flex: 89,
-                              child: Container(
-                                margin: const EdgeInsets.only(right: 5),
-                                child: Stack(
-                                  children: [
-                                    Column(
-                                      children: [
-                                        Expanded(
-                                          flex: constraints.maxHeight < 600
-                                              ? 69
-                                              : 80,
-                                          child: Container(
-                                            padding: const EdgeInsets.only(
-                                                bottom: 20),
-                                            color: Colors.black,
-                                            child: const OscilloscopeGraph(),
+                        child: widget.playbackData != null
+                            ? Container(
+                                margin:
+                                    const EdgeInsets.only(right: 5, bottom: 5),
+                                padding: const EdgeInsets.only(bottom: 20),
+                                color: Colors.black,
+                                child: OscilloscopeGraph(),
+                              )
+                            : Row(
+                                children: [
+                                  Expanded(
+                                    flex: 89,
+                                    child: Container(
+                                      margin: const EdgeInsets.only(right: 5),
+                                      child: Stack(
+                                        children: [
+                                          Column(
+                                            children: [
+                                              Expanded(
+                                                flex:
+                                                    constraints.maxHeight < 600
+                                                        ? 68
+                                                        : 80,
+                                                child: Container(
+                                                  padding:
+                                                      const EdgeInsets.only(
+                                                          bottom: 20),
+                                                  color: Colors.black,
+                                                  child:
+                                                      const OscilloscopeGraph(),
+                                                ),
+                                              ),
+                                              Expanded(
+                                                flex:
+                                                    constraints.maxHeight < 600
+                                                        ? 32
+                                                        : 20,
+                                                child: Selector<
+                                                    OscilloscopeStateProvider,
+                                                    int>(
+                                                  selector: (context,
+                                                          provider) =>
+                                                      provider.selectedIndex,
+                                                  builder: (context,
+                                                      selectedIndex, _) {
+                                                    switch (selectedIndex) {
+                                                      case 0:
+                                                        return const ChannelParametersWidget();
+                                                      case 1:
+                                                        return const TimebaseTriggerWidget();
+                                                      case 2:
+                                                        return const DataAnalysisWidget();
+                                                      case 3:
+                                                        return const XYPlotWidget();
+                                                      default:
+                                                        return const ChannelParametersWidget();
+                                                    }
+                                                  },
+                                                ),
+                                              ),
+                                            ],
                                           ),
-                                        ),
-                                        Expanded(
-                                          flex: constraints.maxHeight < 600
-                                              ? 31
-                                              : 20,
-                                          child: Selector<
-                                              OscilloscopeStateProvider, int>(
-                                            selector: (context, provider) =>
-                                                provider.selectedIndex,
-                                            builder:
-                                                (context, selectedIndex, _) {
-                                              switch (selectedIndex) {
-                                                case 0:
-                                                  return const ChannelParametersWidget();
-                                                case 1:
-                                                  return const TimebaseTriggerWidget();
-                                                case 2:
-                                                  return const DataAnalysisWidget();
-                                                case 3:
-                                                  return const XYPlotWidget();
-                                                default:
-                                                  return const ChannelParametersWidget();
-                                              }
-                                            },
-                                          ),
-                                        ),
-                                      ],
+                                          provider.isMeasurementsChecked
+                                              ? Positioned(
+                                                  right: 0,
+                                                  top: 0,
+                                                  child: SizedBox(
+                                                      width: 135,
+                                                      child: MeasurementsList(
+                                                          dataParamsChannels:
+                                                              provider
+                                                                  .dataParamsChannels)),
+                                                )
+                                              : const SizedBox.shrink(),
+                                        ],
+                                      ),
                                     ),
-                                    provider.isMeasurementsChecked
-                                        ? Positioned(
-                                            right: 0,
-                                            top: 0,
-                                            child: SizedBox(
-                                                width: 135,
-                                                child: MeasurementsList(
-                                                    dataParamsChannels: provider
-                                                        .dataParamsChannels)),
-                                          )
-                                        : const SizedBox.shrink(),
-                                  ],
-                                ),
+                                  ),
+                                  const Expanded(
+                                    flex: 11,
+                                    child: OscilloscopeScreenTabs(),
+                                  )
+                                ],
                               ),
-                            ),
-                            const Expanded(
-                              flex: 11,
-                              child: OscilloscopeScreenTabs(),
-                            )
-                          ],
-                        ),
                       );
                     },
                   ),
@@ -221,63 +480,29 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                           fontWeight: FontWeight.bold,
                         )),
                   ),
-                  IconButton(
-                    icon: provider.isRunning
-                        ? const Icon(
-                            Icons.pause,
-                            color: Colors.white,
-                          )
-                        : const Icon(
-                            Icons.play_arrow,
-                            color: Colors.white,
-                          ),
-                    onPressed: () {
-                      if (provider.isRunning) {
-                        provider.isRunning = false;
-                      } else {
-                        provider.isRunning = true;
-                      }
-                      setState(
-                        () {},
-                      );
-                    },
-                  ),
-                  IconButton(
-                    icon: Image.asset(
-                      widget.icRecord,
-                      width: 24,
-                      height: 24,
-                    ),
-                    onPressed: () {},
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.info, color: Colors.white),
-                    tooltip: appLocalizations.showGuide,
-                    onPressed: () {
-                      setState(() {
-                        _showGuide = !_showGuide;
-                      });
-                    },
-                  ),
-                  PopupMenuButton<CheckboxListTile>(
-                    icon: const Icon(Icons.more_vert, color: Colors.white),
-                    onSelected: (value) {},
-                    itemBuilder: (BuildContext context) => [
-                      PopupMenuItem<CheckboxListTile>(
-                        child: CheckboxListTile(
-                          title: Text(appLocalizations.automatedMeasurements),
-                          value: provider.isMeasurementsChecked,
-                          onChanged: (bool? newValue) {
-                            setState(() {
-                              provider.isMeasurementsChecked =
-                                  newValue ?? false;
-                            });
-                            Navigator.pop(context);
+                  widget.playbackData == null
+                      ? IconButton(
+                          icon: provider.isRunning
+                              ? const Icon(
+                                  Icons.pause,
+                                  color: Colors.white,
+                                )
+                              : const Icon(
+                                  Icons.play_arrow,
+                                  color: Colors.white,
+                                ),
+                          onPressed: () {
+                            if (provider.isRunning) {
+                              provider.isRunning = false;
+                            } else {
+                              provider.isRunning = true;
+                            }
+                            setState(
+                              () {},
+                            );
                           },
-                        ),
-                      ),
-                    ],
-                  ),
+                        )
+                      : const SizedBox.shrink(),
                 ],
               ),
               if (_showGuide)

--- a/lib/view/robotic_arm_screen.dart
+++ b/lib/view/robotic_arm_screen.dart
@@ -285,7 +285,8 @@ class _RoboticArmScreenState extends State<RoboticArmScreen> {
 
                   try {
                     await provider.exportTimelineToCsv(
-                      instrumentName: appLocalizations.roboticArmTitle,
+                      instrumentName:
+                          appLocalizations.roboticArmTitle.toLowerCase(),
                       fileName: (enteredFileName!),
                     );
 

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -73,7 +73,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                         color: oscilloscopeOptionLabelColor,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
-                        fontSize: 15,
+                        fontSize: 14.5,
                       ),
                     ),
                     Padding(
@@ -84,7 +84,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                           color: Color(0xFF424242),
                           fontWeight: FontWeight.normal,
                           fontStyle: FontStyle.normal,
-                          fontSize: 15,
+                          fontSize: 14.5,
                         ),
                       ),
                     ),
@@ -106,7 +106,8 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                           border: InputBorder.none,
                         ),
                         textStyle: TextStyle(
-                            color: oscilloscopeOptionLabelColor, fontSize: 15),
+                            color: oscilloscopeOptionLabelColor,
+                            fontSize: 14.5),
                         onSelected: (String? value) {
                           switch (yAxisRanges.indexOf(value!)) {
                             case 0:
@@ -173,7 +174,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                         color: oscilloscopeOptionLabelColor,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
-                        fontSize: 15,
+                        fontSize: 14.5,
                       ),
                     ),
                     Padding(
@@ -184,7 +185,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                           color: Color(0xFF424242),
                           fontWeight: FontWeight.normal,
                           fontStyle: FontStyle.normal,
-                          fontSize: 15,
+                          fontSize: 14.5,
                         ),
                       ),
                     ),
@@ -198,7 +199,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                             color: oscilloscopeOptionLabelColor,
                             fontStyle: FontStyle.normal,
                             fontWeight: FontWeight.normal,
-                            fontSize: 15,
+                            fontSize: 14.5,
                           ),
                         ),
                       ),
@@ -231,7 +232,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                         color: oscilloscopeOptionLabelColor,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
-                        fontSize: 15,
+                        fontSize: 14.5,
                       ),
                     ),
                   ],
@@ -285,7 +286,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       appLocalizations.inBuiltMic,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
                       ),
@@ -320,7 +321,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       appLocalizations.pslabMic,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
                       ),

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -78,6 +78,7 @@ class _CommonScaffoldState extends State<CommonScaffold> {
           ),
         ),
         actions: [
+          if (widget.actions != null) ...widget.actions!,
           if (widget.isPlayingBack) ...[
             if (widget.onPlaybackPauseResume != null)
               IconButton(
@@ -126,7 +127,6 @@ class _CommonScaffoldState extends State<CommonScaffold> {
                 color: appBarContentColor,
               ),
             ),
-          if (widget.actions != null) ...widget.actions!,
         ],
       ),
       body: widget.body,

--- a/lib/view/widgets/data_analysis_widget.dart
+++ b/lib/view/widgets/data_analysis_widget.dart
@@ -59,7 +59,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                             appLocalizations.fourierAnalysis,
                             style: TextStyle(
                               color: oscilloscopeOptionLabelColor,
-                              fontSize: 15,
+                              fontSize: 14.5,
                               fontWeight: FontWeight.normal,
                               fontStyle: FontStyle.normal,
                             ),
@@ -95,7 +95,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                             ),
                             textStyle: TextStyle(
                               color: oscilloscopeOptionLabelColor,
-                              fontSize: 15,
+                              fontSize: 14.5,
                             ),
                             onSelected: (String? value) {
                               if (value == 'Sine Fit') {
@@ -136,7 +136,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                         ),
                         textStyle: TextStyle(
                           color: oscilloscopeOptionLabelColor,
-                          fontSize: 15,
+                          fontSize: 14.5,
                         ),
                         onSelected: (value) {
                           setState(
@@ -174,7 +174,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                         ),
                         textStyle: TextStyle(
                           color: oscilloscopeOptionLabelColor,
-                          fontSize: 15,
+                          fontSize: 14.5,
                         ),
                         onSelected: (value) {
                           setState(
@@ -252,7 +252,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                           ),
                           textStyle: TextStyle(
                             color: oscilloscopeOptionLabelColor,
-                            fontSize: 15,
+                            fontSize: 14.5,
                           ),
                           onSelected: (value) => {
                             setState(

--- a/lib/view/widgets/oscilloscope_graph.dart
+++ b/lib/view/widgets/oscilloscope_graph.dart
@@ -129,6 +129,18 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                   verticalInterval: oscilloscopeStateProvider
                       .oscilloscopeAxesScale
                       .getTimebaseInterval(),
+                  getDrawingHorizontalLine: (value) {
+                    return const FlLine(
+                      color: Color.fromARGB(50, 255, 255, 255),
+                      strokeWidth: 1,
+                    );
+                  },
+                  getDrawingVerticalLine: (value) {
+                    return const FlLine(
+                      color: Color.fromARGB(50, 255, 255, 255),
+                      strokeWidth: 1,
+                    );
+                  },
                 ),
                 borderData: FlBorderData(
                   show: true,

--- a/lib/view/widgets/oscilloscope_screen_tabs.dart
+++ b/lib/view/widgets/oscilloscope_screen_tabs.dart
@@ -72,7 +72,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                       maxLines: 1,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 10,
+                        fontSize: 9.5,
                         fontStyle: FontStyle.normal,
                         fontWeight: FontWeight.bold,
                       ),
@@ -124,7 +124,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                         maxLines: 1,
                         style: TextStyle(
                           color: oscilloscopeOptionLabelColor,
-                          fontSize: 10,
+                          fontSize: 9.5,
                           fontStyle: FontStyle.normal,
                           fontWeight: FontWeight.bold,
                         ),
@@ -175,7 +175,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                         maxLines: 1,
                         style: TextStyle(
                           color: oscilloscopeOptionLabelColor,
-                          fontSize: 10,
+                          fontSize: 9.5,
                           fontStyle: FontStyle.normal,
                           fontWeight: FontWeight.bold,
                         ),
@@ -226,7 +226,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                       maxLines: 1,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 10,
+                        fontSize: 9.5,
                         fontStyle: FontStyle.normal,
                         fontWeight: FontWeight.bold,
                       ),

--- a/lib/view/widgets/timebase_trigger_widget.dart
+++ b/lib/view/widgets/timebase_trigger_widget.dart
@@ -65,7 +65,7 @@ class _TimebaseTriggerState extends State<TimebaseTriggerWidget> {
                       appLocalizations.trigger,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
                       ),
@@ -89,7 +89,7 @@ class _TimebaseTriggerState extends State<TimebaseTriggerWidget> {
                         ),
                         textStyle: TextStyle(
                           color: oscilloscopeOptionLabelColor,
-                          fontSize: 15,
+                          fontSize: 14,
                         ),
                         onSelected: (String? value) {
                           oscilloscopeStateProvider.triggerChannel = value!;
@@ -228,7 +228,7 @@ class _TimebaseTriggerState extends State<TimebaseTriggerWidget> {
                       appLocalizations.timeBase,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                         fontWeight: FontWeight.bold,
                         fontStyle: FontStyle.normal,
                       ),

--- a/lib/view/widgets/xyplot_widget.dart
+++ b/lib/view/widgets/xyplot_widget.dart
@@ -65,7 +65,7 @@ class _XYPlotState extends State<XYPlotWidget> {
                       appLocalizations.enablePlot,
                       style: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                         fontWeight: FontWeight.normal,
                         fontStyle: FontStyle.normal,
                       ),
@@ -96,7 +96,7 @@ class _XYPlotState extends State<XYPlotWidget> {
                       ),
                       textStyle: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                       ),
                       onSelected: (String? value) {
                         oscilloscopeStateProvider.xyPlotAxis1 = value!;
@@ -118,7 +118,7 @@ class _XYPlotState extends State<XYPlotWidget> {
                       ),
                       textStyle: TextStyle(
                         color: oscilloscopeOptionLabelColor,
-                        fontSize: 15,
+                        fontSize: 14.5,
                       ),
                       onSelected: (String? value) {
                         oscilloscopeStateProvider.xyPlotAxis2 = value!;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -221,10 +221,10 @@ packages:
     dependency: "direct main"
     description:
       name: flusbserial
-      sha256: "82d8201e11e648bd1e6213144dca2bab0a4388dc4d2e65d6698140ad3b0ace80"
+      sha256: e09c993b900230c55a3558a2305006858fae5820237ec10f0cd136bc35394fb1
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.2"
+    version: "0.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -1165,4 +1165,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.3"
+  flutter: ">=3.35.4"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
   path_provider: ^2.1.5
   file_picker: ^10.3.2
   flutter_screenutil: ^5.9.3
-  flusbserial: ^0.2.2
+  flusbserial: ^0.3.0
   inno_bundle: ^0.4.0
   flutter_map: ^8.2.1
   latlong2: ^0.9.1


### PR DESCRIPTION
Fixes #2907

## Screenshots / Recordings

https://github.com/user-attachments/assets/ac365338-d34b-4314-9d8a-f14c52b3d61a


## Summary by Sourcery

Enhancements:
- Adjust OscilloscopeScreen flex values to expand the waveform display area and reduce the tab panel width

## Summary by Sourcery

Enable recording and playback of oscilloscope data (with optional geolocation), introduce a configuration screen and options menu, optimize layout flex ratios and styling, update dependencies, and add new localization entries.

New Features:
- Add oscilloscope data playback mode with play/pause/stop controls for logged CSV recordings
- Enable live recording of oscilloscope data to CSV with save dialog and optional GPS metadata
- Introduce oscilloscope configuration screen for toggling inclusion of location data
- Add options menu in oscilloscope screen for accessing logged data, configurations, and automated measurements toggle

Enhancements:
- Optimize oscilloscope layout by expanding waveform display area (flex 89) and reducing tab panel width (flex 11)
- Standardize font sizes across oscilloscope widgets and add gridline styling to the graph
- Persist oscilloscope settings via shared preferences and inject configuration provider into state management
- Update flusbserial dependency to ^0.3.0

Documentation:
- Add localization keys for oscilloscope configurations and automated measurements info across all supported languages