### PR TITLE
fix: persist settings, theme data and other fixes

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -387,6 +387,11 @@
     "dangerous" : "Dangerous",
     "documentationLink" : "https://docs.pslab.io/",
     "documentationError" : "Could not open the documentation link",
+    "androidRatingLink": "https://play.google.com/store/apps/details?id=io.pslab",
+    "iOSRatingLink": "https://apps.apple.com/us/app/pslab/id6740454978?action=write-review",
+    "ratingError": "Could not open the link",
+    "privacyPolicyLink": "https://pslab.io/privacy-policy/",
+    "privacyPolicyError": "Could not open the privacy policy link",
     "deleteFile": "Delete File",
     "deleteAllData": "Delete All Data",
     "deleteCautionMessage": "Are you sure you want to delete all logged data?",
@@ -503,5 +508,10 @@
     "share": "Share",
     "loggedData": "Logged Data",
     "oscilloscopeConfigs": "Oscilloscope Configurations",
-    "automatedMeasurementsInfo": "Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc."
+    "automatedMeasurementsInfo": "Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.",
+    "theme": "Theme",
+    "light": "Light",
+    "darkExperimental": "Dark (Experimental)",
+    "system": "System",
+    "shareApp": "Share App"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -2448,6 +2448,36 @@ abstract class AppLocalizations {
   /// **'Could not open the documentation link'**
   String get documentationError;
 
+  /// No description provided for @androidRatingLink.
+  ///
+  /// In en, this message translates to:
+  /// **'https://play.google.com/store/apps/details?id=io.pslab'**
+  String get androidRatingLink;
+
+  /// No description provided for @iOSRatingLink.
+  ///
+  /// In en, this message translates to:
+  /// **'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review'**
+  String get iOSRatingLink;
+
+  /// No description provided for @ratingError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open the link'**
+  String get ratingError;
+
+  /// No description provided for @privacyPolicyLink.
+  ///
+  /// In en, this message translates to:
+  /// **'https://pslab.io/privacy-policy/'**
+  String get privacyPolicyLink;
+
+  /// No description provided for @privacyPolicyError.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not open the privacy policy link'**
+  String get privacyPolicyError;
+
   /// No description provided for @deleteFile.
   ///
   /// In en, this message translates to:
@@ -3143,6 +3173,30 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.'**
   String get automatedMeasurementsInfo;
+
+  /// No description provided for @theme.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get theme;
+
+  /// No description provided for @darkExperimental.
+  ///
+  /// In en, this message translates to:
+  /// **'Dark (Experimental)'**
+  String get darkExperimental;
+
+  /// No description provided for @system.
+  ///
+  /// In en, this message translates to:
+  /// **'System'**
+  String get system;
+
+  /// No description provided for @shareApp.
+  ///
+  /// In en, this message translates to:
+  /// **'Share App'**
+  String get shareApp;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsDe extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsEn extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsEs extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsFr extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsHe extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsHi extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsId extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsJa extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsNb extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,6 +1650,18 @@ class AppLocalizationsNb extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }
 
 /// The translations for Norwegian Bokmål, as used in Norway (`nb_NO`).

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsPt extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,6 +1650,18 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsRu extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsUk extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsVi extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,4 +1650,16 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -1265,6 +1265,23 @@ class AppLocalizationsZh extends AppLocalizations {
   String get documentationError => 'Could not open the documentation link';
 
   @override
+  String get androidRatingLink =>
+      'https://play.google.com/store/apps/details?id=io.pslab';
+
+  @override
+  String get iOSRatingLink =>
+      'https://apps.apple.com/us/app/pslab/id6740454978?action=write-review';
+
+  @override
+  String get ratingError => 'Could not open the link';
+
+  @override
+  String get privacyPolicyLink => 'https://pslab.io/privacy-policy/';
+
+  @override
+  String get privacyPolicyError => 'Could not open the privacy policy link';
+
+  @override
   String get deleteFile => 'Delete File';
 
   @override
@@ -1633,6 +1650,18 @@ class AppLocalizationsZh extends AppLocalizations {
   @override
   String get automatedMeasurementsInfo =>
       'Automatically measures and displays waveform characteristics such as Amplitude, Frequency, Period, etc.';
+
+  @override
+  String get theme => 'Theme';
+
+  @override
+  String get darkExperimental => 'Dark (Experimental)';
+
+  @override
+  String get system => 'System';
+
+  @override
+  String get shareApp => 'Share App';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hans`).

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/board_state_provider.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/settings_config_provider.dart';
 import 'package:pslab/view/accelerometer_screen.dart';
 import 'package:pslab/view/barometer_screen.dart';
 import 'package:pslab/view/connect_device_screen.dart';
@@ -35,6 +36,9 @@ void main() {
   runApp(
     MultiProvider(
       providers: [
+        ChangeNotifierProvider<SettingsConfigProvider>(
+          create: (context) => SettingsConfigProvider(),
+        ),
         ChangeNotifierProvider<BoardStateProvider>(
           create: (context) => getIt<BoardStateProvider>(),
         ),
@@ -54,47 +58,59 @@ class MyApp extends StatelessWidget {
     return ScreenUtilInit(
       designSize: const Size(360, 690),
       builder: (context, child) {
-        return MaterialApp(
-          debugShowCheckedModeBanner: false,
-          builder: (context, child) {
-            registerAppLocalizations(AppLocalizations.of(context)!);
-            getIt<BoardStateProvider>().initialize();
-            appLocalizations = getIt.get<AppLocalizations>();
-            return child!;
-          },
-          theme: AppTheme.lightTheme,
-          darkTheme: AppTheme.darkTheme,
-          themeMode: ThemeMode.system,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          initialRoute: '/',
-          routes: {
-            '/': (context) => const InstrumentsScreen(),
-            '/oscilloscope': (context) => const OscilloscopeScreen(),
-            '/multimeter': (context) => const MultimeterScreen(),
-            '/waveGenerator': (context) => const WaveGeneratorScreen(),
-            '/logicAnalyzer': (context) => const LogicAnalyzerScreen(),
-            '/powerSource': (context) => const PowerSourceScreen(),
-            '/compass': (context) => const CompassScreen(),
-            '/connectDevice': (context) => const ConnectDeviceScreen(),
-            '/faq': (context) => FAQScreen(),
-            '/settings': (context) => const SettingsScreen(),
-            '/aboutUs': (context) => const AboutUsScreen(),
-            '/softwareLicenses': (context) => SoftwareLicensesScreen(),
-            '/accelerometer': (context) => const AccelerometerScreen(),
-            '/gyroscope': (context) => const GyroscopeScreen(),
-            '/roboticArm': (context) => const RoboticArmScreen(),
-            '/luxmeter': (context) => const LuxMeterScreen(),
-            '/barometer': (context) => const BarometerScreen(),
-            '/soundmeter': (context) => const SoundMeterScreen(),
-            '/thermometer': (context) => const ThermometerScreen(),
-            '/sensors': (context) => const SensorsScreen(),
-            '/experiments': (context) => const ExperimentsScreen(),
-            '/loggedData': (context) => LoggedDataScreen(
-                  instrumentNames: instrumentNames,
-                  appBarName: appLocalizations!.loggedData,
-                  instrumentIcons: instrumentIcons,
-                ),
+        return Consumer<SettingsConfigProvider>(
+          builder: (context, provider, child) {
+            return MaterialApp(
+              debugShowCheckedModeBanner: false,
+              builder: (context, child) {
+                registerAppLocalizations(AppLocalizations.of(context)!);
+                getIt<BoardStateProvider>().initialize();
+                appLocalizations = getIt.get<AppLocalizations>();
+                return child!;
+              },
+              theme: AppTheme.lightTheme,
+              darkTheme: AppTheme.darkTheme,
+              themeMode: () {
+                if (provider.config.theme == "Light") {
+                  return ThemeMode.light;
+                } else if (provider.config.theme == "Dark (Experimental)") {
+                  return ThemeMode.dark;
+                } else {
+                  return ThemeMode.system;
+                }
+              }(),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              initialRoute: '/',
+              routes: {
+                '/': (context) => const InstrumentsScreen(),
+                '/oscilloscope': (context) => const OscilloscopeScreen(),
+                '/multimeter': (context) => const MultimeterScreen(),
+                '/waveGenerator': (context) => const WaveGeneratorScreen(),
+                '/logicAnalyzer': (context) => const LogicAnalyzerScreen(),
+                '/powerSource': (context) => const PowerSourceScreen(),
+                '/compass': (context) => const CompassScreen(),
+                '/connectDevice': (context) => const ConnectDeviceScreen(),
+                '/faq': (context) => FAQScreen(),
+                '/settings': (context) => const SettingsScreen(),
+                '/aboutUs': (context) => const AboutUsScreen(),
+                '/softwareLicenses': (context) => SoftwareLicensesScreen(),
+                '/accelerometer': (context) => const AccelerometerScreen(),
+                '/gyroscope': (context) => const GyroscopeScreen(),
+                '/roboticArm': (context) => const RoboticArmScreen(),
+                '/luxmeter': (context) => const LuxMeterScreen(),
+                '/barometer': (context) => const BarometerScreen(),
+                '/soundmeter': (context) => const SoundMeterScreen(),
+                '/thermometer': (context) => const ThermometerScreen(),
+                '/sensors': (context) => const SensorsScreen(),
+                '/experiments': (context) => const ExperimentsScreen(),
+                '/loggedData': (context) => LoggedDataScreen(
+                      instrumentNames: instrumentNames,
+                      appBarName: appLocalizations!.loggedData,
+                      instrumentIcons: instrumentIcons,
+                    ),
+              },
+            );
           },
         );
       },

--- a/lib/models/settings_config.dart
+++ b/lib/models/settings_config.dart
@@ -31,7 +31,7 @@ class SettingsConfig {
 
   factory SettingsConfig.fromJson(Map<String, dynamic> json) {
     return SettingsConfig(
-      autoStart: json['autoStart'] ?? false,
+      autoStart: json['autoStart'] ?? true,
       exportFormat: json['exportFormat'] ?? 'CSV',
       theme: json['theme'] ?? 'Light',
     );

--- a/lib/models/settings_config.dart
+++ b/lib/models/settings_config.dart
@@ -1,0 +1,39 @@
+class SettingsConfig {
+  final bool autoStart;
+  final String exportFormat;
+  final String theme;
+
+  const SettingsConfig({
+    this.autoStart = true,
+    this.exportFormat = 'CSV',
+    this.theme = 'Light',
+  });
+
+  SettingsConfig copyWith({
+    bool? autoStart,
+    String? exportFormat,
+    String? theme,
+  }) {
+    return SettingsConfig(
+      autoStart: autoStart ?? this.autoStart,
+      exportFormat: exportFormat ?? this.exportFormat,
+      theme: theme ?? this.theme,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'autoStart': autoStart,
+      'exportFormat': exportFormat,
+      'theme': theme,
+    };
+  }
+
+  factory SettingsConfig.fromJson(Map<String, dynamic> json) {
+    return SettingsConfig(
+      autoStart: json['autoStart'] ?? false,
+      exportFormat: json['exportFormat'] ?? 'CSV',
+      theme: json['theme'] ?? 'Light',
+    );
+  }
+}

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -6,11 +6,13 @@ import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/settings_config_provider.dart';
 import 'package:usb_serial/usb_serial.dart';
 
 import 'package:pslab/others/science_lab_common.dart';
 
 class BoardStateProvider extends ChangeNotifier {
+  late SettingsConfigProvider configProvider;
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
   bool initialisationStatus = false;
   bool pslabIsConnected = false;
@@ -21,15 +23,13 @@ class BoardStateProvider extends ChangeNotifier {
   String pslabVersionIDV5 = 'PSLab V5';
   int pslabVersion = 0;
   int pslabFirmwareVersion = 0;
-  late String exportFormat;
-  bool autoStart = true;
   bool _isProcessing = false;
 
   final ValueNotifier<String?> legacyFirmwareNotifier = ValueNotifier(null);
 
   BoardStateProvider() {
     scienceLabCommon = getIt.get<ScienceLabCommon>();
-    exportFormat = appLocalizations.txtFormat;
+    configProvider = SettingsConfigProvider();
   }
 
   Future<void> initialize() async {
@@ -42,7 +42,7 @@ class BoardStateProvider extends ChangeNotifier {
       await fetchFirmwareVersion();
     }
     _isProcessing = false;
-    if (autoStart) {
+    if (configProvider.config.autoStart) {
       if (Platform.isAndroid) {
         UsbSerial.usbEventStream?.listen(
           (UsbEvent usbEvent) async {

--- a/lib/providers/settings_config_provider.dart
+++ b/lib/providers/settings_config_provider.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/foundation.dart';
+import 'package:pslab/models/settings_config.dart';
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:pslab/others/logger_service.dart';
+
+class SettingsConfigProvider extends ChangeNotifier {
+  SettingsConfig _config = const SettingsConfig();
+
+  SettingsConfig get config => _config;
+
+  SettingsConfigProvider() {
+    _loadConfigFromPrefs();
+  }
+
+  Future<void> _loadConfigFromPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = prefs.getString('settings_config');
+      if (jsonString != null) {
+        final Map<String, dynamic> jsonMap = json.decode(jsonString);
+        _config = SettingsConfig.fromJson(jsonMap);
+        logger.d("Loaded SettingsConfig: ${_config.toJson()}");
+        notifyListeners();
+      }
+    } catch (e) {
+      logger.e("Error loading SettingsConfig from prefs: $e");
+      _config = const SettingsConfig();
+      notifyListeners();
+    }
+  }
+
+  Future<void> _saveConfigToPrefs() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString('settings_config', json.encode(_config.toJson()));
+      logger.d("Saved SettingsConfig: ${_config.toJson()}");
+    } catch (e) {
+      logger.e("Error saving SettingsConfig to prefs: $e");
+    }
+  }
+
+  void updateConfig(SettingsConfig newConfig) {
+    _config = newConfig;
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateExportFormat(String exportFormat) {
+    if (exportFormat != "CSV" && exportFormat != "TXT") {
+      exportFormat = "CSV";
+    }
+    _config = _config.copyWith(exportFormat: exportFormat);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateAutoStart(bool autoStart) {
+    _config = _config.copyWith(autoStart: autoStart);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateTheme(String theme) {
+    if (theme != "Light" &&
+        theme != "Dark (Experimental)" &&
+        theme != "System") {
+      theme = "Light";
+    }
+    _config = _config.copyWith(theme: theme);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void resetToDefaults() {
+    _config = const SettingsConfig();
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+}

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -1,135 +1,101 @@
 import 'package:flutter/material.dart';
-import 'package:get_it/get_it.dart';
-import 'package:pslab/theme/colors.dart';
-import 'package:pslab/providers/board_state_provider.dart';
-import 'package:pslab/view/widgets/main_scaffold_widget.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/settings_config_provider.dart';
+import 'package:pslab/view/widgets/config_widgets.dart';
+
+import '../theme/colors.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
 
   @override
-  State<StatefulWidget> createState() => _SettingsScreenState();
+  State<SettingsScreen> createState() => _SettingsScreenState();
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
-  bool isTxtFormatSelected = false;
-  bool isCsvFormatSelected = false;
 
   @override
   void initState() {
     super.initState();
-    isTxtFormatSelected =
-        (GetIt.instance.get<BoardStateProvider>().exportFormat ==
-            appLocalizations.txtFormat);
-    isCsvFormatSelected =
-        (GetIt.instance.get<BoardStateProvider>().exportFormat ==
-            appLocalizations.csvFormat);
   }
 
-  void _showExportFormatDialog() {
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return SimpleDialog(
-          shape: const RoundedRectangleBorder(
-            borderRadius: BorderRadius.zero,
-          ),
-          backgroundColor: Theme.of(context).colorScheme.surface,
-          title: Text(appLocalizations.export,
-              style:
-                  const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-          children: [
-            RadioGroup(
-              groupValue: isTxtFormatSelected,
-              onChanged: (bool? value) {
-                setState(
-                  () {
-                    isTxtFormatSelected = true;
-                    isCsvFormatSelected = false;
-                    GetIt.instance.get<BoardStateProvider>().exportFormat =
-                        appLocalizations.txtFormat;
-                    Navigator.of(context).pop();
-                  },
-                );
-              },
-              child: RadioListTile<bool>(
-                  title: Text(appLocalizations.txtFormat),
-                  value: true,
-                  activeColor: primaryRed),
-            ),
-            RadioGroup(
-              groupValue: isCsvFormatSelected,
-              onChanged: (bool? value) {
-                setState(
-                  () {
-                    isTxtFormatSelected = false;
-                    isCsvFormatSelected = true;
-                    GetIt.instance.get<BoardStateProvider>().exportFormat =
-                        appLocalizations.csvFormat;
-                    Navigator.of(context).pop();
-                  },
-                );
-              },
-              child: RadioListTile<bool>(
-                title: Text(appLocalizations.csvFormat),
-                value: true,
-                activeColor: primaryRed,
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomRight,
-              child: GestureDetector(
-                onTap: () {
-                  Navigator.of(context).pop();
-                },
-                child: Padding(
-                  padding: const EdgeInsets.only(right: 20, bottom: 5),
-                  child: Text(
-                    appLocalizations.cancel.toUpperCase(),
-                    style: const TextStyle(fontWeight: FontWeight.w500),
-                  ),
-                ),
-              ),
-            )
-          ],
-        );
-      },
-    );
+  @override
+  void dispose() {
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return MainScaffold(
-      title: appLocalizations.settings,
-      index: 4,
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      resizeToAvoidBottomInset: true,
+      appBar: AppBar(
+        iconTheme: IconThemeData(color: appBarContentColor),
+        systemOverlayStyle: SystemUiOverlayStyle(statusBarColor: appBarColor),
+        backgroundColor: primaryRed,
+        title: Text(
+          appLocalizations.luxmeterConfigurations,
+          style: TextStyle(
+            color: appBarContentColor,
+            fontSize: 15,
+          ),
+        ),
+      ),
       body: SafeArea(
-        child: ListView(
-          children: [
-            const SizedBox(height: 10),
-            CheckboxListTile(
-              title: Text(appLocalizations.autoStart),
-              subtitle: Text(appLocalizations.autoStartText),
-              value: GetIt.instance.get<BoardStateProvider>().autoStart,
-              onChanged: (bool? value) {
-                setState(() {
-                  GetIt.instance.get<BoardStateProvider>().autoStart = value!;
-                });
-              },
-              activeColor: primaryRed,
-            ),
-            const SizedBox(height: 10),
-            ListTile(
-              title: Text(appLocalizations.export),
-              subtitle: Text(appLocalizations.currentFormat +
-                  GetIt.instance.get<BoardStateProvider>().exportFormat),
-              onTap: () {
-                _showExportFormatDialog();
-              },
-            ),
-          ],
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Consumer<SettingsConfigProvider>(
+            builder: (context, provider, child) {
+              return SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ConfigCheckboxItem(
+                      title: appLocalizations.autoStart,
+                      subtitle: appLocalizations.autoStartText,
+                      value: provider.config.autoStart,
+                      onChanged: (value) {
+                        provider.updateAutoStart(value);
+                      },
+                    ),
+                    ConfigDropdownItem(
+                      title: appLocalizations.export,
+                      selectedValue: provider.config.exportFormat,
+                      options: [
+                        ConfigOption(value: 'CSV', displayName: 'CSV'),
+                        ConfigOption(value: 'TXT', displayName: 'TXT'),
+                      ],
+                      onChanged: (value) {
+                        provider.updateExportFormat(value);
+                      },
+                    ),
+                    ConfigDropdownItem(
+                      title: appLocalizations.theme,
+                      selectedValue: provider.config.theme,
+                      options: [
+                        ConfigOption(
+                            value: 'Light',
+                            displayName: appLocalizations.light),
+                        ConfigOption(
+                            value: 'Dark (Experimental)',
+                            displayName: appLocalizations.darkExperimental),
+                        ConfigOption(
+                            value: 'System',
+                            displayName: appLocalizations.system),
+                      ],
+                      onChanged: (value) {
+                        provider.updateTheme(value);
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
         ),
       ),
     );

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -38,7 +38,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         systemOverlayStyle: SystemUiOverlayStyle(statusBarColor: appBarColor),
         backgroundColor: primaryRed,
         title: Text(
-          appLocalizations.luxmeterConfigurations,
+          appLocalizations.settings,
           style: TextStyle(
             color: appBarContentColor,
             fontSize: 15,

--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -348,35 +348,6 @@ class _NavDrawerState extends State<NavDrawer> {
               },
             ),
             ListTile(
-              focusColor: listTileFocusColor,
-              dense: true,
-              leading: Icon(
-                Icons.menu_book,
-                color:
-                    widget.selectedIndex == 6 ? selectedMenuColor : menuColor,
-              ),
-              title: Text(
-                appLocalizations.documentationMenu,
-                style: TextStyle(
-                  color: widget.selectedIndex == 6
-                      ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 14,
-                ),
-              ),
-              onTap: () async {
-                final launched = await launchUrl(
-                    Uri.parse(appLocalizations.documentationLink));
-                if (!launched && context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                        content: Text(appLocalizations.documentationError)),
-                  );
-                }
-              },
-            ),
-            ListTile(
                 focusColor: listTileFocusColor,
                 dense: true,
                 leading: Icon(

--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/board_state_provider.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../theme/colors.dart';
@@ -324,8 +327,53 @@ class _NavDrawerState extends State<NavDrawer> {
                   fontSize: 14,
                 ),
               ),
-              onTap: () {
-                /**/
+              onTap: () async {
+                if (Platform.isIOS) {
+                  final launched = await launchUrl(
+                      Uri.parse(appLocalizations.iOSRatingLink));
+                  if (!launched && context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(appLocalizations.ratingError)),
+                    );
+                  }
+                } else {
+                  final launched = await launchUrl(
+                      Uri.parse(appLocalizations.androidRatingLink));
+                  if (!launched && context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text(appLocalizations.ratingError)),
+                    );
+                  }
+                }
+              },
+            ),
+            ListTile(
+              focusColor: listTileFocusColor,
+              dense: true,
+              leading: Icon(
+                Icons.menu_book,
+                color:
+                    widget.selectedIndex == 6 ? selectedMenuColor : menuColor,
+              ),
+              title: Text(
+                appLocalizations.documentationMenu,
+                style: TextStyle(
+                  color: widget.selectedIndex == 6
+                      ? selectedMenuColor
+                      : Theme.of(context).colorScheme.onSurface,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 14,
+                ),
+              ),
+              onTap: () async {
+                final launched = await launchUrl(
+                    Uri.parse(appLocalizations.documentationLink));
+                if (!launched && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                        content: Text(appLocalizations.documentationError)),
+                  );
+                }
               },
             ),
             ListTile(
@@ -405,7 +453,9 @@ class _NavDrawerState extends State<NavDrawer> {
                 ),
               ),
               onTap: () {
-                /**/
+                SharePlus.instance.share(
+                  ShareParams(text: appLocalizations.shareApp),
+                );
               },
             ),
             ListTile(
@@ -426,8 +476,15 @@ class _NavDrawerState extends State<NavDrawer> {
                   fontSize: 14,
                 ),
               ),
-              onTap: () {
-                /**/
+              onTap: () async {
+                final launched = await launchUrl(
+                    Uri.parse(appLocalizations.privacyPolicyLink));
+                if (!launched && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                        content: Text(appLocalizations.privacyPolicyError)),
+                  );
+                }
               },
             ),
             ListTile(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -801,10 +801,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
+      sha256: "3424e9d5c22fd7f7590254ba09465febd6f8827c8b19a44350de4ac31d92d3a6"
       url: "https://pub.dev"
     source: hosted
-    version: "11.1.0"
+    version: "12.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   vibration: ^3.1.3
   shared_preferences: ^2.5.3
   csv: ^6.0.0
-  share_plus: ^11.1.0
+  share_plus: ^12.0.0
   path_provider: ^2.1.5
   file_picker: ^10.3.2
   flutter_screenutil: ^5.9.3


### PR DESCRIPTION
Fixes #2929 

# Notable Changes

- Globalized Settings State, made is persistent and added options to switch themes .
- Fixed Navigation Drawer links.

## Screenshots / Recordings
[untitled.webm](https://github.com/user-attachments/assets/0e073c8e-75b2-40e0-9063-5ffe1c4aebc9)

Edit:- The _AppBar_ title has been corrected to 'Settings' in later commits.

## Summary by Sourcery

Persist application settings with a new provider, refactor the settings screen to use Provider-based widgets, enable dynamic theme switching, and fix navigation drawer actions.

New Features:
- Introduce SettingsConfigProvider to persist and manage autoStart, exportFormat, and theme settings via SharedPreferences
- Add theme selection control in settings and apply the chosen theme dynamically across the app
- Implement in-drawer actions for rating the app, sharing the app, opening documentation, and viewing the privacy policy

Bug Fixes:
- Fix navigation drawer links for app rating, documentation, and privacy policy to handle failures with error snackbars

Enhancements:
- Refactor SettingsScreen to use Provider and reusable ConfigWidgets (checkbox and dropdown) instead of manual GetIt-based state
- Wrap MaterialApp in a Consumer to drive themeMode from SettingsConfigProvider
- Replace the old export format dialog with a dropdown control in the settings UI

Build:
- Upgrade share_plus dependency to version 12.0.0

Documentation:
- Add localized strings for rating links, privacy policy links, theme labels, and shareApp across all supported languages