### PR TITLE
fix: resolve invisible checkboxes and radio buttons in dark mode

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -26,14 +26,14 @@ class AppTheme {
     scaffoldBackgroundColor: Colors.black,
     colorSchemeSeed: Colors.black,
     checkboxTheme: const CheckboxThemeData(
-      side: BorderSide(color: Colors.black, width: 2),
+      side: BorderSide(color:Colors.white, width: 2),
     ),
     radioTheme: RadioThemeData(
       fillColor: WidgetStateProperty.resolveWith<Color>((states) {
         if (states.contains(WidgetState.selected)) {
           return radioButtonActiveColor;
         }
-        return Colors.black;
+        return Colors.white;
       }),
     ),
   );

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -25,14 +25,25 @@ class AppTheme {
     useMaterial3: true,
     scaffoldBackgroundColor: Colors.black,
     colorSchemeSeed: Colors.black,
-    checkboxTheme: const CheckboxThemeData(
-      side: BorderSide(color:Colors.white, width: 2),
+    checkboxTheme: CheckboxThemeData(
+      // Fix 1 & 3: Added space and handled disabled state for border
+      side: WidgetStateBorderSide.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return const BorderSide(color: Colors.grey, width: 2);
+        }
+        return const BorderSide(color: Colors.white, width: 2);
+      }),
     ),
     radioTheme: RadioThemeData(
       fillColor: WidgetStateProperty.resolveWith<Color>((states) {
+        // Fix 2: Handle disabled state
+        if (states.contains(WidgetState.disabled)) {
+          return Colors.grey;
+        }
         if (states.contains(WidgetState.selected)) {
           return radioButtonActiveColor;
         }
+        // Fix 1: Use White for unselected (Bot requested derived, but White is standard for Black theme)
         return Colors.white;
       }),
     ),


### PR DESCRIPTION
**Related Issue**
Fixes #3016

**Describe the solution**
Updated `lib/theme/app_theme.dart` to use `Colors.white` instead of `Colors.black` for:
1. `checkboxTheme` (border side)
2. `radioTheme` (unselected fill color)

This ensures these UI elements are visible against the black background in Dark Mode.

**Screenshots**
![Screenshot_20260102-133151 (1)](https://github.com/user-attachments/assets/04b75ef0-7a95-4e6f-bdb4-645cca608089)

## Summary by Sourcery

Adjust dark mode theming for selection controls to keep checkboxes and radio buttons visible against black backgrounds.

Bug Fixes:
- Fix invisible checkbox borders in dark mode by updating their theme color.
- Fix invisible unselected radio buttons in dark mode by updating their theme fill color.