### PR TITLE
fix: permissions for compliance

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
-    <uses-permission android:name="android.permission.ACCESS_COURSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-feature android:name="android.hardware.usb.host" />
     <uses-feature

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -36,6 +36,8 @@
     <string>App needs access to photo library</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>This app needs access to location.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This app needs access to location.</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>


### PR DESCRIPTION
Removes `FOREGROUND_SERVICE_LOCATION` from the Manifest as it isn't needed and is blocking us from pushing to the Play Store.

Adds `NSLocationAlwaysAndWhenInUseUsageDescription` in Info.plist as it is recommended by App Store Connect.

## Summary by Sourcery

Update platform-specific permission declarations to comply with App Store and Google Play requirements

Bug Fixes:
- Remove unused FOREGROUND_SERVICE_LOCATION permission from AndroidManifest to resolve Play Store submission issues

Enhancements:
- Add NSLocationAlwaysAndWhenInUseUsageDescription key to iOS Info.plist for App Store compliance