### PR TITLE
fix: Oscilloscope Waveform Distortion on FFT Toggle

### DIFF
--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -1048,6 +1048,18 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setFourierTransform(bool enabled) {
+    isFourierTransformSelected = enabled;
+
+    if (!enabled) {
+      oscilloscopeAxesScale.setYAxisScaleMax(oscilloscopeAxesScale.yAxisScale);
+      oscilloscopeAxesScale.setYAxisScaleMin(-oscilloscopeAxesScale.yAxisScale);
+      oscilloscopeAxesScale.setXAxisScale(timebase);
+    }
+
+    notifyListeners();
+  }
+
   @override
   void dispose() {
     _monitor = false;

--- a/lib/view/widgets/data_analysis_widget.dart
+++ b/lib/view/widgets/data_analysis_widget.dart
@@ -49,7 +49,8 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                             onChanged: (bool? value) {
                               setState(
                                 () {
-                                  oscilloscopeStateProvider.setFourierTransform(value!);
+                                  oscilloscopeStateProvider
+                                      .setFourierTransform(value!);
                                 },
                               );
                             },

--- a/lib/view/widgets/data_analysis_widget.dart
+++ b/lib/view/widgets/data_analysis_widget.dart
@@ -49,8 +49,7 @@ class _DataAnalysisState extends State<DataAnalysisWidget> {
                             onChanged: (bool? value) {
                               setState(
                                 () {
-                                  oscilloscopeStateProvider
-                                      .isFourierTransformSelected = value!;
+                                  oscilloscopeStateProvider.setFourierTransform(value!);
                                 },
                               );
                             },


### PR DESCRIPTION
Fixes #3049 

## Changes
Previously, the graph axes were not reset when Fourier Analysis was disabled, causing the time-domain waveform to be rendered on frequency-domain axes and appear distorted.

This has been fixed by introducing a `setFourierTransform` method in the provider that explicitly restores the X-axis to the active timebase and resets the Y-axis voltage limits whenever FFT is turned off. The UI now calls this method directly, ensuring the waveform view is immediately restored correctly without distortion or freezing when switching back to time mode.


## Screenshots / Recordings

https://github.com/user-attachments/assets/3ed567b3-bdf2-4542-8338-5009f7c6cdee


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Ensure oscilloscope waveform axes are correctly restored when toggling Fourier (FFT) analysis off to prevent distorted time-domain displays.

Bug Fixes:
- Reset oscilloscope X/Y axes to the active timebase and voltage limits when Fourier analysis is disabled to eliminate waveform distortion and freezing when returning to time mode.

Enhancements:
- Centralize Fourier transform state handling in the oscilloscope provider via a dedicated setter used by the UI toggle.