### PR TITLE
fix(instruments): Resolve overflow and split-screen layout issues

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -10,6 +10,8 @@ const multimeterScreenTitleKey = 'multimeter_screen_title';
 const waveGeneratorScreenTitleKey = 'wave_generator_screen_title';
 const oscilloscopeScreenTitleKey = 'oscilloscope_screen_title';
 
+const double narrowWidthBreakpoint = 600.0;
+
 AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
 List<String> instrumentIcons = [

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -192,7 +192,8 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                 behavior: const ScrollBehavior(),
                 child: LayoutBuilder(
                   builder: (context, constraints) {
-                    return constraints.maxWidth < constraints.maxHeight
+                    return constraints.maxWidth < narrowWidthBreakpoint ||
+                            constraints.maxWidth < constraints.maxHeight
                         ? ListView.builder(
                             itemCount: _filteredIndices.length,
                             itemBuilder: (context, index) {
@@ -215,7 +216,7 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                             gridDelegate:
                                 SliverGridDelegateWithFixedCrossAxisCount(
                               crossAxisCount: 2,
-                              childAspectRatio: 2.5,
+                              childAspectRatio: 1.2,
                             ),
                             itemCount: _filteredIndices.length,
                             itemBuilder: (context, index) {

--- a/lib/view/widgets/applications_list_item.dart
+++ b/lib/view/widgets/applications_list_item.dart
@@ -25,11 +25,14 @@ class ApplicationsListItem extends StatelessWidget {
       ),
       elevation: 2,
       child: Container(
-        height: 225,
         decoration: BoxDecoration(
             color: primaryRed, borderRadius: BorderRadius.circular(5)),
         child: Stack(
           children: [
+            ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 225),
+              child: const SizedBox(width: double.infinity),
+            ),
             Positioned(
               top: 0,
               bottom: 10,
@@ -92,6 +95,8 @@ class ApplicationsListItem extends StatelessWidget {
                       color: instrumentCardContentColor,
                     ),
                     textAlign: TextAlign.start,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
                   ),
                   Text(
                     description,
@@ -100,6 +105,8 @@ class ApplicationsListItem extends StatelessWidget {
                       color: instrumentCardContentColor,
                     ),
                     textAlign: TextAlign.start,
+                    maxLines: 3,
+                    overflow: TextOverflow.ellipsis,
                   ),
                 ],
               ),


### PR DESCRIPTION
Fixes https://github.com/fossasia/pslab-app/issues/3059

## Description
This PR addresses multiple layout issues on the Instruments screen, specifically targeting overflow errors and broken layouts in split-screen mode.

## Fixes
- **Bottom Overflow:** Fixed the "BOTTOM OVERFLOWED BY 55 PIXEL" error on instrument cards by removing fixed height and adding flexible text handling.
- **Split-Screen Layout:** Implemented logic to strictly enforce `ListView` (single column) when the screen width is less than 600px. This prevents the app from forcing a 2-column `GridView` in narrow split-screen views on phones.
- **White Screen Bug:** Resolved a regression where `Flexible` widgets inside an unbounded column caused the screen to appear white/blank.

## Changes
* **lib/view/widgets/applications_list_item.dart**:
    * Replaced fixed `height: 225` with `ConstrainedBox`/`SizedBox`.
    * Added `maxLines` and `TextOverflow.ellipsis` to `heading` and `description` to prevent clipping.
* **lib/view/instruments_screen.dart**:
    * Adjusted `GridView` aspect ratio from `2.5` to `1.2`.
    * Added layout logic: `constraints.maxWidth < 600 ? ListView : GridView`.

## Verification
- Verified on Android in Portrait mode (ListView works correctly).
- Verified on Android in Split-Screen mode (Now correctly switches to ListView instead of broken GridView).
- Verified "bottom overflow" error is gone.


https://github.com/user-attachments/assets/67525f26-4eef-4908-8808-1cf643313f64



## Summary by Sourcery

Improve Instruments screen card layout and responsive behavior to prevent overflows and broken split‑screen rendering.

Bug Fixes:
- Prevent bottom overflow and text clipping in instrument application cards by constraining card size and truncating long text.
- Force a single-column list layout on narrow or portrait-like viewports to avoid broken two-column grid behavior in split-screen mode.
- Adjust grid item aspect ratio to avoid layout issues that previously caused blank/white screen scenarios in certain configurations.