### PR TITLE
fix: windows build

### DIFF
--- a/.github/actions/windows/action.yml
+++ b/.github/actions/windows/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Build Installer
       shell: pwsh
       run: |
-        choco install innosetup -y
+        choco install innosetup --version=6.4.0 -y
         $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\iscc.exe"
         & "$iscc" /O+ "build\windows\x64\installer\Release\inno-script.iss"
 


### PR DESCRIPTION
Fixes #2939

## Summary by Sourcery

Bug Fixes:
- Pin Inno Setup version to 6.4.0 in the Windows build action to restore build stability