### PR TITLE
feat: Added CSV playback for Accelerometer

### DIFF
--- a/lib/providers/accelerometer_state_provider.dart
+++ b/lib/providers/accelerometer_state_provider.dart
@@ -26,12 +26,20 @@ class AccelerometerStateProvider extends ChangeNotifier {
   double _yMin = 0, _yMax = 0;
   double _zMin = 0, _zMax = 0;
   bool _isRecording = false;
+  bool _isPlayingBack = false;
+  List<List<dynamic>>? _playbackData;
+  int _playbackIndex = 0;
+  Timer? _playbackTimer;
+  bool _isPlaybackPaused = false;
   List<List<dynamic>> _recordedData = [];
   bool get isRecording => _isRecording;
+  bool get isPlayingBack => _isPlayingBack;
+  bool get isPlaybackPaused => _isPlaybackPaused;
+
   late AccelerometerConfigProvider _configProvider;
   StreamSubscription? _locationStream;
-
   Position? currentPosition;
+  Function? onPlaybackEnd;
 
   void setConfigProvider(AccelerometerConfigProvider configProvider) {
     _configProvider = configProvider;
@@ -40,37 +48,36 @@ class AccelerometerStateProvider extends ChangeNotifier {
   AccelerometerConfigProvider? get configProvider => _configProvider;
 
   Future<void> _startGeoLocationUpdates() async {
-    bool serviceEnabled;
-    LocationPermission permission;
+    try {
+      bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+      if (!serviceEnabled) return;
 
-    serviceEnabled = await Geolocator.isLocationServiceEnabled();
-    if (!serviceEnabled) {
-      logger.w('Location services are disabled.');
-      return;
-    }
-
-    permission = await Geolocator.checkPermission();
-    if (permission == LocationPermission.denied) {
-      permission = await Geolocator.requestPermission();
+      LocationPermission permission = await Geolocator.checkPermission();
       if (permission == LocationPermission.denied) {
-        logger.w('Location permissions are denied');
-        return;
+        permission = await Geolocator.requestPermission();
+        if (permission == LocationPermission.denied) return;
       }
-    }
+      if (permission == LocationPermission.deniedForever) return;
 
-    if (permission == LocationPermission.deniedForever) {
-      logger.w(
-          'Location permissions are permanently denied, we cannot request permissions.');
-      return;
-    }
+      await _locationStream?.cancel();
 
-    _locationStream = Geolocator.getPositionStream(
-      locationSettings: const LocationSettings(
-        accuracy: LocationAccuracy.high,
-      ),
-    ).listen((Position position) {
-      currentPosition = position;
-    });
+      const locationSettings = LocationSettings(
+        accuracy: LocationAccuracy.medium,
+        distanceFilter: 5,
+      );
+
+      _locationStream = Stream.periodic(const Duration(seconds: 6))
+          .asyncMap(
+        (_) => Geolocator.getCurrentPosition(
+          locationSettings: locationSettings,
+        ),
+      )
+          .listen((Position position) {
+        currentPosition = position;
+      });
+    } catch (e) {
+      logger.e('Error starting location updates: $e');
+    }
   }
 
   void initializeSensors() {
@@ -81,9 +88,7 @@ class AccelerometerStateProvider extends ChangeNotifier {
         notifyListeners();
       },
       onError: (error) {
-        logger.e(
-          "Accelerometer error: $error",
-        );
+        logger.e("Accelerometer error: $error");
       },
       cancelOnError: true,
     );
@@ -91,6 +96,7 @@ class AccelerometerStateProvider extends ChangeNotifier {
 
   void disposeSensors() {
     _accelerometerSubscription?.cancel();
+    _playbackTimer?.cancel();
   }
 
   @override
@@ -100,6 +106,109 @@ class AccelerometerStateProvider extends ChangeNotifier {
     }
     disposeSensors();
     super.dispose();
+  }
+
+  Future<void> startPlayback(List<List<dynamic>> data) async {
+    if (data.length <= 1) return;
+    _isPlayingBack = true;
+    _isPlaybackPaused = false;
+    _playbackTimer?.cancel();
+    _playbackData = data;
+    _playbackIndex = 1;
+    disposeSensors();
+    _xData.clear();
+    _yData.clear();
+    _zData.clear();
+    xData.clear();
+    yData.clear();
+    zData.clear();
+    _startPlaybackTimer();
+    notifyListeners();
+  }
+
+  void _startPlaybackTimer() {
+    if (_playbackIndex >= _playbackData!.length) {
+      stopPlayback();
+      return;
+    }
+
+    final currentRow = _playbackData![_playbackIndex];
+    if (currentRow.length > 4) {
+      final x = double.tryParse(currentRow[2].toString()) ?? 0.0;
+      final y = double.tryParse(currentRow[3].toString()) ?? 0.0;
+      final z = double.tryParse(currentRow[4].toString()) ?? 0.0;
+
+      _accelerometerEvent = AccelerometerEvent(x, y, z, DateTime.now());
+      _updateData();
+      _playbackIndex++;
+      notifyListeners();
+    } else {
+      logger.e(
+          'Skipping playback row at index $_playbackIndex due to insufficient columns (found ${currentRow.length}, expected at least 5');
+      _playbackIndex++;
+      notifyListeners();
+    }
+
+    Duration interval = const Duration(seconds: 1);
+
+    if (_playbackIndex < _playbackData!.length && _playbackIndex > 1) {
+      try {
+        final currentTimestamp =
+            int.tryParse(_playbackData![_playbackIndex - 1][0].toString());
+        final nextTimestamp =
+            int.tryParse(_playbackData![_playbackIndex][0].toString());
+
+        if (currentTimestamp != null && nextTimestamp != null) {
+          final timeDiff = nextTimestamp - currentTimestamp;
+          interval = Duration(milliseconds: timeDiff);
+          if (interval.inMilliseconds < 100) {
+            interval = const Duration(milliseconds: 100);
+          } else if (interval.inMilliseconds > 10000) {
+            interval = const Duration(seconds: 10);
+          }
+        }
+      } catch (e) {
+        interval = const Duration(seconds: 1);
+      }
+    }
+
+    _playbackTimer = Timer(interval, () {
+      if (_isPlayingBack && !_isPlaybackPaused) {
+        _startPlaybackTimer();
+      }
+    });
+  }
+
+  Future<void> stopPlayback() async {
+    _isPlayingBack = false;
+    _isPlaybackPaused = false;
+    _playbackData = null;
+    _playbackIndex = 0;
+    _xData.clear();
+    _yData.clear();
+    _zData.clear();
+    xData.clear();
+    yData.clear();
+    zData.clear();
+    _accelerometerEvent = AccelerometerEvent(0, 0, 0, DateTime.now());
+    notifyListeners();
+    onPlaybackEnd?.call();
+  }
+
+  void pausePlayback() {
+    if (_isPlayingBack) {
+      _isPlaybackPaused = true;
+      _playbackTimer?.cancel();
+      notifyListeners();
+    }
+  }
+
+  void resumePlayback() {
+    if (_isPlayingBack && _isPlaybackPaused) {
+      _isPlaybackPaused = false;
+      _startPlaybackTimer();
+      notifyListeners();
+    }
   }
 
   void _updateData() {

--- a/lib/view/accelerometer_screen.dart
+++ b/lib/view/accelerometer_screen.dart
@@ -16,7 +16,8 @@ import '../theme/colors.dart';
 import 'accelerometer_config_screen.dart';
 
 class AccelerometerScreen extends StatefulWidget {
-  const AccelerometerScreen({super.key});
+  final List<List<dynamic>>? playbackData;
+  const AccelerometerScreen({super.key, this.playbackData});
 
   @override
   State<StatefulWidget> createState() => _AccelerometerScreenState();
@@ -35,10 +36,19 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
     super.initState();
     _provider = AccelerometerStateProvider();
     _configProvider = AccelerometerConfigProvider();
+    _provider.onPlaybackEnd = () {
+      if (mounted && Navigator.canPop(context)) {
+        Navigator.pop(context);
+      }
+    };
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        _provider.setConfigProvider(_configProvider);
-        _provider.initializeSensors();
+        if (widget.playbackData != null) {
+          _provider.startPlayback(widget.playbackData!);
+        } else {
+          _provider.setConfigProvider(_configProvider);
+          _provider.initializeSensors();
+        }
       }
     });
   }
@@ -235,12 +245,26 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
         Consumer<AccelerometerStateProvider>(
           builder: (context, provider, child) {
             return CommonScaffold(
-              title: appLocalizations.accelerometerTitle,
-              key: const Key(accelerometerScreenTitleKey),
+              title: provider.isPlayingBack
+                  ? '${appLocalizations.accelerometerTitle} - ${appLocalizations.playback}'
+                  : appLocalizations.accelerometerTitle,
               onGuidePressed: _showInstrumentGuide,
-              onOptionsPressed: _showOptionsMenu,
-              onRecordPressed: _toggleRecording,
+              onOptionsPressed:
+                  provider.isPlayingBack ? null : _showOptionsMenu,
+              onRecordPressed: provider.isPlayingBack ? null : _toggleRecording,
               isRecording: provider.isRecording,
+              isPlayingBack: provider.isPlayingBack,
+              isPlaybackPaused: provider.isPlaybackPaused,
+              onPlaybackPauseResume: provider.isPlayingBack
+                  ? (provider.isPlaybackPaused
+                      ? _provider.resumePlayback
+                      : _provider.pausePlayback)
+                  : null,
+              onPlaybackStop: provider.isPlayingBack
+                  ? () async {
+                      await _provider.stopPlayback();
+                    }
+                  : null,
               body: SafeArea(
                 child: Column(
                   children: [

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -16,6 +16,7 @@ import 'package:pslab/view/soundmeter_screen.dart';
 import 'package:pslab/view/wave_generator_screen.dart';
 import '../l10n/app_localizations.dart';
 import '../providers/locator.dart';
+import 'accelerometer_screen.dart';
 
 class LoggedDataScreen extends StatefulWidget {
   final List<String> instrumentNames;
@@ -191,7 +192,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
     final data = await _csvService.readCsvFromFile(file);
     if (data.isNotEmpty && mounted) {
       switch (instrumentName) {
-        case 'soundmeter':
+        case 'sound meter':
           Navigator.push(
             context,
             MaterialPageRoute(
@@ -259,6 +260,14 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
             context,
             MaterialPageRoute(
               builder: (context) => LogicAnalyzerScreen(playbackData: data),
+            ),
+          );
+          break;
+        case 'accelerometer':
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => AccelerometerScreen(playbackData: data),
             ),
           );
           break;
@@ -461,6 +470,9 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                                           .toLowerCase() ||
                                   instrumentName ==
                                       appLocalizations.logicAnalyzer
+                                          .toLowerCase() ||
+                                  instrumentName ==
+                                      appLocalizations.accelerometer
                                           .toLowerCase())
                                 PopupMenuItem<String>(
                                   value: appLocalizations.play,


### PR DESCRIPTION
## Changes
- Added **CSV playback** for the **Accelerometer Instrument**, which was previously missing.  
- Fixed a **minor typo** that prevented **Sound Meter CSV playback** from working.

### Recording

https://github.com/user-attachments/assets/04f618f3-edd9-45d0-b450-afce747593e7

## Summary by Sourcery

Add CSV playback functionality to the Accelerometer instrument and correct a typo in Sound Meter CSV playback logic.

New Features:
- Enable CSV playback for accelerometer data with play, pause, resume, and stop controls.
- Display playback status in UI and disable recording/options during playback.
- Schedule playback timing based on timestamps in CSV rows and invoke a callback when playback ends.

Bug Fixes:
- Fix instrument name typo from 'soundmeter' to 'sound meter' for Sound Meter CSV playback.

Enhancements:
- Improve geolocation updates by polling current position with medium accuracy and error handling.
- Streamline logging messages and cancel playback timer on sensor disposal.