### PR TITLE
chore: fix target branch for PRs created by workflow

### DIFF
--- a/.github/workflows/flutter_upgrade.yml
+++ b/.github/workflows/flutter_upgrade.yml
@@ -56,5 +56,5 @@ jobs:
 
           PR_URL=$(gh pr create --title "chore(deps): upgrade Flutter to ${{ env.latest_flutter_version }}" \
                        --body "This PR updates Flutter version in pubspec.yaml to the latest stable release." \
-                       --base development \
+                       --base flutter \
                        --head $BRANCH_NAME)


### PR DESCRIPTION
Fixes: https://github.com/fossasia/pslab-app/issues/2966

When the workflow detects that a new version of Flutter is available, it will create a PR which updates the Flutter version of the project.

This PR changes the target branch of the PR created by the workflow to the current default branch called "flutter".

## Summary by Sourcery

Chores:
- Update the GitHub Actions flutter_upgrade workflow to target the "flutter" branch instead of "development"