### PR TITLE
fix: remove hardcoded non-functional menu button from MainScaffold

### DIFF
--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -194,7 +194,7 @@ class _MainScaffoldState extends State<MainScaffold>
                     );
                   },
                 ),
-                ...(widget.actions ?? []),
+                ...(widget.actions ?? const []),
               ],
       ),
       body: widget.body,

--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -194,15 +194,7 @@ class _MainScaffoldState extends State<MainScaffold>
                     );
                   },
                 ),
-                IconButton(
-                  icon: Icon(
-                    Icons.more_vert,
-                    color: appBarContentColor,
-                  ),
-                  onPressed: () {
-                    /**/
-                  },
-                ),
+                ...(widget.actions ?? []),
               ],
       ),
       body: widget.body,


### PR DESCRIPTION
**Related Issue**
Fixes #3021

**Describe the solution**
Removed the hardcoded `IconButton` with `Icons.more_vert` in `MainScaffold` that had an empty `onPressed` callback.
Replaced it with `...(widget.actions ?? [])` to correctly render actions passed from child widgets.

**Screenshots**
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/62aad876-b217-4f4c-a7f9-831e0a85d0ac" />

## Summary by Sourcery

Bug Fixes:
- Ensure MainScaffold correctly renders and wires app bar action widgets passed in via the actions property instead of showing a disabled placeholder button.