### PR TITLE
fix: crash on back navigation

### DIFF
--- a/lib/view/accelerometer_screen.dart
+++ b/lib/view/accelerometer_screen.dart
@@ -135,8 +135,8 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => ChangeNotifierProvider(
-          create: (context) => _configProvider,
+        builder: (context) => ChangeNotifierProvider.value(
+          value: _configProvider,
           child: const AccelerometerConfigScreen(),
         ),
       ),

--- a/lib/view/gyroscope_screen.dart
+++ b/lib/view/gyroscope_screen.dart
@@ -134,13 +134,14 @@ class _GyroscopeScreenState extends State<GyroscopeScreen> {
 
   void _navigateToConfig() {
     Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => ChangeNotifierProvider(
-            create: (context) => _configProvider,
-            child: const GyroscopeConfigScreen(),
-          ),
-        ));
+      context,
+      MaterialPageRoute(
+        builder: (context) => ChangeNotifierProvider.value(
+          value: _configProvider,
+          child: const GyroscopeConfigScreen(),
+        ),
+      ),
+    );
   }
 
   Future<void> _toggleRecording() async {

--- a/lib/view/soundmeter_screen.dart
+++ b/lib/view/soundmeter_screen.dart
@@ -95,8 +95,8 @@ class _SoundMeterScreenState extends State<SoundMeterScreen> {
     Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => ChangeNotifierProvider(
-          create: (context) => _configProvider,
+        builder: (context) => ChangeNotifierProvider.value(
+          value: _configProvider,
           child: const SoundMeterConfigScreen(),
         ),
       ),


### PR DESCRIPTION
- Existing providers were disposed when screens were removed.  
- This caused "used after dispose" errors on phone's default back navigation.  
- The issue affected **Accelerometer, Gyroscope, and SoundMeter screens**.


## Changes
- Fixed disposed provider crash by using `ChangeNotifierProvider.value` for existing instances.
- Applies to Accelerometer, Gyroscope, and SoundMeter screens.

**Before**

https://github.com/user-attachments/assets/611e424f-e6b9-49e8-9f26-c2b0a595059b

**After**

https://github.com/user-attachments/assets/6d14198e-314b-44fe-8c70-97b85b560b37

## Summary by Sourcery

Bug Fixes:
- Use ChangeNotifierProvider.value instead of create to prevent disposing existing providers for accelerometer, gyroscope, and sound meter screens