### PR TITLE
fix: non-functional switch in multimeter screen

### DIFF
--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -115,8 +115,8 @@ class MultimeterStateProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void toggleSwitch(bool value) {
-    isSwitchChecked = value;
+  void setSwitch(bool checked) {
+    isSwitchChecked = checked;
     notifyListeners();
   }
 

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -439,7 +439,10 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                                                         value: provider
                                                             .isSwitchChecked,
                                                         onChanged:
-                                                            (bool value) {},
+                                                            (bool value) {
+                                                          provider
+                                                              .setSwitch(value);
+                                                        },
                                                       ),
                                                     ),
                                                     Text(


### PR DESCRIPTION
Fixes #3008

## Changes
- Add call to method which toggles state of the button
- Rename 

## Screenshots / Recordings
https://github.com/user-attachments/assets/33840663-dbf3-4f13-91d5-2bfdcad35883

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Fix the multimeter screen switch so that toggling it updates the underlying state.

Bug Fixes:
- Wire the multimeter screen switch to update the provider state when toggled.

Enhancements:
- Rename the provider method for updating the switch state to a clearer, more descriptive name.