### PR TITLE
fix: power source knob scroll conflict

### DIFF
--- a/lib/view/widgets/power_source_knob.dart
+++ b/lib/view/widgets/power_source_knob.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/providers/power_source_state_provider.dart';
@@ -134,16 +135,7 @@ class PowerSourceKnob extends StatefulWidget {
 class _PowerSourceKnobState extends State<PowerSourceKnob> {
   double outerValue = 0.0;
   late final double maxValue = widget.maxValue;
-
-  final double initialAngle = 150 * pi / 180;
-  double previousAngle = 0.0;
-  bool isDragging = true;
-
-  @override
-  void initState() {
-    super.initState();
-    previousAngle = initialAngle;
-  }
+  bool isDragging = false;
 
   @override
   Widget build(BuildContext context) {
@@ -153,93 +145,123 @@ class _PowerSourceKnobState extends State<PowerSourceKnob> {
       powerSourceStateProvider.getValue(widget.pin),
       widget.pin,
     );
-    void updateOuterValue(double angle) {
-      const startAngle = 155 * pi / 180;
-      const endAngle = 355 * pi / 180;
 
-      const totalAngle = endAngle - startAngle;
+    bool isTouchOnActiveArea(PointerDownEvent event) {
+      final RenderBox box = context.findRenderObject() as RenderBox;
+      final localPosition = box.globalToLocal(event.position);
+      final center = Offset(box.size.width / 2, box.size.height / 2);
+      final distance = (localPosition - center).distance;
+      const double minActiveRadius = 40.0;
+      const double maxActiveRadius = 100.0;
+
+      if (distance >= minActiveRadius && distance <= maxActiveRadius) {
+        return true;
+      }
+      return false;
+    }
+
+    void updateOuterValue(double angle) {
+      const startAngle = 3 * pi / 4;
+      const endAngle = startAngle + 6 * pi / 4;
+      const totalAngle = 6 * pi / 4;
+
+      double normalizedAngle = angle;
+
+      if (normalizedAngle < startAngle || normalizedAngle > endAngle) {
+        double distToStart = (normalizedAngle - startAngle).abs();
+        double distToEnd = (normalizedAngle - endAngle).abs();
+        if (distToStart < distToEnd) {
+          normalizedAngle = startAngle;
+        } else {
+          normalizedAngle = endAngle;
+        }
+      }
 
       final numSections = maxValue;
-
       final anglePerSection = totalAngle / numSections;
 
-      final section = ((angle - startAngle) / anglePerSection).round();
-
+      final section =
+          ((normalizedAngle - startAngle) / anglePerSection).round();
       final clampedSection = section.clamp(0, numSections);
 
-      setState(() async {
+      setState(() {
         outerValue = clampedSection.toDouble();
-        await powerSourceStateProvider.setValue(
-            powerSourceStateProvider.indexToValue(
-              outerValue,
-              widget.pin,
-            ),
-            widget.pin);
       });
+
+      powerSourceStateProvider.setValue(
+        powerSourceStateProvider.indexToValue(
+          outerValue,
+          widget.pin,
+        ),
+        widget.pin,
+      );
     }
 
     void updateAngle(Offset position, Size size) {
-      if (!isDragging) return;
-
       final center = Offset(size.width / 2, size.height / 2);
       final dx = position.dx - center.dx;
       final dy = position.dy - center.dy;
-      final distanceFromCenter = sqrt(dx * dx + dy * dy);
-
-      if (distanceFromCenter > size.width / 2) return;
 
       var angle = atan2(dy, dx);
-
       if (angle < 0) {
         angle += 2 * pi;
       }
 
-      const startAngle = 150 * pi / 180;
-      const endAngle = 360 * pi / 180;
-
-      if (angle >= startAngle && angle <= endAngle) {
-        if ((angle >= previousAngle && angle <= endAngle) ||
-            (angle < startAngle && previousAngle < startAngle) ||
-            (angle - previousAngle).abs() < pi) {
-          setState(() {
-            updateOuterValue(angle);
-          });
-        }
-        previousAngle = angle;
-      }
+      updateOuterValue(angle);
     }
 
-    return Stack(
-      alignment: Alignment.center,
-      children: [
-        CustomPaint(
-          painter: RadialDialPainter(
-            value: outerValue,
-            max: maxValue,
-            color: primaryRed,
+    return RawGestureDetector(
+      behavior: HitTestBehavior.opaque,
+      gestures: {
+        _SelectivePanGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+            _SelectivePanGestureRecognizer>(
+          () => _SelectivePanGestureRecognizer(
+            debugOwner: this,
+            shouldClaimGesture: isTouchOnActiveArea,
           ),
-          child: SizedBox(
-            width: 200,
-            height: 200,
-          ),
-        ),
-        CustomPaint(
-          painter: InnerDialPainter(),
-          child: SizedBox(
-            width: 180,
-            height: 180,
-          ),
-        ),
-        GestureDetector(
-          onPanUpdate: (details) {
-            if (isDragging) {
+          (_SelectivePanGestureRecognizer instance) {
+            instance.onStart = (details) {
+              FocusScope.of(context).unfocus();
+              isDragging = true;
               RenderBox renderBox = context.findRenderObject() as RenderBox;
-              Offset localPosition =
-                  renderBox.globalToLocal(details.globalPosition);
-              updateAngle(localPosition, renderBox.size);
-            }
+              updateAngle(renderBox.globalToLocal(details.globalPosition),
+                  renderBox.size);
+            };
+            instance.onUpdate = (details) {
+              if (isDragging) {
+                RenderBox renderBox = context.findRenderObject() as RenderBox;
+                updateAngle(renderBox.globalToLocal(details.globalPosition),
+                    renderBox.size);
+              }
+            };
+            instance.onEnd = (details) {
+              isDragging = false;
+            };
           },
-          child: CustomPaint(
+        ),
+      },
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CustomPaint(
+            painter: RadialDialPainter(
+              value: outerValue,
+              max: maxValue,
+              color: primaryRed,
+            ),
+            child: SizedBox(
+              width: 200,
+              height: 200,
+            ),
+          ),
+          CustomPaint(
+            painter: InnerDialPainter(),
+            child: SizedBox(
+              width: 180,
+              height: 180,
+            ),
+          ),
+          CustomPaint(
             painter: InnerPointerPainter(
               value: outerValue,
               max: maxValue,
@@ -250,8 +272,28 @@ class _PowerSourceKnobState extends State<PowerSourceKnob> {
               height: 140,
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
+  }
+}
+
+class _SelectivePanGestureRecognizer extends PanGestureRecognizer {
+  final bool Function(PointerDownEvent event) shouldClaimGesture;
+
+  _SelectivePanGestureRecognizer({
+    super.debugOwner,
+    required this.shouldClaimGesture,
+  });
+
+  @override
+  void addPointer(PointerDownEvent event) {
+    super.addPointer(event);
+
+    if (shouldClaimGesture(event)) {
+      resolve(GestureDisposition.accepted);
+    } else {
+      resolve(GestureDisposition.rejected);
+    }
   }
 }

--- a/lib/view/widgets/power_source_knob.dart
+++ b/lib/view/widgets/power_source_knob.dart
@@ -167,6 +167,10 @@ class _PowerSourceKnobState extends State<PowerSourceKnob> {
 
       double normalizedAngle = angle;
 
+      if (normalizedAngle < pi / 2) {
+        normalizedAngle += 2 * pi;
+      }
+
       if (normalizedAngle < startAngle || normalizedAngle > endAngle) {
         double distToStart = (normalizedAngle - startAngle).abs();
         double distToEnd = (normalizedAngle - endAngle).abs();


### PR DESCRIPTION
Fixes #3014 

## Changes

* **Fixed Scroll Conflict:** Implemented a custom `_SelectivePanGestureRecognizer` to prevent the parent `ListView` from stealing touch events during knob adjustment.
* **Smart Touch Zones:** Added `isTouchOnActiveArea` logic to distinguish between knob interaction (ring) and scrolling (center/corners).
* **Expanded Touch Target:** Wrapped the entire `Stack` in the gesture detector, ensuring the visual ring is touchable, not just the inner pointer.

## Screenshots / Recordings

https://github.com/user-attachments/assets/640e5a29-b7ed-4e4e-99e9-5bcba5271c43



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Resolve touch and scroll gesture conflicts for the power source knob by selectively capturing pan gestures on the active dial area and updating value mapping for knob rotation.

Bug Fixes:
- Prevent the surrounding scrollable parent from intercepting knob drag gestures so users can reliably adjust the power source value.
- Ensure knob rotation is only triggered when dragging within the intended ring area, avoiding accidental value changes from center or corner touches.

Enhancements:
- Expand the interactive touch target of the power source knob to match the visual dial ring for more ergonomic interaction.
- Refine the angle-to-value mapping logic for the power source knob to provide more consistent snapping across the full rotation range.