### PR TITLE
chore: replace USB Serial library with version from pub.dev

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1029,12 +1029,11 @@ packages:
   usb_serial:
     dependency: "direct main"
     description:
-      path: "."
-      ref: master
-      resolved-ref: ba7892bca3b8bf7725af92c6cc58279659c2a2bc
-      url: "https://github.com/AsCress/usbserial.git"
-    source: git
-    version: "0.5.1"
+      name: usb_serial
+      sha256: a605a600e34e7f28d4e80851ca3999ef747e42e406138887b8a88b8c382a8b07
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,10 +42,7 @@ dependencies:
   google_fonts: ^6.3.1
   fl_chart: ^1.1.0
   provider: ^6.1.5
-  usb_serial:
-    git:
-      url: https://github.com/AsCress/usbserial.git
-      ref: master
+  usb_serial: ^0.5.0
   get_it: ^8.2.0
   flutter_audio_capture:
     git:


### PR DESCRIPTION
Fixes: #2962

Requires testing with phone and PSLab device.

## Summary by Sourcery

Build:
- Switch usb_serial dependency from Git master to version ^0.5.0 on pub.dev