### PR TITLE
fix(barometer): set back arrow icon color to app bar content color

### DIFF
--- a/lib/view/barometer_config_screen.dart
+++ b/lib/view/barometer_config_screen.dart
@@ -56,16 +56,10 @@ class _BarometerConfigScreenState extends State<BarometerConfigScreen> {
           builder: (context) {
             return IconButton(
               onPressed: () {
-                if (Navigator.canPop(context) &&
-                    ModalRoute.of(context)?.settings.name == '/barometer') {
-                  Navigator.popUntil(
-                      context, ModalRoute.withName('/barometer'));
+                if (Navigator.canPop(context)) {
+                  Navigator.pop(context);
                 } else {
-                  Navigator.pushNamedAndRemoveUntil(
-                    context,
-                    '/barometer',
-                    (route) => route.isFirst,
-                  );
+                  Navigator.pushReplacementNamed(context, '/barometer');
                 }
               },
               icon: Icon(

--- a/lib/view/barometer_config_screen.dart
+++ b/lib/view/barometer_config_screen.dart
@@ -52,6 +52,29 @@ class _BarometerConfigScreenState extends State<BarometerConfigScreen> {
           statusBarBrightness: Brightness.dark,
         ),
         backgroundColor: primaryRed,
+        leading: Builder(
+          builder: (context) {
+            return IconButton(
+              onPressed: () {
+                if (Navigator.canPop(context) &&
+                    ModalRoute.of(context)?.settings.name == '/barometer') {
+                  Navigator.popUntil(
+                      context, ModalRoute.withName('/barometer'));
+                } else {
+                  Navigator.pushNamedAndRemoveUntil(
+                    context,
+                    '/barometer',
+                    (route) => route.isFirst,
+                  );
+                }
+              },
+              icon: Icon(
+                Icons.arrow_back,
+                color: appBarContentColor,
+              ),
+            );
+          },
+        ),
         title: Text(
           appLocalizations.barometerConfig,
           style: TextStyle(


### PR DESCRIPTION
## Summary
This PR addresses a visibility issue in the **Barometer Configuration screen**. The back arrow icon was defaulting to a black color, making it nearly invisible against the dark AppBar background.


## Changes
* **File Modified:** `lib/view/barometer_config_screen.dart`
* **Widget Update:** Replaced the default `AppBar` leading widget with a custom `IconButton`.
* **Explicit Styling:** * Set `color: appBarContentColor` to ensure high contrast.
  * Ensured proper navigation handling using `Navigator` and `ModalRoute`.


## Technical Implementation
Flutter’s `AppBar` typically inherits from the global `iconTheme`. In this specific configuration, the default rendered black. 
1. **Manual Override:** Overriding the `leading` widget provides explicit control over the icon's color property.
2. **Context Handling:** Using a `Builder` ensures the correct `BuildContext` is utilized for seamless navigation.

https://github.com/user-attachments/assets/fe0c5d72-6f66-4294-b897-d731fed6e77b

