### PR TITLE
feat: finalize Logic Analyzer screen

### DIFF
--- a/lib/models/logic_analyzer_config.dart
+++ b/lib/models/logic_analyzer_config.dart
@@ -1,0 +1,27 @@
+class LogicAnalyzerConfig {
+  final bool includeLocationData;
+
+  const LogicAnalyzerConfig({
+    this.includeLocationData = true,
+  });
+
+  LogicAnalyzerConfig copyWith({
+    bool? includeLocationData,
+  }) {
+    return LogicAnalyzerConfig(
+      includeLocationData: includeLocationData ?? this.includeLocationData,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'includeLocationData': includeLocationData,
+    };
+  }
+
+  factory LogicAnalyzerConfig.fromJson(Map<String, dynamic> json) {
+    return LogicAnalyzerConfig(
+      includeLocationData: json['includeLocationData'] ?? true,
+    );
+  }
+}

--- a/lib/providers/logic_analyzer_config_provider.dart
+++ b/lib/providers/logic_analyzer_config_provider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:pslab/models/logic_analyzer_config.dart';
+
+class LogicAnalyzerConfigProvider extends ChangeNotifier {
+  LogicAnalyzerConfig _config = const LogicAnalyzerConfig();
+
+  LogicAnalyzerConfig get config => _config;
+
+  LogicAnalyzerConfigProvider() {
+    _loadConfigFromPrefs();
+  }
+
+  Future<void> _loadConfigFromPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString('logic_analyzer_config');
+    if (jsonString != null) {
+      final Map<String, dynamic> jsonMap = json.decode(jsonString);
+      _config = LogicAnalyzerConfig.fromJson(jsonMap);
+      notifyListeners();
+    }
+  }
+
+  Future<void> _saveConfigToPrefs() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+        'logic_analyzer_config', json.encode(_config.toJson()));
+  }
+
+  void updateConfig(LogicAnalyzerConfig newConfig) {
+    _config = newConfig;
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void updateIncludeLocationData(bool includeLocationData) {
+    _config = _config.copyWith(includeLocationData: includeLocationData);
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+
+  void resetToDefaults() {
+    _config = const LogicAnalyzerConfig();
+    notifyListeners();
+    _saveConfigToPrefs();
+  }
+}

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -2,14 +2,18 @@ import 'dart:collection';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:intl/intl.dart';
 import 'package:pslab/communication/digitalChannel/digital_channel.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/logic_analyzer_config_provider.dart';
 import 'package:pslab/theme/colors.dart';
 
 class LogicAnalyzerStateProvider extends ChangeNotifier {
+  LogicAnalyzerConfigProvider? _configProvider;
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
   static const singleChannelAxisMin = -0.1;
   static const singleChannelAxisMax = 1.1;
@@ -51,6 +55,9 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
   late ScienceLab _scienceLab;
   late bool isProcessing;
   late bool isData;
+  List<List<dynamic>> _recordedData = [];
+
+  Position? currentPosition;
 
   late List<String> channelNames;
   LogicAnalyzerStateProvider() {
@@ -88,6 +95,44 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     _scienceLab = getIt<ScienceLab>();
     isProcessing = false;
     isData = false;
+  }
+
+  void setConfigProvider(
+      LogicAnalyzerConfigProvider logicAnalyzerConfigProvider) {
+    _configProvider = logicAnalyzerConfigProvider;
+  }
+
+  Future<void> _getCurrentLocation() async {
+    bool serviceEnabled;
+    LocationPermission permission;
+
+    serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      logger.w('Location services are disabled.');
+      return;
+    }
+
+    permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        logger.w('Location permissions are denied');
+        return;
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      logger.w(
+          'Location permissions are permanently denied, we cannot request permissions.');
+      return;
+    }
+
+    final LocationSettings locationSettings = LocationSettings(
+      accuracy: LocationAccuracy.high,
+    );
+
+    currentPosition =
+        await Geolocator.getCurrentPosition(locationSettings: locationSettings);
   }
 
   Future<void> analyze() async {
@@ -703,6 +748,79 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
       }
     }
   }
+
+  List<List<FlSpot>> parseFlSpotList(String data) {
+    String clean = data.trim();
+    if (clean.startsWith('[[') && clean.endsWith(']]')) {
+      clean = clean.substring(2, clean.length - 2);
+    }
+
+    List<String> groups = clean.split('], [');
+
+    return groups.map((group) {
+      List<String> tuples = group.split('), (');
+      return tuples.map((tuple) {
+        String cleaned = tuple.replaceAll('(', '').replaceAll(')', '');
+        List<String> parts = cleaned.split(',');
+        if (parts.length <= 2) {
+          return FlSpot(0.0, 0.0);
+        }
+        double x = double.tryParse(parts[0].trim()) ?? 0.0;
+        double y = double.tryParse(parts[1].trim()) ?? 0.0;
+
+        return FlSpot(x, y);
+      }).toList();
+    }).toList();
+  }
+
+  void loadPlaybackData(List<List<dynamic>> playbackData) {
+    dataSets =
+        parseFlSpotList(playbackData[playbackData.length - 1][2].toString());
+    maxY = double.parse(playbackData[playbackData.length - 1][3].toString());
+    minY = double.parse(playbackData[playbackData.length - 1][4].toString());
+    isData = true;
+    notifyListeners();
+  }
+
+  Future<bool> logData() async {
+    if (!_scienceLab.isConnected()) {
+      return false;
+    }
+    if (_configProvider!.config.includeLocationData) {
+      await _getCurrentLocation();
+    }
+    _recordedData = [
+      [
+        'Timestamp',
+        'DateTime',
+        'Readings',
+        'maxY',
+        'minY',
+        'Latitude',
+        'Longitude'
+      ]
+    ];
+    final now = DateTime.now();
+    final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
+    _recordedData.add(
+      [
+        now.millisecondsSinceEpoch.toString(),
+        dateFormat.format(now),
+        dataSets,
+        maxY,
+        minY,
+        _configProvider!.config.includeLocationData
+            ? currentPosition?.latitude.toString() ?? 0
+            : 0,
+        _configProvider!.config.includeLocationData
+            ? currentPosition?.longitude.toString() ?? 0
+            : 0
+      ],
+    );
+    return true;
+  }
+
+  List<List<dynamic>> get recordedData => _recordedData;
 
   List<LineChartBarData> createPlots() {
     List<LineChartBarData> plots = [];

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -773,13 +773,63 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     }).toList();
   }
 
+  List<String> parseList(String input) {
+    String clean = input.trim();
+    if (clean.startsWith('[') && clean.endsWith(']')) {
+      clean = clean.substring(1, clean.length - 1);
+    }
+
+    return clean.split(',').map((s) => s.trim()).toList();
+  }
+
   void loadPlaybackData(List<List<dynamic>> playbackData) {
     dataSets =
         parseFlSpotList(playbackData[playbackData.length - 1][2].toString());
     maxY = double.parse(playbackData[playbackData.length - 1][3].toString());
     minY = double.parse(playbackData[playbackData.length - 1][4].toString());
+    analysisChannelNames =
+        parseList(playbackData[playbackData.length - 1][5].toString());
+    analysisEdgesNames =
+        parseList(playbackData[playbackData.length - 1][6].toString());
+    channelMode = analysisChannelNames.length;
+    setConfigData();
     isData = true;
     notifyListeners();
+  }
+
+  void setConfigData() {
+    switch (channelMode) {
+      case 1:
+        channelSelectSpinner1 = analysisChannelNames[0];
+        edgeSelectSpinner1 = analysisEdgesNames[0];
+        break;
+      case 2:
+        channelSelectSpinner1 = analysisChannelNames[0];
+        channelSelectSpinner2 = analysisChannelNames[1];
+        edgeSelectSpinner1 = analysisEdgesNames[0];
+        edgeSelectSpinner2 = analysisEdgesNames[1];
+        break;
+      case 3:
+        channelSelectSpinner1 = analysisChannelNames[0];
+        channelSelectSpinner2 = analysisChannelNames[1];
+        channelSelectSpinner3 = analysisChannelNames[2];
+        edgeSelectSpinner1 = analysisEdgesNames[0];
+        edgeSelectSpinner2 = analysisEdgesNames[1];
+        edgeSelectSpinner3 = analysisEdgesNames[2];
+        break;
+      case 4:
+        channelSelectSpinner1 = analysisChannelNames[0];
+        channelSelectSpinner2 = analysisChannelNames[1];
+        channelSelectSpinner3 = analysisChannelNames[2];
+        channelSelectSpinner4 = analysisChannelNames[3];
+        edgeSelectSpinner1 = analysisEdgesNames[0];
+        edgeSelectSpinner2 = analysisEdgesNames[1];
+        edgeSelectSpinner3 = analysisEdgesNames[2];
+        edgeSelectSpinner4 = analysisEdgesNames[3];
+        break;
+      default:
+        break;
+    }
   }
 
   Future<bool> logData() async {
@@ -796,6 +846,8 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
         'Readings',
         'maxY',
         'minY',
+        'Channels',
+        'Edges',
         'Latitude',
         'Longitude'
       ]
@@ -809,6 +861,8 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
         dataSets,
         maxY,
         minY,
+        analysisChannelNames,
+        analysisEdgesNames,
         _configProvider!.config.includeLocationData
             ? currentPosition?.latitude.toString() ?? 0
             : 0,

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -6,6 +6,7 @@ import 'package:pslab/theme/colors.dart';
 import 'package:pslab/view/barometer_screen.dart';
 import 'package:pslab/view/gyroscope_screen.dart';
 import 'package:pslab/view/logged_data_chart_screen.dart';
+import 'package:pslab/view/logic_analyzer_screen.dart';
 import 'package:pslab/view/luxmeter_screen.dart';
 import 'package:pslab/view/map_screen.dart';
 import 'package:pslab/view/multimeter_screen.dart';
@@ -253,6 +254,14 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
             ),
           );
           break;
+        case 'logic analyzer':
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => LogicAnalyzerScreen(playbackData: data),
+            ),
+          );
+          break;
       }
     }
   }
@@ -429,9 +438,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                               }
                             },
                             itemBuilder: (BuildContext context) => [
-                              if (instrumentName ==
-                                      appLocalizations.soundMeter
-                                          .toLowerCase() ||
+                              if (instrumentName == appLocalizations.soundMeter.toLowerCase() ||
                                   instrumentName ==
                                       appLocalizations.barometer
                                           .toLowerCase() ||
@@ -450,7 +457,11 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                                       appLocalizations.oscilloscope
                                           .toLowerCase() ||
                                   instrumentName ==
-                                      appLocalizations.multimeter.toLowerCase())
+                                      appLocalizations.multimeter
+                                          .toLowerCase() ||
+                                  instrumentName ==
+                                      appLocalizations.logicAnalyzer
+                                          .toLowerCase())
                                 PopupMenuItem<String>(
                                   value: appLocalizations.play,
                                   child: ListTile(

--- a/lib/view/logic_analyzer_config_screen.dart
+++ b/lib/view/logic_analyzer_config_screen.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/logic_analyzer_config_provider.dart';
+import 'package:pslab/view/widgets/config_widgets.dart';
+
+import '../theme/colors.dart';
+
+class LogicAnalyzerConfigScreen extends StatefulWidget {
+  const LogicAnalyzerConfigScreen({super.key});
+
+  @override
+  State<LogicAnalyzerConfigScreen> createState() =>
+      _LogicAnalyzerConfigScreenState();
+}
+
+class _LogicAnalyzerConfigScreenState extends State<LogicAnalyzerConfigScreen> {
+  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      resizeToAvoidBottomInset: true,
+      appBar: AppBar(
+        iconTheme: IconThemeData(color: appBarContentColor),
+        systemOverlayStyle: SystemUiOverlayStyle(statusBarColor: appBarColor),
+        backgroundColor: primaryRed,
+        title: Text(
+          appLocalizations.logicAnalyzerConfigs,
+          style: TextStyle(
+            color: appBarContentColor,
+            fontSize: 15,
+          ),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Consumer<LogicAnalyzerConfigProvider>(
+            builder: (context, provider, child) {
+              return SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    ConfigCheckboxItem(
+                      title: appLocalizations.locationData,
+                      subtitle: appLocalizations.locationDataHint,
+                      value: provider.config.includeLocationData,
+                      onChanged: (value) {
+                        provider.updateIncludeLocationData(value);
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/providers/logic_analyzer_config_provider.dart';
@@ -252,6 +253,20 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
                   IconButton(
                     icon: Icon(Icons.save, color: Colors.white),
                     onPressed: () async {
+                      if (!getIt.get<ScienceLab>().isConnected()) {
+                        if (context.mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(
+                                appLocalizations.notConnected,
+                                style: TextStyle(color: snackBarContentColor),
+                              ),
+                              backgroundColor: snackBarBackgroundColor,
+                            ),
+                          );
+                        }
+                        return;
+                      }
                       if (mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -50,12 +50,12 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
     _provider = LogicAnalyzerStateProvider();
     _configProvider = LogicAnalyzerConfigProvider();
     _provider.setConfigProvider(_configProvider!);
+    if (widget.playbackData != null) {
+      _provider.loadPlaybackData(widget.playbackData!);
+    }
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setLandscapeOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
-      if (widget.playbackData != null) {
-        _provider.loadPlaybackData(widget.playbackData!);
-      }
     });
     super.initState();
   }

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/others/csv_service.dart';
+import 'package:pslab/providers/logic_analyzer_config_provider.dart';
 import 'package:pslab/providers/logic_analyzer_state_provider.dart';
 import 'package:pslab/theme/colors.dart';
+import 'package:pslab/view/logged_data_screen.dart';
+import 'package:pslab/view/logic_analyzer_config_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/logic_analyzer_channel_selection.dart';
@@ -11,7 +17,8 @@ import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 
 class LogicAnalyzerScreen extends StatefulWidget {
-  const LogicAnalyzerScreen({super.key});
+  const LogicAnalyzerScreen({super.key, this.playbackData});
+  final List<List<dynamic>>? playbackData;
   final logicAnalyzerCircuit = 'assets/images/logic_analyzer_circuit.png';
 
   @override
@@ -20,6 +27,9 @@ class LogicAnalyzerScreen extends StatefulWidget {
 
 class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  late LogicAnalyzerStateProvider _provider;
+  late LogicAnalyzerConfigProvider? _configProvider;
+  final CsvService _csvService = CsvService();
   bool _showGuide = false;
 
   void _hideInstrumentGuide() {
@@ -36,9 +46,15 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
 
   @override
   void initState() {
+    _provider = LogicAnalyzerStateProvider();
+    _configProvider = LogicAnalyzerConfigProvider();
+    _provider.setConfigProvider(_configProvider!);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _setLandscapeOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersiveSticky);
+      if (widget.playbackData != null) {
+        _provider.loadPlaybackData(widget.playbackData!);
+      }
     });
     super.initState();
   }
@@ -64,12 +80,143 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
     super.dispose();
   }
 
+  Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
+    final TextEditingController filenameController = TextEditingController();
+    final String defaultFilename =
+        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
+    filenameController.text = defaultFilename;
+
+    final String? fileName = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(appLocalizations.saveRecording),
+          content: TextField(
+            controller: filenameController,
+            decoration: InputDecoration(
+              hintText: appLocalizations.enterFileName,
+              labelText: appLocalizations.fileName,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: Text(appLocalizations.cancel.toUpperCase()),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pop(context, filenameController.text);
+              },
+              child: Text(appLocalizations.save),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (fileName != null) {
+      _csvService.writeMetaData(
+          appLocalizations.logicAnalyzer.toLowerCase(), data);
+      final file = await _csvService.saveCsvFile(
+          appLocalizations.logicAnalyzer.toLowerCase(), fileName, data);
+      if (mounted) {
+        if (file != null) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                '${appLocalizations.fileSaved}: ${file.path.split('/').last}',
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                appLocalizations.failedToSave,
+                style: TextStyle(color: snackBarContentColor),
+              ),
+              backgroundColor: snackBarBackgroundColor,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  void _showOptionsMenu() {
+    showMenu(
+      context: context,
+      position: RelativeRect.fromLTRB(
+        MediaQuery.of(context).size.width,
+        0,
+        0,
+        MediaQuery.of(context).size.height,
+      ),
+      items: [
+        PopupMenuItem(
+          value: 'show_logged_data',
+          child: Text(appLocalizations.showLoggedData),
+        ),
+        PopupMenuItem(
+          value: 'logic_analyzer_config',
+          child: Text(appLocalizations.logicAnalyzerConfigs),
+        ),
+      ],
+      elevation: 8,
+    ).then((value) {
+      if (value != null) {
+        switch (value) {
+          case 'show_logged_data':
+            _navigateToLoggedData();
+            break;
+          case 'logic_analyzer_config':
+            _navigateToConfig();
+            break;
+        }
+      }
+    });
+  }
+
+  void _navigateToConfig() {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) =>
+            ChangeNotifierProvider<LogicAnalyzerConfigProvider>.value(
+          value: _configProvider!,
+          child: const LogicAnalyzerConfigScreen(),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _navigateToLoggedData() async {
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => LoggedDataScreen(
+          instrumentNames: [appLocalizations.logicAnalyzer.toLowerCase()],
+          appBarName: appLocalizations.logicAnalyzer,
+          instrumentIcons: [instrumentIcons[2]],
+        ),
+      ),
+    );
+  }
+
+  void _showInstrumentGuide() {
+    setState(() {
+      _showGuide = true;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(
-          create: (context) => LogicAnalyzerStateProvider(),
+          create: (context) => _provider,
         ),
       ],
       child: Consumer<LogicAnalyzerStateProvider>(
@@ -78,6 +225,8 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
             children: [
               CommonScaffold(
                 title: appLocalizations.logicAnalyzerTitle,
+                onOptionsPressed: _showOptionsMenu,
+                onGuidePressed: _showInstrumentGuide,
                 body: SafeArea(
                   minimum: const EdgeInsets.only(right: 0, bottom: 0),
                   child: Container(
@@ -102,19 +251,23 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
                 actions: [
                   IconButton(
                     icon: Icon(Icons.save, color: Colors.white),
-                    onPressed: () {},
-                  ),
-                  IconButton(
-                    icon: Icon(Icons.info, color: Colors.white),
-                    onPressed: () {
-                      setState(() {
-                        _showGuide = !_showGuide;
-                      });
+                    onPressed: () async {
+                      if (mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              appLocalizations.saving,
+                              style: TextStyle(color: snackBarContentColor),
+                            ),
+                            backgroundColor: snackBarBackgroundColor,
+                          ),
+                        );
+                      }
+                      await _provider.logData();
+                      final data = _provider.recordedData;
+                      await _showSaveFileDialog(data);
                     },
                   ),
-                  IconButton(
-                      icon: Icon(Icons.more_vert, color: Colors.white),
-                      onPressed: () {}),
                 ],
               ),
               if (_showGuide)

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -96,7 +96,7 @@ class _LogicAnalyzerChannelSelectionState
                   options: CarouselOptions(
                     height: 40,
                     enableInfiniteScroll: false,
-                    initialPage: 0,
+                    initialPage: provider.channelMode - 1,
                     viewportFraction: 0.4,
                     enlargeCenterPage: true,
                     enlargeFactor: 0.4,


### PR DESCRIPTION
Fixes #2944

## Screenshots / Recordings

https://github.com/user-attachments/assets/c7dda6d2-87f5-4ac9-a237-7f56c169991e

## Summary by Sourcery

New Features:
- Add LogicAnalyzerConfig model to represent and serialize the logic analyzer's includeLocationData setting with copyWith and JSON (de)serialization

## Summary by Sourcery

Finalize the logic analyzer screen by implementing CSV export with optional location metadata, adding a configuration screen for persisting location settings, enabling playback of logged data, and enhancing the UI with an options menu and necessary localization updates

New Features:
- Save logic analyzer recordings to CSV with metadata and custom filename prompt
- Add options menu for navigating to logged data view and logic analyzer configuration
- Introduce logic analyzer configuration screen and provider for persisting include-location-data setting
- Enable playback of previously logged logic analyzer data via navigation from the logged data screen

Enhancements:
- Extend logic analyzer state provider to fetch device geolocation, parse playback data, and expose recorded data
- Refactor provider initialization to share config provider across logic analyzer screens

Documentation:
- Add localization entries for “Logic Analyzer Configurations” and “Saving...” in all supported languages