### PR TITLE
fix: map tile loading in release builds

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-feature android:name="android.hardware.usb.host" />
     <uses-feature


### PR DESCRIPTION
Fixes #2932 
Adds `android.permission.INTERNET` in the manifest to enable map tile loading in release builds on the _Android_ platform.

Context: https://docs.fleaflet.dev/getting-started/installation#platform-configuration

## Screenshots
<img width="1080" height="2400" alt="Screenshot_1758127343" src="https://github.com/user-attachments/assets/7e3f1cd0-aedc-4d07-a181-0039c157f57f" />

## Summary by Sourcery

Bug Fixes:
- Enable map tile loading in Android release builds by adding android.permission.INTERNET to the AndroidManifest