### PR TITLE
fix: Screen State Reset on Navigation and optimize integration tests

### DIFF
--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -55,16 +55,7 @@ class _CommonScaffoldState extends State<CommonScaffold> {
         leading: Builder(builder: (context) {
           return IconButton(
             onPressed: () {
-              if (Navigator.canPop(context) &&
-                  ModalRoute.of(context)?.settings.name == '/') {
-                Navigator.popUntil(context, ModalRoute.withName('/'));
-              } else {
-                Navigator.pushNamedAndRemoveUntil(
-                  context,
-                  '/',
-                  (route) => route.isFirst,
-                );
-              }
+              Navigator.maybePop(context);
             },
             icon: Icon(
               Icons.arrow_back,

--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -83,18 +83,10 @@ class _NavDrawerState extends State<NavDrawer> {
                 ),
               ),
               onTap: () {
-                // Check if the HomeScreen is already in the navigation stack
-                if (Navigator.canPop(context) &&
-                    ModalRoute.of(context)?.settings.name == '/') {
-                  // If it's already in the stack, pop to it
+                if (ModalRoute.of(context)?.settings.name != '/') {
                   Navigator.popUntil(context, ModalRoute.withName('/'));
                 } else {
-                  // Otherwise, navigate to HomeScreen
-                  Navigator.pushNamedAndRemoveUntil(
-                    context,
-                    '/',
-                    (route) => route.isFirst,
-                  );
+                  Navigator.pop(context);
                 }
               },
             ),

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -10,7 +10,7 @@ void main() async {
   final binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() {
     return Future(() async {
-      WidgetsApp.debugAllowBannerOverride = false; // Hide the debug banner
+      WidgetsApp.debugAllowBannerOverride = false;
       if (Platform.isAndroid) {
         await binding.convertFlutterSurfaceToImage();
       }
@@ -36,22 +36,29 @@ void main() async {
       final notConnectedText = find.text('Not Connected');
       final backButton = find.byIcon(Icons.arrow_back);
 
+      Future<void> scrollToTop() async {
+        final topItem = find.text('OSCILLOSCOPE');
+        await tester.scrollUntilVisible(
+          topItem,
+          -300.0,
+          scrollable: find.byType(Scrollable),
+          maxScrolls: 50,
+        );
+        await tester.pumpAndSettle();
+      }
+
       await pumpUntilFound(tester, instrumentsScreenTitle);
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
       await binding.takeScreenshot('1_instruments_screen');
 
       ScaffoldState state = tester.firstState(find.byType(Scaffold));
       state.openDrawer();
+      await tester.pumpAndSettle();
       await pumpUntilFound(tester, notConnectedText);
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 1));
       await binding.takeScreenshot('2_nav_drawer');
 
       state.closeDrawer();
-      await pumpUntilFound(tester, instrumentsScreenTitle);
       await tester.pumpAndSettle();
 
       final accelerometerCard = find.text('ACCELEROMETER');
@@ -62,23 +69,24 @@ void main() async {
       );
       await tester.pumpAndSettle();
       await tester.tap(accelerometerCard);
-      await tester.pump(const Duration(seconds: 5));
+      await tester.pump(const Duration(seconds: 2));
 
       final infoIcon = find.byIcon(Icons.info);
       await tester.tap(infoIcon);
-      int i = 0;
-      while (i < 10) {
-        await tester.pump(const Duration(seconds: 1));
-        i++;
-      }
+      await tester.pump(const Duration(seconds: 2));
       await binding.takeScreenshot('3_accelerometer');
 
       final hideGuideText = find.text('Hide Guide');
-      await tester.tap(hideGuideText);
-      await tester.pump(const Duration(seconds: 5));
+      if (tester.any(hideGuideText)) {
+        await tester.tap(hideGuideText);
+        await tester.pump(const Duration(seconds: 1));
+      }
 
       await tester.tap(backButton);
+      await tester.pump(const Duration(seconds: 2));
       await pumpUntilFound(tester, instrumentsScreenTitle);
+
+      await scrollToTop();
 
       final powerSourceCard = find.text('POWER SOURCE');
       await tester.scrollUntilVisible(
@@ -89,14 +97,14 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.tap(powerSourceCard);
       await pumpUntilFound(tester, powerSourceScreenTitle);
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
       await binding.takeScreenshot('4_power_source');
 
       await tester.tap(backButton);
+      await tester.pump(const Duration(seconds: 2));
       await pumpUntilFound(tester, instrumentsScreenTitle);
+
+      await scrollToTop();
 
       final multimeterCard = find.text('MULTIMETER');
       await tester.scrollUntilVisible(
@@ -107,14 +115,14 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.tap(multimeterCard);
       await pumpUntilFound(tester, multimeterScreenTitle);
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
       await binding.takeScreenshot('5_multimeter');
 
       await tester.tap(backButton);
+      await tester.pump(const Duration(seconds: 2));
       await pumpUntilFound(tester, instrumentsScreenTitle);
+
+      await scrollToTop();
 
       final waveGeneratorCard = find.text('WAVE GENERATOR');
       await tester.scrollUntilVisible(
@@ -127,15 +135,17 @@ void main() async {
       await pumpUntilFound(tester, waveGeneratorScreenTitle);
 
       final freqText = find.text('Freq');
-      await tester.tap(freqText);
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
+      if (tester.any(freqText)) {
+        await tester.tap(freqText);
+        await tester.pump(const Duration(seconds: 2));
+      }
       await binding.takeScreenshot('6_wave_generator');
 
       await tester.tap(backButton);
+      await tester.pump(const Duration(seconds: 2));
       await pumpUntilFound(tester, instrumentsScreenTitle);
+
+      await scrollToTop();
 
       final oscilloscopeCard = find.text('OSCILLOSCOPE');
       await tester.scrollUntilVisible(
@@ -146,10 +156,7 @@ void main() async {
       await tester.pumpAndSettle();
       await tester.tap(oscilloscopeCard);
       await pumpUntilFound(tester, oscilloscopeScreenTitle);
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
-      await tester.pump(const Duration(seconds: 5));
-      await tester.pumpAndSettle();
+      await tester.pump(const Duration(seconds: 2));
       await binding.takeScreenshot('7_oscilloscope');
     });
   });


### PR DESCRIPTION
Fixes #3067 
## Changes
This issue occurs because the current navigation logic uses `Navigator.pushNamedAndRemoveUntil` to return to the Home route.

Instead of navigating back to the existing instance of the `InstrumentsScreen`, this method pushes a new instance onto the navigation stack. As a result, a "duplicate Home Screen" scenario is created.

Because a new instance is created:

- The previous state (such as scroll position and search query) is lost.
- The original screen instance may still exist deeper in the stack.
- Pressing the back button on certain screens can unexpectedly reveal the older state, leading to inconsistent and confusing behavior.

This improper stack management causes the Home Screen to rebuild and lose its state instead of preserving the existing instance.

**Integration Testing Refactor**
- `test_integration/screenshots.dart` Updated to align with the new state-preserving navigation behavior.
Since the Screen state is now preserved, the integration tests were updated to reflect the new navigation behavior. A `scrollToTop()` helper was added because the list no longer resets automatically when navigating back. Back-navigation steps were also adjusted to wait for the pop animation, as we now reveal the existing Screen instance instead of rebuilding it.


## Screenshots / Recordings
[navigation_fixed.webm](https://github.com/user-attachments/assets/fcfb3e10-6a0a-463e-b464-b148d8500f76)


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Adjust navigation behavior to return to the existing Home screen instance and preserve its state when navigating back from nested screens.

Bug Fixes:
- Prevent creation of duplicate Home screen instances by popping back to the existing '/' route instead of pushing a new one from the navigation drawer.
- Ensure back navigation from the common scaffold attempts to pop the current route gracefully rather than recreating the Home screen.