### PR TITLE
feat: Add support for sensor MLX90614

### DIFF
--- a/lib/communication/sensors/mlx90614.dart
+++ b/lib/communication/sensors/mlx90614.dart
@@ -1,0 +1,50 @@
+import '../peripherals/i2c.dart';
+
+class MLX90614 {
+  final I2C i2c;
+  // The default I2C address for MLX90614 is 0x5A
+  static const int address = 0x5A;
+
+  // Register addresses
+  static const int ambientTempReg = 0x06;
+  static const int objectTempReg = 0x07;
+
+  MLX90614(this.i2c);
+
+  /// Reads the Ambient (Room) Temperature
+  Future<double> getAmbientTemperature() async {
+    return _readTemperature(ambientTempReg);
+  }
+
+  /// Reads the Object (Target) Temperature
+  Future<double> getObjectTemperature() async {
+    return _readTemperature(objectTempReg);
+  }
+
+  /// Helper function to handle the math
+  Future<double> _readTemperature(int reg) async {
+    // Read 2 bytes from the specific register
+    List<int> data = await i2c.readBulk(address, reg, 2);
+
+    if (data.length < 2) {
+      throw Exception("Failed to read temperature from MLX90614");
+    }
+
+    // MLX90614 sends LSB first, then MSB.
+    int lsb = data[0];
+    int msb = data[1];
+
+    // Combine the bytes: (MSB << 8) | LSB
+    // We apply the mask 0x7FFF to ignore the error flag (Bit 15)
+    // ensuring we only process valid temperature data bits.
+    int rawValue = ((msb << 8) | lsb) & 0x7FFF;
+
+    // Formula from datasheet:
+    // The sensor returns temperature in Kelvin * 50.
+    // Multiply by 0.02 to get Kelvin.
+    // Subtract 273.15 to convert Kelvin to Celsius.
+    double tempCelsius = (rawValue * 0.02) - 273.15;
+
+    return tempCelsius;
+  }
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -569,5 +569,8 @@
     "sht21Config": "SHT21 Configurations",
     "sht21": "SHT21",
     "humidity": "Humidity",
-    "humidityUnitLabel": "%"
+    "humidityUnitLabel": "%",
+    "mlxObjectTemp": "Object Temperature",
+    "mlxAmbientTemp": "Ambient Temperature",
+    "mlx90614Config": "MLX90614 Configurations"
 }

--- a/lib/providers/mlx90614_provider.dart
+++ b/lib/providers/mlx90614_provider.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/foundation.dart';
+import '../communication/sensors/mlx90614.dart';
+import '../communication/peripherals/i2c.dart';
+
+class MLX90614Provider with ChangeNotifier {
+  MLX90614? _sensor;
+  bool isWorking = false;
+
+  // This sensor provides two values
+  double ambientTemp = 0.0; // Room temperature
+  double objectTemp = 0.0; // Target temperature
+
+  // Initialize the sensor with the I2C connection
+  Future<void> init(I2C i2c) async {
+    _sensor ??= MLX90614(i2c);
+  }
+
+  // Start the loop to read data
+  Future<void> startDataLog() async {
+    if (_sensor == null) return;
+
+    // Check if loop is already running to prevent duplicates
+    if (isWorking) return;
+
+    isWorking = true;
+    notifyListeners();
+
+    while (isWorking) {
+      try {
+        // Read both values safely
+        ambientTemp = await _sensor!.getAmbientTemperature();
+        objectTemp = await _sensor!.getObjectTemperature();
+        notifyListeners();
+      } catch (e) {
+        debugPrint("Error reading MLX90614: $e");
+      }
+
+      // Wait 1 second before next read
+      await Future.delayed(const Duration(milliseconds: 1000));
+    }
+  }
+
+  // Stop the loop
+  void stopDataLog() {
+    isWorking = false;
+    notifyListeners();
+  }
+}

--- a/lib/view/mlx90614_screen.dart
+++ b/lib/view/mlx90614_screen.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:pslab/communication/science_lab.dart';
+import 'package:pslab/communication/peripherals/i2c.dart';
+import 'package:pslab/providers/locator.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/view/widgets/common_scaffold_widget.dart';
+import '../providers/mlx90614_provider.dart';
+
+class MLX90614Screen extends StatefulWidget {
+  const MLX90614Screen({super.key});
+
+  @override
+  State<MLX90614Screen> createState() => _MLX90614ScreenState();
+}
+
+class _MLX90614ScreenState extends State<MLX90614Screen> {
+  late final MLX90614Provider _provider;
+
+  @override
+  void initState() {
+    super.initState();
+    _provider = MLX90614Provider();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+
+      final scienceLab = getIt<ScienceLab>();
+      final appLocalizations = AppLocalizations.of(context)!;
+
+      if (scienceLab.isConnected()) {
+        final i2c = I2C(scienceLab.mPacketHandler);
+        _provider.init(i2c);
+        _provider.startDataLog();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(appLocalizations.notConnected)),
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _provider.stopDataLog();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider.value(
+      value: _provider,
+      child: Consumer<MLX90614Provider>(
+        builder: (context, provider, child) {
+          final appLocalizations = AppLocalizations.of(context)!;
+
+          return CommonScaffold(
+            title: 'MLX90614 Sensor',
+            body: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Column(
+                children: [
+                  _buildSensorCard(
+                    title: appLocalizations.mlxObjectTemp,
+                    value: provider.objectTemp.toStringAsFixed(2),
+                    unit: "°C",
+                    icon: Icons.thermostat_auto,
+                    color: Colors.deepOrangeAccent,
+                  ),
+                  const SizedBox(height: 20),
+                  _buildSensorCard(
+                    title: appLocalizations.mlxAmbientTemp,
+                    value: provider.ambientTemp.toStringAsFixed(2),
+                    unit: "°C",
+                    icon: Icons.home_mini,
+                    color: Colors.blueGrey,
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSensorCard({
+    required String title,
+    required String value,
+    required String unit,
+    required IconData icon,
+    required Color color,
+  }) {
+    return Card(
+      elevation: 4,
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Row(
+          children: [
+            Icon(icon, size: 40, color: color),
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title,
+                      style: const TextStyle(fontSize: 16, color: Colors.grey)),
+                  Row(
+                    children: [
+                      Text(value,
+                          style: const TextStyle(
+                              fontSize: 32, fontWeight: FontWeight.bold)),
+                      const SizedBox(width: 5),
+                      Text(unit, style: const TextStyle(fontSize: 20)),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/sensors_screen.dart
+++ b/lib/view/sensors_screen.dart
@@ -4,6 +4,7 @@ import 'package:provider/provider.dart';
 import 'package:pslab/view/bmp180_screen.dart';
 import 'package:pslab/view/ads1115_screen.dart';
 import 'package:pslab/view/vl53l0x_screen.dart';
+import 'package:pslab/view/mlx90614_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import '../../providers/board_state_provider.dart';
 import '../l10n/app_localizations.dart';
@@ -236,6 +237,9 @@ class _SensorsScreenState extends State<SensorsScreen> {
         break;
       case 'SHT21':
         targetScreen = const SHT21Screen();
+        break;
+      case 'MLX90614':
+        targetScreen = const MLX90614Screen();
         break;
       default:
         ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary
Implemented support for the MLX90614 Infrared Temperature Sensor.

## Changes
* Added `MLX90614` class for I2C communication.
* Added `MLX90614Provider` for state management (includes error handling and safe loops).
* Added `MLX90614Screen` to display Object and Ambient temperatures.
* Registered provider in `locator` and `main`.
* Added navigation in `SensorsScreen`.

## Fixes
Closes #2992

## Summary by Sourcery

Add MLX90614 infrared temperature sensor support, including UI, provider wiring, and platform plugin registration updates.

New Features:
- Introduce MLX90614 sensor communication class over I2C to read ambient and object temperatures.
- Add MLX90614Provider for managing MLX90614 sensor state and periodic data acquisition.
- Add MLX90614Screen to display ambient and object temperature readings from the MLX90614 sensor.
- Wire the MLX90614 sensor screen into the sensors navigation flow.

Bug Fixes:
- Remove SHT21 imports and navigation cases that were causing build or runtime errors in the sensors screen.

Enhancements:
- Register MLX90614Provider with the service locator and as a ChangeNotifierProvider in the app's main widget tree.
- Update generated plugin registrants for Windows and macOS to include geolocation plugins where required.