### PR TITLE
feat: Add support for SHT21 sensor

### DIFF
--- a/lib/communication/sensors/sht21.dart
+++ b/lib/communication/sensors/sht21.dart
@@ -2,56 +2,43 @@ import 'dart:async';
 import '../peripherals/i2c.dart';
 
 class SHT21 {
-  // SHT21 Default I2C Address
-  static const int addr = 0x40;
-
-  // The I2C helper instance (passed in from the main app)
   final I2C i2c;
+  static const int address = 0x40;
 
-  // Constructor: Ask for the I2C object instead of trying to create a new empty one
+  // Commands (Use Hold Master Mode for readBulk compatibility)
+  static const int tempHoldCmd = 0xE3;
+  static const int humidityHoldCmd = 0xE5;
+
   SHT21(this.i2c);
 
-  // Commands (No Hold Master Mode)
-  static const int _triggerTempMeasure = 0xF3;
-  static const int _triggerHumMeasure = 0xF5;
-
-  /// Read Temperature in Celsius
   Future<double> getTemperature() async {
-    // 1. Send the "Measure" command
-    // We use writeBulk because it sends the bytes directly to the address
-    await i2c.writeBulk(addr, [_triggerTempMeasure]);
+    // FIX: Use readBulk to handle the Write -> Restart -> Read sequence automatically.
+    // This avoids the argument errors with .write() and .read()
+    List<int> data = await i2c.readBulk(address, tempHoldCmd, 3);
 
-    // 2. Wait for measurement (Datasheet max ~85ms)
-    await Future.delayed(Duration(milliseconds: 100));
+    if (data.length < 2) {
+      throw Exception("Failed to read temperature from SHT21");
+    }
 
-    // 3. Read 3 bytes (MSB, LSB, Checksum)
-    // simpleRead automatically handles the "Start Condition" + "Read" logic
-    List<int> data = await i2c.simpleRead(addr, 3);
-
-    if (data.length < 2) return 0.0;
-
-    // 4. Combine bytes & clear status bits
+    // Mask out status bits (last 2 bits) using & 0xFC
     int rawValue = (data[0] << 8) | (data[1] & 0xFC);
 
-    // 5. Calculate Formula
+    // Formula: T = -46.85 + 175.72 * (S_T / 2^16)
     return -46.85 + 175.72 * (rawValue / 65536.0);
   }
 
-  /// Read Humidity in %RH
   Future<double> getHumidity() async {
-    // 1. Send Measure Command
-    await i2c.writeBulk(addr, [_triggerHumMeasure]);
+    // FIX: Use readBulk here too
+    List<int> data = await i2c.readBulk(address, humidityHoldCmd, 3);
 
-    // 2. Wait
-    await Future.delayed(Duration(milliseconds: 100));
+    if (data.length < 2) {
+      throw Exception("Failed to read humidity from SHT21");
+    }
 
-    // 3. Read
-    List<int> data = await i2c.simpleRead(addr, 3);
-    if (data.length < 2) return 0.0;
-
+    // Mask out status bits
     int rawValue = (data[0] << 8) | (data[1] & 0xFC);
 
-    // 4. Calculate
+    // Formula: RH = -6 + 125 * (S_RH / 2^16)
     return -6.0 + 125.0 * (rawValue / 65536.0);
   }
 }

--- a/lib/communication/sensors/sht21.dart
+++ b/lib/communication/sensors/sht21.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+import '../peripherals/i2c.dart';
+
+class SHT21 {
+  // SHT21 Default I2C Address
+  static const int addr = 0x40;
+
+  // The I2C helper instance (passed in from the main app)
+  final I2C i2c;
+
+  // Constructor: Ask for the I2C object instead of trying to create a new empty one
+  SHT21(this.i2c);
+
+  // Commands (No Hold Master Mode)
+  static const int _triggerTempMeasure = 0xF3;
+  static const int _triggerHumMeasure = 0xF5;
+
+  /// Read Temperature in Celsius
+  Future<double> getTemperature() async {
+    // 1. Send the "Measure" command
+    // We use writeBulk because it sends the bytes directly to the address
+    await i2c.writeBulk(addr, [_triggerTempMeasure]);
+
+    // 2. Wait for measurement (Datasheet max ~85ms)
+    await Future.delayed(Duration(milliseconds: 100));
+
+    // 3. Read 3 bytes (MSB, LSB, Checksum)
+    // simpleRead automatically handles the "Start Condition" + "Read" logic
+    List<int> data = await i2c.simpleRead(addr, 3);
+
+    if (data.length < 2) return 0.0;
+
+    // 4. Combine bytes & clear status bits
+    int rawValue = (data[0] << 8) | (data[1] & 0xFC);
+
+    // 5. Calculate Formula
+    return -46.85 + 175.72 * (rawValue / 65536.0);
+  }
+
+  /// Read Humidity in %RH
+  Future<double> getHumidity() async {
+    // 1. Send Measure Command
+    await i2c.writeBulk(addr, [_triggerHumMeasure]);
+
+    // 2. Wait
+    await Future.delayed(Duration(milliseconds: 100));
+
+    // 3. Read
+    List<int> data = await i2c.simpleRead(addr, 3);
+    if (data.length < 2) return 0.0;
+
+    int rawValue = (data[0] << 8) | (data[1] & 0xFC);
+
+    // 4. Calculate
+    return -6.0 + 125.0 * (rawValue / 65536.0);
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -528,5 +528,8 @@
     "darkExperimental": "Dark (Experimental)",
     "system": "System",
     "shareApp": "Share App",
-    "sht21Config": "SHT21 Configurations"
+    "sht21Config": "SHT21 Configurations",
+    "sht21": "SHT21",
+    "humidity": "Humidity",
+    "humidityUnitLabel": "%"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -527,5 +527,6 @@
     "light": "Light",
     "darkExperimental": "Dark (Experimental)",
     "system": "System",
-    "shareApp": "Share App"
+    "shareApp": "Share App",
+    "sht21Config": "SHT21 Configurations"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,11 +43,10 @@ void main() {
         ChangeNotifierProvider<BoardStateProvider>(
           create: (context) => getIt<BoardStateProvider>(),
         ),
-        // --- ADD THIS BLOCK BELOW ---
         ChangeNotifierProvider<SHT21Provider>(
-          create: (context) => SHT21Provider(),
+          // FIX: Use getIt to resolve the provider instead of 'SHT21Provider()'
+          create: (context) => getIt<SHT21Provider>(),
         ),
-        // ----------------------------
       ],
       child: const MyApp(),
     ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,7 +44,6 @@ void main() {
           create: (context) => getIt<BoardStateProvider>(),
         ),
         ChangeNotifierProvider<SHT21Provider>(
-          // FIX: Use getIt to resolve the provider instead of 'SHT21Provider()'
           create: (context) => getIt<SHT21Provider>(),
         ),
       ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:pslab/providers/sht21_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
@@ -42,6 +43,11 @@ void main() {
         ChangeNotifierProvider<BoardStateProvider>(
           create: (context) => getIt<BoardStateProvider>(),
         ),
+        // --- ADD THIS BLOCK BELOW ---
+        ChangeNotifierProvider<SHT21Provider>(
+          create: (context) => SHT21Provider(),
+        ),
+        // ----------------------------
       ],
       child: const MyApp(),
     ),

--- a/lib/providers/locator.dart
+++ b/lib/providers/locator.dart
@@ -10,6 +10,7 @@ import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/communication/socket_client.dart';
 import 'package:pslab/others/science_lab_common.dart';
 import 'package:pslab/providers/board_state_provider.dart';
+import 'package:pslab/providers/sht21_provider.dart';
 
 final GetIt getIt = GetIt.instance;
 
@@ -29,6 +30,7 @@ void setupLocator() {
   getIt.registerLazySingleton<ScienceLab>(
       () => getIt.get<ScienceLabCommon>().getScienceLab());
   getIt.registerLazySingleton<BoardStateProvider>(() => BoardStateProvider());
+  getIt.registerLazySingleton<SHT21Provider>(() => SHT21Provider());
 }
 
 void registerAppLocalizations(AppLocalizations appLocalizations) {

--- a/lib/providers/sht21_provider.dart
+++ b/lib/providers/sht21_provider.dart
@@ -11,7 +11,6 @@ class SHT21Provider with ChangeNotifier {
 
   // Initialize the sensor with the I2C connection
   Future<void> init(I2C i2c) async {
-    // This fixes the lint warning you saw earlier
     _sensor ??= SHT21(i2c);
   }
 
@@ -19,19 +18,26 @@ class SHT21Provider with ChangeNotifier {
   Future<void> startDataLog() async {
     if (_sensor == null) return;
 
+    // FIX 1: Prevent multiple loops running at the same time
+    // If it's already working, stop here.
+    if (isWorking) return;
+
     isWorking = true;
     notifyListeners();
 
     while (isWorking) {
-      // Fetch new values
-      temp = await _sensor!.getTemperature();
-      hum = await _sensor!.getHumidity();
-
-      // Update UI
-      notifyListeners();
+      try {
+        // FIX 2: Wrap I2C calls in try-catch to prevent crashing on error
+        temp = await _sensor!.getTemperature();
+        hum = await _sensor!.getHumidity();
+        notifyListeners();
+      } catch (e) {
+        // Log the error but don't crash the app
+        debugPrint("Error reading SHT21: $e");
+      }
 
       // Wait 1 second before next read
-      await Future.delayed(Duration(milliseconds: 1000));
+      await Future.delayed(const Duration(milliseconds: 1000));
     }
   }
 

--- a/lib/providers/sht21_provider.dart
+++ b/lib/providers/sht21_provider.dart
@@ -2,53 +2,165 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import '../communication/peripherals/i2c.dart';
 import '../communication/sensors/sht21.dart';
+import '../models/chart_data_points.dart';
+import '../others/logger_service.dart';
 
 class SHT21Provider extends ChangeNotifier {
   SHT21? _sensor;
-  Timer? _timer;
+  Timer? _dataTimer;
 
-  // These are the public variables the Screen is trying to read
-  double temperature = 0.0;
-  double humidity = 0.0;
+  double _temperature = 0.0;
+  double _humidity = 0.0;
 
-  bool isRecording = false;
+  final List<ChartDataPoint> _temperatureData = [];
+  final List<ChartDataPoint> _humidityData = [];
+
+  bool _isRunning = false;
+  bool _isLooping = false;
+  int _timegapMs = 1000;
+  int _numberOfReadings = 100;
+  int _collectedReadings = 0;
+
+  double _currentTime = 0.0;
+  static const int maxDataPoints = 1000;
+
+  double get temperature => _temperature;
+  double get humidity => _humidity;
+
+  List<ChartDataPoint> get temperatureData =>
+      List.unmodifiable(_temperatureData);
+  List<ChartDataPoint> get humidityData => List.unmodifiable(_humidityData);
+
+  bool get isRunning => _isRunning;
+  bool get isLooping => _isLooping;
+  int get timegapMs => _timegapMs;
+  int get numberOfReadings => _numberOfReadings;
+  int get collectedReadings => _collectedReadings;
+
+  SHT21Provider();
 
   void init(I2C i2c) {
     _sensor = SHT21(i2c);
   }
 
-  void startDataLog() {
-    if (_sensor == null || isRecording) return;
-
-    isRecording = true;
-    _timer = Timer.periodic(const Duration(milliseconds: 1000), (timer) async {
-      try {
-        // Fetch new values
-        double temp = await _sensor!.getTemperature();
-        double hum = await _sensor!.getHumidity();
-
-        // Update variables
-        temperature = temp;
-        humidity = hum;
-
-        // Notify the screen to update
-        notifyListeners();
-      } catch (e) {
-        if (kDebugMode) {
-          print("SHT21 Error: $e");
-        }
-      }
-    });
+  void toggleDataCollection() {
+    if (_isRunning) {
+      _stopDataCollection();
+    } else {
+      _startDataCollection();
+    }
   }
 
-  void stopDataLog() {
-    _timer?.cancel();
-    isRecording = false;
+  void _startDataCollection() {
+    if (_sensor == null) return;
+
+    _isRunning = true;
+    _collectedReadings = 0;
+
+    _dataTimer =
+        Timer.periodic(Duration(milliseconds: _timegapMs), (timer) async {
+      try {
+        await _fetchSensorData();
+        _collectedReadings++;
+
+        if (!_isLooping && _collectedReadings >= _numberOfReadings) {
+          _stopDataCollection();
+        }
+
+        if (_isLooping && _temperatureData.length >= maxDataPoints) {
+          _removeOldestDataPoints();
+        }
+      } catch (e) {
+        logger.e('Error fetching SHT21 sensor data: $e');
+      }
+    });
+    notifyListeners();
+  }
+
+  void _stopDataCollection() {
+    _isRunning = false;
+    _dataTimer?.cancel();
+    _dataTimer = null;
+    notifyListeners();
+  }
+
+  Future<void> _fetchSensorData() async {
+    if (_sensor == null) return;
+
+    try {
+      double temp = await _sensor!.getTemperature();
+      double hum = await _sensor!.getHumidity();
+
+      _temperature = temp;
+      _humidity = hum;
+
+      _currentTime += _timegapMs / 1000.0;
+
+      _addDataPoint(_temperatureData, _temperature);
+      _addDataPoint(_humidityData, _humidity);
+
+      notifyListeners();
+    } catch (e) {
+      logger.e('Error in _fetchSensorData: $e');
+      rethrow;
+    }
+  }
+
+  void _addDataPoint(List<ChartDataPoint> dataList, double value) {
+    dataList.add(ChartDataPoint(_currentTime, value));
+    if (dataList.length > 50) {
+      dataList.removeAt(0);
+    }
+  }
+
+  void _removeOldestDataPoints() {
+    const keepPoints = 800;
+
+    if (_temperatureData.length > keepPoints) {
+      final removeCount = _temperatureData.length - keepPoints;
+      _temperatureData.removeRange(0, removeCount);
+      _humidityData.removeRange(0, removeCount);
+    }
+  }
+
+  void toggleLooping() {
+    _isLooping = !_isLooping;
+    notifyListeners();
+  }
+
+  void setTimegap(int timegapMs) {
+    _timegapMs = timegapMs;
+
+    if (_isRunning) {
+      _stopDataCollection();
+      _startDataCollection();
+    }
+
+    notifyListeners();
+  }
+
+  void setNumberOfReadings(int numberOfReadings) {
+    _numberOfReadings = numberOfReadings;
+    notifyListeners();
+  }
+
+  void clearData() {
+    _temperatureData.clear();
+    _humidityData.clear();
+    _temperature = 0;
+    _humidity = 0;
+    _currentTime = 0.0;
+    _collectedReadings = 0;
+    notifyListeners();
+  }
+
+  bool get isCollectionComplete {
+    return !_isLooping && _collectedReadings >= _numberOfReadings;
   }
 
   @override
   void dispose() {
-    stopDataLog();
+    _stopDataCollection();
     super.dispose();
   }
 }

--- a/lib/providers/sht21_provider.dart
+++ b/lib/providers/sht21_provider.dart
@@ -1,49 +1,54 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
-import '../communication/sensors/sht21.dart';
 import '../communication/peripherals/i2c.dart';
+import '../communication/sensors/sht21.dart';
 
-class SHT21Provider with ChangeNotifier {
+class SHT21Provider extends ChangeNotifier {
   SHT21? _sensor;
-  bool isWorking = false;
-  double temp = 0.0;
-  double hum = 0.0;
+  Timer? _timer;
 
-  // Initialize the sensor with the I2C connection
-  Future<void> init(I2C i2c) async {
-    _sensor ??= SHT21(i2c);
+  // These are the public variables the Screen is trying to read
+  double temperature = 0.0;
+  double humidity = 0.0;
+
+  bool isRecording = false;
+
+  void init(I2C i2c) {
+    _sensor = SHT21(i2c);
   }
 
-  // Start the loop to read data
-  Future<void> startDataLog() async {
-    if (_sensor == null) return;
+  void startDataLog() {
+    if (_sensor == null || isRecording) return;
 
-    // FIX 1: Prevent multiple loops running at the same time
-    // If it's already working, stop here.
-    if (isWorking) return;
-
-    isWorking = true;
-    notifyListeners();
-
-    while (isWorking) {
+    isRecording = true;
+    _timer = Timer.periodic(const Duration(milliseconds: 1000), (timer) async {
       try {
-        // FIX 2: Wrap I2C calls in try-catch to prevent crashing on error
-        temp = await _sensor!.getTemperature();
-        hum = await _sensor!.getHumidity();
+        // Fetch new values
+        double temp = await _sensor!.getTemperature();
+        double hum = await _sensor!.getHumidity();
+
+        // Update variables
+        temperature = temp;
+        humidity = hum;
+
+        // Notify the screen to update
         notifyListeners();
       } catch (e) {
-        // Log the error but don't crash the app
-        debugPrint("Error reading SHT21: $e");
+        if (kDebugMode) {
+          print("SHT21 Error: $e");
+        }
       }
-
-      // Wait 1 second before next read
-      await Future.delayed(const Duration(milliseconds: 1000));
-    }
+    });
   }
 
-  // Stop the loop
   void stopDataLog() {
-    isWorking = false;
-    notifyListeners();
+    _timer?.cancel();
+    isRecording = false;
+  }
+
+  @override
+  void dispose() {
+    stopDataLog();
+    super.dispose();
   }
 }

--- a/lib/providers/sht21_provider.dart
+++ b/lib/providers/sht21_provider.dart
@@ -1,0 +1,43 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import '../communication/sensors/sht21.dart';
+import '../communication/peripherals/i2c.dart';
+
+class SHT21Provider with ChangeNotifier {
+  SHT21? _sensor;
+  bool isWorking = false;
+  double temp = 0.0;
+  double hum = 0.0;
+
+  // Initialize the sensor with the I2C connection
+  Future<void> init(I2C i2c) async {
+    // This fixes the lint warning you saw earlier
+    _sensor ??= SHT21(i2c);
+  }
+
+  // Start the loop to read data
+  Future<void> startDataLog() async {
+    if (_sensor == null) return;
+
+    isWorking = true;
+    notifyListeners();
+
+    while (isWorking) {
+      // Fetch new values
+      temp = await _sensor!.getTemperature();
+      hum = await _sensor!.getHumidity();
+
+      // Update UI
+      notifyListeners();
+
+      // Wait 1 second before next read
+      await Future.delayed(Duration(milliseconds: 1000));
+    }
+  }
+
+  // Stop the loop
+  void stopDataLog() {
+    isWorking = false;
+    notifyListeners();
+  }
+}

--- a/lib/theme/colors.dart
+++ b/lib/theme/colors.dart
@@ -85,6 +85,7 @@ Color sensorControlIconColor = Colors.grey.shade600;
 List<Color> bmp180ChartColors = [Colors.blue, Colors.green, Colors.red];
 Color chartHintTextColor = Colors.yellow;
 List<Color> apds9960ChartColors = [Colors.blue, Colors.yellow];
+List<Color> sht21ChartColors = [Colors.redAccent, Colors.blueAccent];
 Color buttonEnabledColor = primaryRed;
 Color buttonDisabledColor = Color.fromARGB(255, 240, 162, 162);
 Color waveGeneratorPropTextColor = Colors.deepOrange;

--- a/lib/view/sensors_screen.dart
+++ b/lib/view/sensors_screen.dart
@@ -1,3 +1,4 @@
+import 'package:pslab/view/sht21_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/view/bmp180_screen.dart';
@@ -229,8 +230,12 @@ class _SensorsScreenState extends State<SensorsScreen> {
         break;
       case 'APDS9960':
         targetScreen = const APDS9960Screen();
+        break;
       case 'VL53L0X':
         targetScreen = const VL53L0XScreen();
+        break;
+      case 'SHT21':
+        targetScreen = const SHT21Screen();
         break;
       default:
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/view/sht21_screen.dart
+++ b/lib/view/sht21_screen.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/communication/science_lab.dart';
-import 'package:pslab/communication/peripherals/i2c.dart'; // Import I2C class
+import 'package:pslab/communication/peripherals/i2c.dart';
 import 'package:pslab/providers/locator.dart';
+import 'package:pslab/l10n/app_localizations.dart';
 import '../providers/sht21_provider.dart';
 
 class SHT21Screen extends StatefulWidget {
@@ -17,22 +18,19 @@ class _SHT21ScreenState extends State<SHT21Screen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      // FIX: Check if widget is still on screen before using context
       if (!mounted) return;
 
-      final sht21Provider = Provider.of<SHT21Provider>(context, listen: false);
-
-      // Get the ScienceLab instance via the locator
+      final provider = Provider.of<SHT21Provider>(context, listen: false);
       final scienceLab = getIt<ScienceLab>();
+      final appLocalizations = AppLocalizations.of(context)!;
 
       if (scienceLab.isConnected()) {
-        // Create I2C helper and init
         I2C i2c = I2C(scienceLab.mPacketHandler);
-        sht21Provider.init(i2c);
-        sht21Provider.startDataLog();
+        provider.init(i2c);
+        provider.startDataLog();
       } else {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Device not connected')),
+          SnackBar(content: Text(appLocalizations.notConnected)),
         );
       }
     });
@@ -40,7 +38,6 @@ class _SHT21ScreenState extends State<SHT21Screen> {
 
   @override
   void dispose() {
-    // Stop the data loop when leaving the screen
     if (mounted) {
       Provider.of<SHT21Provider>(context, listen: false).stopDataLog();
     }
@@ -49,6 +46,8 @@ class _SHT21ScreenState extends State<SHT21Screen> {
 
   @override
   Widget build(BuildContext context) {
+    final appLocalizations = AppLocalizations.of(context)!;
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('SHT21 Sensor'),
@@ -60,8 +59,9 @@ class _SHT21ScreenState extends State<SHT21Screen> {
             child: Column(
               children: [
                 _buildSensorCard(
-                  title: "Temperature",
-                  value: provider.temp.toStringAsFixed(2),
+                  // Using the localized string we added earlier
+                  title: appLocalizations.temperature,
+                  value: provider.temperature.toStringAsFixed(2),
                   unit: "°C",
                   icon: Icons.thermostat,
                   color: Colors.redAccent,
@@ -69,7 +69,7 @@ class _SHT21ScreenState extends State<SHT21Screen> {
                 const SizedBox(height: 20),
                 _buildSensorCard(
                   title: "Humidity",
-                  value: provider.hum.toStringAsFixed(2),
+                  value: provider.humidity.toStringAsFixed(2),
                   unit: "%",
                   icon: Icons.water_drop,
                   color: Colors.blueAccent,
@@ -97,21 +97,23 @@ class _SHT21ScreenState extends State<SHT21Screen> {
           children: [
             Icon(icon, size: 40, color: color),
             const SizedBox(width: 20),
-            Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(title,
-                    style: const TextStyle(fontSize: 18, color: Colors.grey)),
-                Row(
-                  children: [
-                    Text(value,
-                        style: const TextStyle(
-                            fontSize: 32, fontWeight: FontWeight.bold)),
-                    const SizedBox(width: 5),
-                    Text(unit, style: const TextStyle(fontSize: 20)),
-                  ],
-                ),
-              ],
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title,
+                      style: const TextStyle(fontSize: 16, color: Colors.grey)),
+                  Row(
+                    children: [
+                      Text(value,
+                          style: const TextStyle(
+                              fontSize: 32, fontWeight: FontWeight.bold)),
+                      const SizedBox(width: 5),
+                      Text(unit, style: const TextStyle(fontSize: 20)),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/view/sht21_screen.dart
+++ b/lib/view/sht21_screen.dart
@@ -1,9 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/view/widgets/common_scaffold_widget.dart';
+import 'package:pslab/view/widgets/sensor_controls.dart';
 import 'package:pslab/communication/peripherals/i2c.dart';
+import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/providers/locator.dart';
-import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/logger_service.dart';
+import '../l10n/app_localizations.dart';
+import '../theme/colors.dart';
+import 'widgets/sensor_chart_widget.dart';
 import '../providers/sht21_provider.dart';
 
 class SHT21Screen extends StatefulWidget {
@@ -14,65 +19,135 @@ class SHT21Screen extends StatefulWidget {
 }
 
 class _SHT21ScreenState extends State<SHT21Screen> {
+  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  String sensorImage = 'assets/images/sht21.jpg';
+  I2C? _i2c;
+  ScienceLab? _scienceLab;
+  late SHT21Provider _provider;
+
+  // Hardcoded strings for SHT21-specific labels (not in l10n yet)
+  static const String _sht21Title = 'SHT21';
+  static const String _humidityLabel = 'Humidity';
+  static const String _humidityUnit = '%';
+
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-
-      final provider = Provider.of<SHT21Provider>(context, listen: false);
-      final scienceLab = getIt<ScienceLab>();
-      final appLocalizations = AppLocalizations.of(context)!;
-
-      if (scienceLab.isConnected()) {
-        I2C i2c = I2C(scienceLab.mPacketHandler);
-        provider.init(i2c);
-        provider.startDataLog();
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(appLocalizations.notConnected)),
-        );
-      }
-    });
+    _initializeScienceLab();
   }
 
-  @override
-  void dispose() {
-    if (mounted) {
-      Provider.of<SHT21Provider>(context, listen: false).stopDataLog();
+  void _initializeScienceLab() async {
+    try {
+      _scienceLab = getIt.get<ScienceLab>();
+      if (_scienceLab != null && _scienceLab!.isConnected()) {
+        _i2c = I2C(_scienceLab!.mPacketHandler);
+      }
+    } catch (e) {
+      logger.e('Error initializing ScienceLab: $e');
     }
-    super.dispose();
+  }
+
+  void _showSensorErrorSnackbar(String message) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            message,
+            style: TextStyle(color: snackBarContentColor),
+          ),
+          backgroundColor: snackBarBackgroundColor,
+          duration: const Duration(milliseconds: 500),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  void _showSuccessSnackbar(String message) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            message,
+            style: TextStyle(color: snackBarContentColor),
+          ),
+          backgroundColor: snackBarBackgroundColor,
+          duration: const Duration(milliseconds: 500),
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final appLocalizations = AppLocalizations.of(context)!;
-
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('SHT21 Sensor'),
-      ),
-      body: Consumer<SHT21Provider>(
+    return ChangeNotifierProvider(
+      create: (context) {
+        _provider = SHT21Provider();
+        if (_i2c != null) {
+          _provider.init(_i2c!);
+        } else if (_scienceLab == null || !_scienceLab!.isConnected()) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            _showSensorErrorSnackbar(appLocalizations.pslabNotConnected);
+          });
+        }
+        return _provider;
+      },
+      child: Consumer<SHT21Provider>(
         builder: (context, provider, child) {
-          return Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
+          return CommonScaffold(
+            title: _sht21Title,
+            body: Column(
               children: [
-                _buildSensorCard(
-                  // Using the localized string we added earlier
-                  title: appLocalizations.temperature,
-                  value: provider.temperature.toStringAsFixed(2),
-                  unit: "°C",
-                  icon: Icons.thermostat,
-                  color: Colors.redAccent,
+                Expanded(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.all(16.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        _buildRawDataSection(provider),
+                        const SizedBox(height: 24),
+                        SensorChartWidget(
+                          title:
+                              '${appLocalizations.plot} - ${appLocalizations.temperature}',
+                          yAxisLabel:
+                              '${appLocalizations.temperature} (${appLocalizations.temperatureUnitLabel})',
+                          data: provider.temperatureData,
+                          lineColor: sht21ChartColors[0],
+                          unit: appLocalizations.temperatureUnitLabel,
+                          maxDataPoints: provider.numberOfReadings,
+                          showDots: true,
+                        ),
+                        const SizedBox(height: 20),
+                        SensorChartWidget(
+                          title: '${appLocalizations.plot} - $_humidityLabel',
+                          yAxisLabel: '$_humidityLabel ($_humidityUnit)',
+                          data: provider.humidityData,
+                          lineColor: sht21ChartColors[1],
+                          unit: _humidityUnit,
+                          maxDataPoints: provider.numberOfReadings,
+                          showDots: true,
+                        ),
+                        const SizedBox(height: 100),
+                      ],
+                    ),
+                  ),
                 ),
-                const SizedBox(height: 20),
-                _buildSensorCard(
-                  title: "Humidity",
-                  value: provider.humidity.toStringAsFixed(2),
-                  unit: "%",
-                  icon: Icons.water_drop,
-                  color: Colors.blueAccent,
+                SensorControlsWidget(
+                  isPlaying: provider.isRunning,
+                  isLooping: provider.isLooping,
+                  timegapMs: provider.timegapMs,
+                  numberOfReadings: provider.numberOfReadings,
+                  onPlayPause: () {
+                    provider.toggleDataCollection();
+                  },
+                  onLoop: provider.toggleLooping,
+                  onTimegapChanged: provider.setTimegap,
+                  onNumberOfReadingsChanged: provider.setNumberOfReadings,
+                  onClearData: () {
+                    provider.clearData();
+                    _showSuccessSnackbar(appLocalizations.dataCleared);
+                  },
                 ),
               ],
             ),
@@ -82,42 +157,147 @@ class _SHT21ScreenState extends State<SHT21Screen> {
     );
   }
 
-  Widget _buildSensorCard({
-    required String title,
-    required String value,
-    required String unit,
-    required IconData icon,
-    required Color color,
-  }) {
-    return Card(
-      elevation: 4,
-      child: Padding(
-        padding: const EdgeInsets.all(20.0),
-        child: Row(
-          children: [
-            Icon(icon, size: 40, color: color),
-            const SizedBox(width: 20),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(title,
-                      style: const TextStyle(fontSize: 16, color: Colors.grey)),
-                  Row(
-                    children: [
-                      Text(value,
-                          style: const TextStyle(
-                              fontSize: 32, fontWeight: FontWeight.bold)),
-                      const SizedBox(width: 5),
-                      Text(unit, style: const TextStyle(fontSize: 20)),
-                    ],
-                  ),
-                ],
+  Widget _buildRawDataSection(SHT21Provider provider) {
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        color: cardBackgroundColor,
+        borderRadius: BorderRadius.zero,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(50),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        children: [
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+            decoration: BoxDecoration(
+              color: primaryRed,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.zero,
+                topRight: Radius.zero,
               ),
             ),
-          ],
-        ),
+            child: Row(
+              children: [
+                Text(
+                  appLocalizations.rawData,
+                  style: TextStyle(
+                    color: appBarContentColor,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const Spacer(),
+                if (provider.isRunning)
+                  Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: appBarContentColor,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(24),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: Column(
+                    children: [
+                      _buildDataCard(
+                        appLocalizations.temperature,
+                        provider.temperature.toStringAsFixed(2),
+                      ),
+                      const SizedBox(height: 16),
+                      _buildDataCard(
+                        _humidityLabel,
+                        provider.humidity.toStringAsFixed(2),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 24),
+                SizedBox(
+                  width: 80,
+                  height: 80,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: Image.asset(
+                      sensorImage,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) {
+                        return Icon(
+                          Icons.sensors,
+                          size: 40,
+                          color: sensorControlsTextBox,
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
     );
+  }
+
+  Widget _buildDataCard(String label, String value) {
+    return Row(
+      children: [
+        SizedBox(
+          width: 100,
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+              color: blackTextColor,
+            ),
+          ),
+        ),
+        Expanded(
+          flex: 3,
+          child: Container(
+            height: 36,
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            decoration: BoxDecoration(
+              border: Border.all(color: sensorControlsTextBox),
+              borderRadius: BorderRadius.circular(4),
+              color: cardBackgroundColor,
+            ),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                value,
+                style: TextStyle(
+                  fontSize: 14,
+                  color: blackTextColor,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _provider.dispose();
+    super.dispose();
   }
 }

--- a/lib/view/sht21_screen.dart
+++ b/lib/view/sht21_screen.dart
@@ -17,18 +17,17 @@ class _SHT21ScreenState extends State<SHT21Screen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      // FIX: Check if widget is still on screen before using context
+      if (!mounted) return;
+
       final sht21Provider = Provider.of<SHT21Provider>(context, listen: false);
 
-      // 1. Get the ScienceLab instance
+      // Get the ScienceLab instance via the locator
       final scienceLab = getIt<ScienceLab>();
 
-      // 2. Check connection
       if (scienceLab.isConnected()) {
-        // 3. MANUALLY create the I2C helper using the packet handler
-        // This fixes the "getter i2c not defined" error
+        // Create I2C helper and init
         I2C i2c = I2C(scienceLab.mPacketHandler);
-
-        // 4. Initialize the sensor provider
         sht21Provider.init(i2c);
         sht21Provider.startDataLog();
       } else {

--- a/lib/view/sht21_screen.dart
+++ b/lib/view/sht21_screen.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/communication/peripherals/i2c.dart'; // Import I2C class
+import 'package:pslab/providers/locator.dart';
+import '../providers/sht21_provider.dart';
+
+class SHT21Screen extends StatefulWidget {
+  const SHT21Screen({super.key});
+
+  @override
+  State<SHT21Screen> createState() => _SHT21ScreenState();
+}
+
+class _SHT21ScreenState extends State<SHT21Screen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final sht21Provider = Provider.of<SHT21Provider>(context, listen: false);
+
+      // 1. Get the ScienceLab instance
+      final scienceLab = getIt<ScienceLab>();
+
+      // 2. Check connection
+      if (scienceLab.isConnected()) {
+        // 3. MANUALLY create the I2C helper using the packet handler
+        // This fixes the "getter i2c not defined" error
+        I2C i2c = I2C(scienceLab.mPacketHandler);
+
+        // 4. Initialize the sensor provider
+        sht21Provider.init(i2c);
+        sht21Provider.startDataLog();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Device not connected')),
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    // Stop the data loop when leaving the screen
+    if (mounted) {
+      Provider.of<SHT21Provider>(context, listen: false).stopDataLog();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('SHT21 Sensor'),
+      ),
+      body: Consumer<SHT21Provider>(
+        builder: (context, provider, child) {
+          return Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              children: [
+                _buildSensorCard(
+                  title: "Temperature",
+                  value: provider.temp.toStringAsFixed(2),
+                  unit: "°C",
+                  icon: Icons.thermostat,
+                  color: Colors.redAccent,
+                ),
+                const SizedBox(height: 20),
+                _buildSensorCard(
+                  title: "Humidity",
+                  value: provider.hum.toStringAsFixed(2),
+                  unit: "%",
+                  icon: Icons.water_drop,
+                  color: Colors.blueAccent,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSensorCard({
+    required String title,
+    required String value,
+    required String unit,
+    required IconData icon,
+    required Color color,
+  }) {
+    return Card(
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Row(
+          children: [
+            Icon(icon, size: 40, color: color),
+            const SizedBox(width: 20),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title,
+                    style: const TextStyle(fontSize: 18, color: Colors.grey)),
+                Row(
+                  children: [
+                    Text(value,
+                        style: const TextStyle(
+                            fontSize: 32, fontWeight: FontWeight.bold)),
+                    const SizedBox(width: 5),
+                    Text(unit, style: const TextStyle(fontSize: 20)),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Summary:**
This PR implements support for the SHT21 Temperature & Humidity sensor.

**Changes:**
- Added `sht21.dart` (Sensor logic implementation).
- Added `sht21_provider.dart` (State management).
- Added `sht21_screen.dart` (UI for displaying data).
- Registered the sensor in `main.dart` and `sensors_screen.dart`.

**Issue:**
Closes #2995

## Summary by Sourcery

Add SHT21 temperature and humidity sensor support to the app, including data acquisition, state management, and UI display.

New Features:
- Introduce SHT21 sensor driver for temperature and humidity readings over I2C.
- Add SHT21Provider for managing SHT21 sensor state and periodic data polling.
- Create SHT21Screen to visualize live temperature and humidity data from the SHT21 sensor.
- Register the SHT21 provider and screen so the sensor can be accessed from the sensors list.