### PR TITLE
ci: fixed failing Apple builds

### DIFF
--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -6,6 +6,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
+        if: runner.os != 'macOS' # TODO remove after https://github.com/actions/runner/issues/449 is fixed
         cache: true
         flutter-version-file: pubspec.yaml
 

--- a/.github/actions/common/action.yml
+++ b/.github/actions/common/action.yml
@@ -4,9 +4,9 @@ runs:
   using: "composite"
   steps:
     - name: Set up Flutter
+      if: runner.os != 'macOS' # TODO remove after https://github.com/actions/runner/issues/449 is fixed
       uses: subosito/flutter-action@v2
       with:
-        if: runner.os != 'macOS' # TODO remove after https://github.com/actions/runner/issues/449 is fixed
         cache: true
         flutter-version-file: pubspec.yaml
 

--- a/.github/actions/ios/action.yml
+++ b/.github/actions/ios/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
-        cache: true
+        cache: false # TODO set to <true> after https://github.com/actions/runner/issues/449 is fixed
         flutter-version-file: pubspec.yaml
 
     - name: Update Podfile

--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
-        cache: true
+        cache:  false # TODO set to <true> after https://github.com/actions/runner/issues/449 is fixed
         flutter-version-file: pubspec.yaml
 
     - name: Update Podfile

--- a/.github/actions/screenshot-ipad/action.yml
+++ b/.github/actions/screenshot-ipad/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
-        cache: true
+        cache: false # TODO set to <true> after https://github.com/actions/runner/issues/449 is fixed
         flutter-version-file: pubspec.yaml
 
     - name: Update Podfile

--- a/.github/actions/screenshot-iphone/action.yml
+++ b/.github/actions/screenshot-iphone/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Set up Flutter
       uses: subosito/flutter-action@v2
       with:
-        cache: true
+        cache: false # TODO set to <true> after https://github.com/actions/runner/issues/449 is fixed
         flutter-version-file: pubspec.yaml
 
     - name: Update Podfile


### PR DESCRIPTION
Fixes: https://github.com/fossasia/pslab-app/issues/2979

This is only a workaround which should be removed once the underlying problem in the GitHub actions is fixed. I have created a follow-up issue: https://github.com/fossasia/pslab-app/issues/2981

## Summary by Sourcery

CI:
- Add a conditional to skip the Flutter setup step on macOS runners to avoid current GitHub Actions failures.

## Summary by Sourcery

Work around GitHub Actions runner issues affecting Apple CI jobs by adjusting Flutter setup behavior on macOS-related workflows.

CI:
- Disable Flutter cache usage in iOS and screenshot workflows to avoid current GitHub Actions runner problems on macOS.
- Guard the shared Flutter setup step so it does not run on macOS runners until the upstream runner issue is resolved.