### PR TITLE
fix: Enable resizeToAvoidBottomInset in CommonScaffold

### DIFF
--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -45,7 +45,7 @@ class _CommonScaffoldState extends State<CommonScaffold> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: scaffoldBackgroundColor,
-      resizeToAvoidBottomInset: false,
+      resizeToAvoidBottomInset: true,
       appBar: AppBar(
         systemOverlayStyle: SystemUiOverlayStyle(
           statusBarColor: appBarColor,


### PR DESCRIPTION
### Problem
When users tap on the "Number of Readings" TextField in the `SensorControlsWidget` (located at the bottom of sensor screens), the on-screen keyboard completely covers the input field, making it impossible to see what's being typed.

This affects **all sensor screens** that use `CommonScaffold`:
* APDS9960, Accelerometer, Gyroscope, Barometer, Luxmeter, Thermometer, and more.

### Root Cause
`resizeToAvoidBottomInset` was explicitly set to `false` in `CommonScaffold`, which prevents Flutter from automatically resizing the screen content when the keyboard appears.

## Solution
Removed the explicit resizeToAvoidBottomInset: false line, allowing the scaffold to use Flutter's default behavior (true), which automatically resizes content when the keyboard opens.

## Testing
* Verified on sensor screens with `SensorControlsWidget`.
* Confirmed no overflow issues occur on other screens using `CommonScaffold` (all use scrollable containers like `SingleChildScrollView`, `ListView`, or `GridView`).

## Summary by Sourcery

Bug Fixes:
- Fix bottom-aligned inputs being covered by the keyboard on sensor screens using CommonScaffold.