### PR TITLE
fix(macOS): mark AppIcon as template-rendering-intent to enable system tinting

### DIFF
--- a/.github/actions/windows/action.yml
+++ b/.github/actions/windows/action.yml
@@ -40,6 +40,11 @@ runs:
       run: |
         choco install innosetup --version=6.4.0 -y
         $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\iscc.exe"
+        # Remove missing Icelandic language include if present to avoid build failure
+        $issPath = "build\windows\x64\installer\Release\inno-script.iss"
+        if (Test-Path $issPath) {
+          (Get-Content $issPath) | Where-Object { $_ -notmatch 'Icelandic\.isl' } | Set-Content $issPath
+        }
         & "$iscc" /O+ "build\windows\x64\installer\Release\inno-script.iss"
 
     - name: Store Installer

--- a/macos/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/macos/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -65,4 +65,8 @@
     "version" : 1,
     "author" : "xcode"
   }
+  ,
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
 }


### PR DESCRIPTION
Fixes: #2973, #2974 

fix(macOS): mark AppIcon as template-rendering-intent to enable system tinting

## Summary by Sourcery

Enhancements:
- Add "template-rendering-intent" attribute to the AppIcon asset in Contents.json to allow system tinting on macOS

## Summary by Sourcery

Enable system tinting on macOS by marking the AppIcon asset as a template and harden the Windows build pipeline by stripping out a missing language include in the installer script

Enhancements:
- Mark the macOS AppIcon asset as template-rendering-intent to enable system tinting

Build:
- Remove references to a missing Icelandic language include from the Windows Inno Setup script to prevent CI build failures