### PR TITLE
feat: finalize Multimeter Screen

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -503,5 +503,7 @@
     "share": "Share",
     "loggedData": "Logged Data",
     "oscilloscopeConfigs": "Oscilloscope Configurations",
-    "automatedMeasurementsInfo": "Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc."
+    "automatedMeasurementsInfo": "Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.",
+    "multimeterConfigs": "Multimeter Configurations",
+    "multimeterUpdatePeriodHint": "Please provide time interval at which data will be updated (100 ms to 1000 ms)"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -3143,6 +3143,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.'**
   String get automatedMeasurementsInfo;
+
+  /// No description provided for @multimeterConfigs.
+  ///
+  /// In en, this message translates to:
+  /// **'Multimeter Configurations'**
+  String get multimeterConfigs;
+
+  /// No description provided for @multimeterUpdatePeriodHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Please provide time interval at which data will be updated (100 ms to 1000 ms)'**
+  String get multimeterUpdatePeriodHint;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1633,6 +1633,13 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }
 
 /// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1633,6 +1633,13 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1633,4 +1633,11 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1633,6 +1633,13 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get multimeterConfigs => 'Multimeter Configurations';
+
+  @override
+  String get multimeterUpdatePeriodHint =>
+      'Please provide time interval at which data will be updated (100 ms to 1000 ms)';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/models/multimeter_config.dart
+++ b/lib/models/multimeter_config.dart
@@ -1,0 +1,33 @@
+class MultimeterConfig {
+  final int updatePeriod;
+  final bool includeLocationData;
+
+  const MultimeterConfig({
+    this.updatePeriod = 1000,
+    this.includeLocationData = true,
+  });
+
+  MultimeterConfig copyWith({
+    int? updatePeriod,
+    bool? includeLocationData,
+  }) {
+    return MultimeterConfig(
+      updatePeriod: updatePeriod ?? this.updatePeriod,
+      includeLocationData: includeLocationData ?? this.includeLocationData,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'updatePeriod': updatePeriod,
+      'includeLocationData': includeLocationData,
+    };
+  }
+
+  factory MultimeterConfig.fromJson(Map<String, dynamic> json) {
+    return MultimeterConfig(
+      updatePeriod: json['updatePeriod'] ?? 1000,
+      includeLocationData: json['includeLocationData'] ?? true,
+    );
+  }
+}

--- a/lib/providers/multimeter_config_provider.dart
+++ b/lib/providers/multimeter_config_provider.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/foundation.dart';
+import 'package:pslab/models/multimeter_config.dart';
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:pslab/others/logger_service.dart';
+
+class MultimeterConfigProvider extends ChangeNotifier {
+  MultimeterConfig _config = const MultimeterConfig();
+
+  MultimeterConfig get config => _config;
+
+  MultimeterConfigProvider() {
+    _loadConfigFromPrefs();
+  }
+
+  Future<void> _loadConfigFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = prefs.getString('multimeter_config');
+      if (jsonString != null) {
+        final Map<String, dynamic> jsonMap = json.decode(jsonString);
+        _config = MultimeterConfig.fromJson(jsonMap);
+        logger.d("Loaded MultimeterConfig: ${_config.toJson()}");
+        notifyListeners();
+      }
+    } catch (e) {
+      logger.e("Error loading MultimeterConfig from prefs: $e");
+      _config = const MultimeterConfig();
+      notifyListeners();
+    }
+  }
+
+  Future<void> _saveConfigToPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('multimeter_config', json.encode(_config.toJson()));
+      logger.d("Saved MultimeterConfig: ${_config.toJson()}");
+    } catch (e) {
+      logger.e("Error saving MultimeterConfig to prefs: $e");
+    }
+  }
+
+  void updateConfig(MultimeterConfig newConfig) {
+    _config = newConfig;
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateUpdatePeriod(int updatePeriod) {
+    _config = _config.copyWith(updatePeriod: updatePeriod);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateIncludeLocationData(bool includeLocationData) {
+    _config = _config.copyWith(includeLocationData: includeLocationData);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void resetToDefaults() {
+    _config = const MultimeterConfig();
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+}

--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -1,11 +1,16 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:intl/intl.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/multimeter_config_provider.dart';
 
 class MultimeterStateProvider extends ChangeNotifier {
+  late MultimeterConfigProvider _configProvider;
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
   late List<String> knobMarker;
   late int _selectedIndex = 0;
@@ -16,7 +21,22 @@ class MultimeterStateProvider extends ChangeNotifier {
   late String unit;
 
   late bool _isProcessing;
-  late Timer _timer;
+  Timer? _timer;
+
+  bool _isPlayingBack = false;
+  bool get isPlayingBack => _isPlayingBack;
+  bool _isPlaybackPaused = false;
+  bool get isPlaybackPaused => _isPlaybackPaused;
+  List<List<dynamic>>? _playbackData;
+  int _playbackIndex = 0;
+  Timer? _playbackTimer;
+  Function? onPlaybackEnd;
+  late bool _isRecording;
+  bool get isRecording => _isRecording;
+  List<List<dynamic>> _recordedData = [];
+
+  Position? currentPosition;
+  StreamSubscription? _locationStream;
 
   MultimeterStateProvider() {
     _selectedIndex = 0;
@@ -39,8 +59,45 @@ class MultimeterStateProvider extends ChangeNotifier {
       appLocalizations.knobMarkerCh2,
     ];
     _isProcessing = false;
+    _isRecording = false;
+  }
 
-    logData();
+  void setConfigProvider(MultimeterConfigProvider multimeterConfigProvider) {
+    _configProvider = multimeterConfigProvider;
+  }
+
+  Future<void> _startGeoLocationUpdates() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      logger.w('Location services are disabled.');
+      return;
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        logger.w('Location permissions are denied');
+        return;
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      logger.w(
+          'Location permissions are permanently denied, we cannot request permissions.');
+      return;
+    }
+
+    _locationStream = Geolocator.getPositionStream(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+      ),
+    ).listen((Position position) {
+      currentPosition = position;
+    });
   }
 
   int getSelectedIndex() => _selectedIndex;
@@ -56,7 +113,9 @@ class MultimeterStateProvider extends ChangeNotifier {
   }
 
   Future<void> logData() async {
-    _timer = Timer.periodic(Duration(milliseconds: delay), (timer) async {
+    _timer = Timer.periodic(
+        Duration(milliseconds: _configProvider.config.updatePeriod),
+        (timer) async {
       if (_isProcessing) {
         return;
       }
@@ -148,6 +207,25 @@ class MultimeterStateProvider extends ChangeNotifier {
             value = voltageValue;
             unit = voltageUnit;
         }
+        if (_isRecording) {
+          final now = DateTime.now();
+          final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
+          _recordedData.add(
+            [
+              now.millisecondsSinceEpoch.toString(),
+              dateFormat.format(now),
+              _selectedIndex,
+              value,
+              unit,
+              _configProvider.config.includeLocationData
+                  ? currentPosition?.latitude.toString() ?? 0
+                  : 0,
+              _configProvider.config.includeLocationData
+                  ? currentPosition?.longitude.toString() ?? 0
+                  : 0
+            ],
+          );
+        }
         notifyListeners();
         _isProcessing = false;
       }
@@ -173,10 +251,137 @@ class MultimeterStateProvider extends ChangeNotifier {
     }
   }
 
+  void _startPlaybackTimer() {
+    if (_playbackIndex >= _playbackData!.length) {
+      stopPlayback();
+      return;
+    }
+
+    final currentRow = _playbackData![_playbackIndex];
+    if (currentRow.length > 2) {
+      _selectedIndex = int.tryParse(currentRow[2].toString()) ?? 0;
+      value = currentRow[3].toString();
+      unit = currentRow[4].toString();
+      _playbackIndex++;
+      notifyListeners();
+    } else {
+      logger.e(
+          'Skipping playback row at index $_playbackIndex due to insufficient columns (found ${currentRow.length}, expected at least 3');
+      _playbackIndex++;
+      notifyListeners();
+    }
+
+    Duration interval = const Duration(seconds: 1);
+
+    if (_playbackIndex < _playbackData!.length && _playbackIndex > 1) {
+      try {
+        final currentTimestamp =
+            int.tryParse(_playbackData![_playbackIndex - 1][0].toString());
+        final nextTimestamp =
+            int.tryParse(_playbackData![_playbackIndex][0].toString());
+
+        if (currentTimestamp != null && nextTimestamp != null) {
+          final timeDiff = nextTimestamp - currentTimestamp;
+          interval = Duration(milliseconds: timeDiff);
+          if (interval.inMilliseconds < 100) {
+            interval = const Duration(milliseconds: 100);
+          } else if (interval.inMilliseconds > 10000) {
+            interval = const Duration(seconds: 10);
+          }
+        }
+      } catch (e) {
+        interval = const Duration(seconds: 1);
+      }
+    }
+
+    _playbackTimer = Timer(interval, () {
+      if (_isPlayingBack && !_isPlaybackPaused) {
+        _startPlaybackTimer();
+      }
+    });
+  }
+
+  Future<void> stopPlayback() async {
+    _isPlayingBack = false;
+    _isPlaybackPaused = false;
+    _playbackTimer?.cancel();
+    _playbackData = null;
+    _playbackIndex = 0;
+
+    notifyListeners();
+    onPlaybackEnd?.call();
+  }
+
+  void startPlayback(List<List<dynamic>> data) {
+    if (data.length <= 1) return;
+
+    _isPlayingBack = true;
+    _isPlaybackPaused = false;
+    _playbackData = data;
+    _playbackIndex = 1;
+
+    if (_timer != null && _timer!.isActive) {
+      _timer!.cancel();
+    }
+
+    value = appLocalizations.defaultValue;
+    unit = appLocalizations.unitVolts;
+    _startPlaybackTimer();
+    notifyListeners();
+  }
+
+  void pausePlayback() {
+    if (_isPlayingBack) {
+      _isPlaybackPaused = true;
+      _playbackTimer?.cancel();
+      notifyListeners();
+    }
+  }
+
+  void resumePlayback() {
+    if (_isPlayingBack && _isPlaybackPaused) {
+      _isPlaybackPaused = false;
+      _startPlaybackTimer();
+      notifyListeners();
+    }
+  }
+
+  Future<bool> startRecording() async {
+    if (!_scienceLab.isConnected()) {
+      return false;
+    }
+    if (_configProvider.config.includeLocationData) {
+      await _startGeoLocationUpdates();
+    }
+    _isRecording = true;
+    _recordedData = [
+      [
+        'Timestamp',
+        'DateTime',
+        'Mode',
+        'Reading',
+        'Unit',
+        'Latitude',
+        'Longitude'
+      ]
+    ];
+    notifyListeners();
+    return true;
+  }
+
+  List<List<dynamic>> stopRecording() {
+    if (_locationStream != null) {
+      _locationStream!.cancel();
+    }
+    _isRecording = false;
+    notifyListeners();
+    return _recordedData;
+  }
+
   @override
   void dispose() {
-    if (_timer.isActive) {
-      _timer.cancel();
+    if (_timer != null && _timer!.isActive) {
+      _timer!.cancel();
     }
     super.dispose();
   }

--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -10,13 +10,12 @@ import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/multimeter_config_provider.dart';
 
 class MultimeterStateProvider extends ChangeNotifier {
-  late MultimeterConfigProvider _configProvider;
+  MultimeterConfigProvider? _configProvider;
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
   late List<String> knobMarker;
   late int _selectedIndex = 0;
   late ScienceLab _scienceLab;
   late bool isSwitchChecked;
-  late int delay;
   late String value;
   late String unit;
 
@@ -42,7 +41,6 @@ class MultimeterStateProvider extends ChangeNotifier {
     _selectedIndex = 0;
     _scienceLab = getIt<ScienceLab>();
     isSwitchChecked = false;
-    delay = 1000;
     value = appLocalizations.defaultValue;
     unit = appLocalizations.unitVolts;
     knobMarker = [
@@ -64,6 +62,16 @@ class MultimeterStateProvider extends ChangeNotifier {
 
   void setConfigProvider(MultimeterConfigProvider multimeterConfigProvider) {
     _configProvider = multimeterConfigProvider;
+    _configProvider?.addListener(_onConfigChanged);
+    _onConfigChanged();
+  }
+
+  void _onConfigChanged() async {
+    if (_timer != null && _timer!.isActive) {
+      _timer!.cancel();
+    }
+    logData();
+    notifyListeners();
   }
 
   Future<void> _startGeoLocationUpdates() async {
@@ -114,7 +122,7 @@ class MultimeterStateProvider extends ChangeNotifier {
 
   Future<void> logData() async {
     _timer = Timer.periodic(
-        Duration(milliseconds: _configProvider.config.updatePeriod),
+        Duration(milliseconds: _configProvider!.config.updatePeriod),
         (timer) async {
       if (_isProcessing) {
         return;
@@ -217,10 +225,10 @@ class MultimeterStateProvider extends ChangeNotifier {
               _selectedIndex,
               value,
               unit,
-              _configProvider.config.includeLocationData
+              _configProvider!.config.includeLocationData
                   ? currentPosition?.latitude.toString() ?? 0
                   : 0,
-              _configProvider.config.includeLocationData
+              _configProvider!.config.includeLocationData
                   ? currentPosition?.longitude.toString() ?? 0
                   : 0
             ],
@@ -350,7 +358,7 @@ class MultimeterStateProvider extends ChangeNotifier {
     if (!_scienceLab.isConnected()) {
       return false;
     }
-    if (_configProvider.config.includeLocationData) {
+    if (_configProvider!.config.includeLocationData) {
       await _startGeoLocationUpdates();
     }
     _isRecording = true;
@@ -383,6 +391,13 @@ class MultimeterStateProvider extends ChangeNotifier {
     if (_timer != null && _timer!.isActive) {
       _timer!.cancel();
     }
+    if (_playbackTimer != null && _playbackTimer!.isActive) {
+      _playbackTimer!.cancel();
+    }
+    if (_locationStream != null) {
+      _locationStream!.cancel();
+    }
+    _configProvider?.removeListener(_onConfigChanged);
     super.dispose();
   }
 }

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -275,13 +275,9 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
     _filteredIndices =
         List<int>.generate(instrumentHeadings.length, (index) => index);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _setOrientation();
+      _setPortraitOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     });
-  }
-
-  void _setOrientation() {
-    _setPortraitOrientation();
   }
 
   void _setPortraitOrientation() {
@@ -294,6 +290,7 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
   @override
   void didChangeDependencies() {
     _setPortraitOrientation();
+    SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     super.didChangeDependencies();
   }
 

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -281,10 +281,20 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
   }
 
   void _setOrientation() {
-    SystemChrome.setPreferredOrientations(<DeviceOrientation>[
+    _setPortraitOrientation();
+  }
+
+  void _setPortraitOrientation() {
+    SystemChrome.setPreferredOrientations([
       DeviceOrientation.portraitUp,
       DeviceOrientation.portraitDown,
     ]);
+  }
+
+  @override
+  void didChangeDependencies() {
+    _setPortraitOrientation();
+    super.didChangeDependencies();
   }
 
   @override

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -8,6 +8,7 @@ import 'package:pslab/view/gyroscope_screen.dart';
 import 'package:pslab/view/logged_data_chart_screen.dart';
 import 'package:pslab/view/luxmeter_screen.dart';
 import 'package:pslab/view/map_screen.dart';
+import 'package:pslab/view/multimeter_screen.dart';
 import 'package:pslab/view/oscilloscope_screen.dart';
 import 'package:pslab/view/soundmeter_screen.dart';
 import '../l10n/app_localizations.dart';
@@ -227,6 +228,14 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
             ),
           );
           break;
+        case 'multimeter':
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => MultimeterScreen(playbackData: data),
+            ),
+          );
+          break;
       }
     }
   }
@@ -416,7 +425,9 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                                       appLocalizations.luxMeter.toLowerCase() ||
                                   instrumentName ==
                                       appLocalizations.oscilloscope
-                                          .toLowerCase())
+                                          .toLowerCase() ||
+                                  instrumentName ==
+                                      appLocalizations.multimeter.toLowerCase())
                                 PopupMenuItem<String>(
                                   value: appLocalizations.play,
                                   child: ListTile(

--- a/lib/view/multimeter_config_screen.dart
+++ b/lib/view/multimeter_config_screen.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/multimeter_config_provider.dart';
+import 'package:pslab/view/widgets/config_widgets.dart';
+
+import '../theme/colors.dart';
+
+class MultimeterConfigScreen extends StatefulWidget {
+  const MultimeterConfigScreen({super.key});
+
+  @override
+  State<MultimeterConfigScreen> createState() => _MultimeterConfigScreenState();
+}
+
+class _MultimeterConfigScreenState extends State<MultimeterConfigScreen> {
+  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  final TextEditingController _updatePeriodController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final provider =
+          Provider.of<MultimeterConfigProvider>(context, listen: false);
+      _updatePeriodController.text = provider.config.updatePeriod.toString();
+    });
+  }
+
+  @override
+  void dispose() {
+    _updatePeriodController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      resizeToAvoidBottomInset: true,
+      appBar: AppBar(
+        iconTheme: IconThemeData(color: appBarContentColor),
+        systemOverlayStyle: SystemUiOverlayStyle(statusBarColor: appBarColor),
+        backgroundColor: primaryRed,
+        title: Text(
+          appLocalizations.multimeterConfigs,
+          style: TextStyle(
+            color: appBarContentColor,
+            fontSize: 15,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Consumer<MultimeterConfigProvider>(
+            builder: (context, provider, child) {
+              return SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ConfigInputItem(
+                      title: appLocalizations.updatePeriod,
+                      value:
+                          '${provider.config.updatePeriod} ${appLocalizations.ms}',
+                      controller: _updatePeriodController,
+                      onChanged: (value) {
+                        final intValue = int.tryParse(value);
+                        if (intValue != null &&
+                            intValue >= 100 &&
+                            intValue <= 1000) {
+                          provider.updateUpdatePeriod(intValue);
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                                content: Text(
+                                  appLocalizations.updatePeriodErrorMessage,
+                                  style: TextStyle(color: snackBarContentColor),
+                                ),
+                                backgroundColor: snackBarBackgroundColor),
+                          );
+                        }
+                      },
+                      hint: appLocalizations.multimeterUpdatePeriodHint,
+                    ),
+                    ConfigCheckboxItem(
+                      title: appLocalizations.locationData,
+                      subtitle: appLocalizations.locationDataHint,
+                      value: provider.config.includeLocationData,
+                      onChanged: (value) {
+                        provider.updateIncludeLocationData(value);
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/multimeter_config_provider.dart';
 import 'package:pslab/providers/multimeter_state_provider.dart';
 import 'package:pslab/theme/colors.dart';
+import 'package:pslab/view/logged_data_screen.dart';
+import 'package:pslab/view/multimeter_config_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/multimeter_knob.dart';
@@ -12,7 +17,8 @@ import 'package:pslab/view/widgets/multimeter_knob.dart';
 class MultimeterScreen extends StatefulWidget {
   final String icRecord = 'assets/icons/ic_record_white.png';
   final multimeterCircuit = 'assets/images/multimeter_circuit.png';
-  const MultimeterScreen({super.key});
+  final List<List<dynamic>>? playbackData;
+  const MultimeterScreen({super.key, this.playbackData});
 
   @override
   State<StatefulWidget> createState() => _MultimeterScreenState();
@@ -20,6 +26,9 @@ class MultimeterScreen extends StatefulWidget {
 
 class _MultimeterScreenState extends State<MultimeterScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  late MultimeterStateProvider _provider;
+  late MultimeterConfigProvider? _configProvider;
+  final CsvService _csvService = CsvService();
   bool _showGuide = false;
 
   void _hideInstrumentGuide() {
@@ -28,10 +37,194 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
     });
   }
 
+  @override
+  void initState() {
+    _provider = MultimeterStateProvider();
+    _configProvider = MultimeterConfigProvider();
+    _provider.setConfigProvider(_configProvider!);
+
+    _provider.onPlaybackEnd = () {
+      if (mounted && Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
+    };
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (widget.playbackData != null) {
+        _provider.startPlayback(widget.playbackData!);
+      } else {
+        _provider.logData();
+      }
+    });
+    super.initState();
+  }
+
   List<Widget> _getMultimeterContent() {
     return [
       InstrumentImage(imagePath: widget.multimeterCircuit),
     ];
+  }
+
+  void _showOptionsMenu() {
+    showMenu(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        MediaQuery.of(context).size.width,
+        0,
+        0,
+        MediaQuery.of(context).size.height,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'show_logged_data',
+          child: Text(appLocalizations.showLoggedData),
+        ),
+        PopupMenuItem(
+          value: 'multimeter_config',
+          child: Text(appLocalizations.multimeterConfigs),
+        ),
+      ],
+      elevation: 8,
+    ).then((value) {
+      if (value != null) {
+        switch (value) {
+          case 'show_logged_data':
+            _navigateToLoggedData();
+            break;
+          case 'multimeter_config':
+            _navigateToConfig();
+            break;
+        }
+      }
+    });
+  }
+
+  void _navigateToConfig() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) =>
+            ChangeNotifierProvider<MultimeterConfigProvider>.value(
+          value: _configProvider!,
+          child: const MultimeterConfigScreen(),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _navigateToLoggedData() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => LoggedDataScreen(
+          instrumentNames: [appLocalizations.multimeter.toLowerCase()],
+          appBarName: appLocalizations.multimeter,
+          instrumentIcons: [instrumentIcons[1]],
+        ),
+      ),
+    );
+  }
+
+  void _showInstrumentGuide() {
+    setState(() {
+      _showGuide = true;
+    });
+  }
+
+  Future<void> _toggleRecording() async {
+    if (_provider.isRecording) {
+      final data = _provider.stopRecording();
+      await _showSaveFileDialog(data);
+    } else {
+      bool hasStarted = await _provider.startRecording();
+      if (!mounted) return;
+      if (hasStarted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '${appLocalizations.recordingStarted}...',
+              style: TextStyle(color: snackBarContentColor),
+            ),
+            backgroundColor: snackBarBackgroundColor,
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              appLocalizations.notConnected,
+              style: TextStyle(color: snackBarContentColor),
+            ),
+            backgroundColor: snackBarBackgroundColor,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
+    final TextEditingController filenameController = TextEditingController();
+    final String defaultFilename =
+        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
+    filenameController.text = defaultFilename;
+
+    final String? fileName = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.saveRecording),
+          content: TextField(
+            controller: filenameController,
+            decoration: InputDecoration(
+              hintText: appLocalizations.enterFileName,
+              labelText: appLocalizations.fileName,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel.toUpperCase()),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, filenameController.text);
+              },
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (fileName != null) {
+      _csvService.writeMetaData(
+          appLocalizations.multimeter.toLowerCase(), data);
+      final file = await _csvService.saveCsvFile(
+          appLocalizations.multimeter.toLowerCase(), fileName, data);
+      if (mounted) {
+        if (file != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                '${appLocalizations.fileSaved}: ${file.path.split('/').last}',
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                appLocalizations.failedToSave,
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        }
+      }
+    }
   }
 
   @override
@@ -39,7 +232,7 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(
-          create: (_) => MultimeterStateProvider(),
+          create: (_) => _provider,
         ),
       ],
       child: Consumer<MultimeterStateProvider>(
@@ -47,8 +240,28 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
           return Stack(
             children: [
               CommonScaffold(
-                title: appLocalizations.multimeterTitle,
+                title: provider.isPlayingBack
+                    ? '${appLocalizations.multimeterTitle} - ${appLocalizations.playback}'
+                    : appLocalizations.multimeterTitle,
                 key: const Key(multimeterScreenTitleKey),
+                onOptionsPressed:
+                    provider.isPlayingBack ? null : _showOptionsMenu,
+                onGuidePressed: _showInstrumentGuide,
+                onRecordPressed:
+                    provider.isPlayingBack ? null : _toggleRecording,
+                isRecording: provider.isRecording,
+                isPlayingBack: provider.isPlayingBack,
+                isPlaybackPaused: provider.isPlaybackPaused,
+                onPlaybackPauseResume: provider.isPlayingBack
+                    ? (provider.isPlaybackPaused
+                        ? _provider.resumePlayback
+                        : _provider.pausePlayback)
+                    : null,
+                onPlaybackStop: provider.isPlayingBack
+                    ? () async {
+                        await _provider.stopPlayback();
+                      }
+                    : null,
                 body: SafeArea(
                   child: LayoutBuilder(
                     builder: (context, constraints) {
@@ -264,27 +477,6 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                     },
                   ),
                 ),
-                actions: [
-                  IconButton(
-                    icon: Image.asset(
-                      widget.icRecord,
-                      width: 24,
-                      height: 24,
-                    ),
-                    onPressed: () {},
-                  ),
-                  IconButton(
-                    icon: Icon(Icons.info, color: multimeterIconColor),
-                    onPressed: () {
-                      setState(() {
-                        _showGuide = !_showGuide;
-                      });
-                    },
-                  ),
-                  IconButton(
-                      icon: Icon(Icons.more_vert, color: multimeterIconColor),
-                      onPressed: () {}),
-                ],
               ),
               if (_showGuide)
                 InstrumentOverviewDrawer(

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -73,6 +73,13 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
     super.didChangeDependencies();
   }
 
+  void _setPortraitOrientation() {
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+    ]);
+  }
+
   void _showOptionsMenu() {
     showMenu(
       context: context,
@@ -222,6 +229,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
 
   @override
   void dispose() {
+    _setPortraitOrientation();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     super.dispose();
   }

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -173,13 +173,6 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
     });
   }
 
-  void _setPortraitOrientation() {
-    SystemChrome.setPreferredOrientations([
-      DeviceOrientation.portraitUp,
-      DeviceOrientation.portraitDown,
-    ]);
-  }
-
   void _setLandscapeOrientation() {
     SystemChrome.setPreferredOrientations([
       DeviceOrientation.landscapeLeft,
@@ -229,7 +222,6 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
 
   @override
   void dispose() {
-    _setPortraitOrientation();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     super.dispose();
   }


### PR DESCRIPTION
Fixes #2941 
Adds Config screens and support for variable time period, data logging and playback.

## Screenshots / Recordings

https://github.com/user-attachments/assets/13677e58-f5ac-4b2f-85b0-48b7657e2d97

## Summary by Sourcery

Implement persistent configuration, data recording, and playback for the Multimeter screen

New Features:
- Add Multimeter Config screen to adjust update period and include location data
- Implement data recording with on-screen controls and CSV export via save dialog
- Add playback mode with controls (pause, resume, stop) and automatic timing based on logged timestamps
- Enable launching Multimeter in playback mode from the logged data list

Enhancements:
- Persist Multimeter settings in SharedPreferences via MultimeterConfigProvider
- Integrate geolocation into recorded data when enabled
- Add options menu on the Multimeter screen for accessing configurations and logged data
- Enforce portrait orientation in instrument navigation screens
- Display playback status in the Multimeter title

Documentation:
- Add localization entries for Multimeter configurations and update period hints in all supported languages