### PR TITLE
fix: restrict Power Source inputs to number pad only

### DIFF
--- a/lib/view/power_source_screen.dart
+++ b/lib/view/power_source_screen.dart
@@ -269,13 +269,12 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             ),
                             textAlign: TextAlign.center,
                             onSubmitted: (value) async {
-                              String powerValue =
-                                  value.replaceAll("V", "").trim();
                               double parsedValue =
-                                  double.tryParse(powerValue) ?? 0.0;
+                                  double.tryParse(value) ?? 0.0;
                               await provider.setPV1(parsedValue);
                             },
                             decoration: InputDecoration(
+                              suffixText: ' V',
                               enabledBorder: OutlineInputBorder(
                                 borderSide: BorderSide(
                                   color: powerSourceBorderLightRed,
@@ -377,16 +376,15 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             ),
                             textAlign: TextAlign.center,
                             onSubmitted: (value) async {
-                              String powerValue =
-                                  value.replaceAll("V", "").trim();
                               double parsedValue =
-                                  double.tryParse(powerValue) ?? 0.0;
+                                  double.tryParse(value) ?? 0.0;
                               await provider.setPV2(parsedValue);
                             },
                             style: TextStyle(
                               fontSize: 18,
                             ),
                             decoration: InputDecoration(
+                              suffixText: ' V',
                               enabledBorder: OutlineInputBorder(
                                 borderSide: BorderSide(
                                   color: powerSourceBorderLightRed,
@@ -488,16 +486,15 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             ),
                             textAlign: TextAlign.center,
                             onSubmitted: (value) async {
-                              String powerValue =
-                                  value.replaceAll("V", "").trim();
                               double parsedValue =
-                                  double.tryParse(powerValue) ?? 0.0;
+                                  double.tryParse(value) ?? 0.0;
                               await provider.setPV3(parsedValue);
                             },
                             style: TextStyle(
                               fontSize: 18,
                             ),
                             decoration: InputDecoration(
+                              suffixText: ' V',
                               enabledBorder: OutlineInputBorder(
                                 borderSide: BorderSide(
                                   color: powerSourceBorderLightRed,
@@ -602,13 +599,12 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             ),
                             textAlign: TextAlign.center,
                             onSubmitted: (value) async {
-                              String powerValue =
-                                  value.replaceAll("V", "").trim();
                               double parsedValue =
-                                  double.tryParse(powerValue) ?? 0.0;
+                                  double.tryParse(value) ?? 0.0;
                               await provider.setPCS(parsedValue);
                             },
                             decoration: InputDecoration(
+                              suffixText: ' mA',
                               enabledBorder: OutlineInputBorder(
                                 borderSide: BorderSide(
                                   color: powerSourceBorderLightRed,

--- a/lib/view/power_source_screen.dart
+++ b/lib/view/power_source_screen.dart
@@ -259,7 +259,8 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
-                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                            keyboardType: const TextInputType.numberWithOptions(
+                                decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.voltagePV1.toStringAsFixed(2)} V',
@@ -370,7 +371,8 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
-                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                            keyboardType: const TextInputType.numberWithOptions(
+                                decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.voltagePV2.toStringAsFixed(2)} V',
@@ -481,7 +483,8 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
-                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                            keyboardType: const TextInputType.numberWithOptions(
+                                decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.voltagePV3.toStringAsFixed(2)} V',
@@ -592,7 +595,8 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
-                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                            keyboardType: const TextInputType.numberWithOptions(
+                                decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.currentPCS.toStringAsFixed(2)} mA',

--- a/lib/view/power_source_screen.dart
+++ b/lib/view/power_source_screen.dart
@@ -259,6 +259,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
+                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.voltagePV1.toStringAsFixed(2)} V',
@@ -369,6 +370,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
+                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.voltagePV2.toStringAsFixed(2)} V',
@@ -479,6 +481,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
+                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.voltagePV3.toStringAsFixed(2)} V',
@@ -589,6 +592,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                           ),
                           const SizedBox(height: 8),
                           TextField(
+                            keyboardType: const TextInputType.numberWithOptions(decimal: true),
                             controller: TextEditingController(
                               text:
                                   '${provider.currentPCS.toStringAsFixed(2)} mA',

--- a/lib/view/power_source_screen.dart
+++ b/lib/view/power_source_screen.dart
@@ -262,8 +262,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             keyboardType: const TextInputType.numberWithOptions(
                                 decimal: true),
                             controller: TextEditingController(
-                              text:
-                                  '${provider.voltagePV1.toStringAsFixed(2)} V',
+                              text: provider.voltagePV1.toStringAsFixed(2),
                             ),
                             style: TextStyle(
                               fontSize: 18,
@@ -374,8 +373,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             keyboardType: const TextInputType.numberWithOptions(
                                 decimal: true),
                             controller: TextEditingController(
-                              text:
-                                  '${provider.voltagePV2.toStringAsFixed(2)} V',
+                              text: provider.voltagePV2.toStringAsFixed(2),
                             ),
                             textAlign: TextAlign.center,
                             onSubmitted: (value) async {
@@ -486,8 +484,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             keyboardType: const TextInputType.numberWithOptions(
                                 decimal: true),
                             controller: TextEditingController(
-                              text:
-                                  '${provider.voltagePV3.toStringAsFixed(2)} V',
+                              text: provider.voltagePV3.toStringAsFixed(2),
                             ),
                             textAlign: TextAlign.center,
                             onSubmitted: (value) async {
@@ -598,8 +595,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
                             keyboardType: const TextInputType.numberWithOptions(
                                 decimal: true),
                             controller: TextEditingController(
-                              text:
-                                  '${provider.currentPCS.toStringAsFixed(2)} mA',
+                              text: provider.currentPCS.toStringAsFixed(2),
                             ),
                             style: TextStyle(
                               fontSize: 18,


### PR DESCRIPTION
**Related Issue**
Fixes #3019

**Describe the solution**
Updated `lib/view/power_source_screen.dart` to use `TextInputType.numberWithOptions(decimal: true)` for:
- PV1
- PV2
- PV3
- PCS

This ensures the user sees a numeric keypad instead of the full QWERTY keyboard, preventing invalid text input and improving UX.

**Screenshots**
<img width="720" height="1600" alt="Screenshot_20260102-161545" src="https://github.com/user-attachments/assets/415261c0-51ef-44ac-a23e-dfac9838ecce" />

## Summary by Sourcery

Bug Fixes:
- Ensure PV1, PV2, PV3, and PCS input fields present a numeric keypad with decimal support instead of a full keyboard to avoid invalid text input.