### PR TITLE
fix(soundmeter): prevent instrument stop on back navigation from config screen

### DIFF
--- a/lib/view/barometer_config_screen.dart
+++ b/lib/view/barometer_config_screen.dart
@@ -56,16 +56,10 @@ class _BarometerConfigScreenState extends State<BarometerConfigScreen> {
           builder: (context) {
             return IconButton(
               onPressed: () {
-                if (Navigator.canPop(context) &&
-                    ModalRoute.of(context)?.settings.name == '/barometer') {
-                  Navigator.popUntil(
-                      context, ModalRoute.withName('/barometer'));
+                if (Navigator.canPop(context)) {
+                  Navigator.pop(context);
                 } else {
-                  Navigator.pushNamedAndRemoveUntil(
-                    context,
-                    '/barometer',
-                    (route) => route.isFirst,
-                  );
+                  Navigator.pushReplacementNamed(context, '/barometer');
                 }
               },
               icon: Icon(

--- a/lib/view/barometer_config_screen.dart
+++ b/lib/view/barometer_config_screen.dart
@@ -52,6 +52,29 @@ class _BarometerConfigScreenState extends State<BarometerConfigScreen> {
           statusBarBrightness: Brightness.dark,
         ),
         backgroundColor: primaryRed,
+        leading: Builder(
+          builder: (context) {
+            return IconButton(
+              onPressed: () {
+                if (Navigator.canPop(context) &&
+                    ModalRoute.of(context)?.settings.name == '/barometer') {
+                  Navigator.popUntil(
+                      context, ModalRoute.withName('/barometer'));
+                } else {
+                  Navigator.pushNamedAndRemoveUntil(
+                    context,
+                    '/barometer',
+                    (route) => route.isFirst,
+                  );
+                }
+              },
+              icon: Icon(
+                Icons.arrow_back,
+                color: appBarContentColor,
+              ),
+            );
+          },
+        ),
         title: Text(
           appLocalizations.barometerConfig,
           style: TextStyle(

--- a/lib/view/soundmeter_config_screen.dart
+++ b/lib/view/soundmeter_config_screen.dart
@@ -9,21 +9,15 @@ import '../theme/colors.dart';
 
 class SoundMeterConfigScreen extends StatefulWidget {
   const SoundMeterConfigScreen({super.key});
+
   @override
-  State<SoundMeterConfigScreen> createState() => _SoundMeterConfigScreenState();
+  State<SoundMeterConfigScreen> createState() =>
+      _SoundMeterConfigScreenState();
 }
 
-class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
+class _SoundMeterConfigScreenState
+    extends State<SoundMeterConfigScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,26 +30,15 @@ class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
-        leading: Builder(builder: (context) {
-          return IconButton(
-            onPressed: () {
-              if (Navigator.canPop(context) &&
-                  ModalRoute.of(context)?.settings.name == '/Soundmeter') {
-                Navigator.popUntil(context, ModalRoute.withName('/Soundmeter'));
-              } else {
-                Navigator.pushNamedAndRemoveUntil(
-                  context,
-                  '/soundmeter',
-                  (route) => route.isFirst,
-                );
-              }
-            },
-            icon: Icon(
-              Icons.arrow_back,
-              color: appBarContentColor,
-            ),
-          );
-        }),
+        leading: IconButton(
+          onPressed: () {
+            Navigator.maybePop(context);
+          },
+          icon: Icon(
+            Icons.arrow_back,
+            color: appBarContentColor,
+          ),
+        ),
         backgroundColor: primaryRed,
         title: Text(
           appLocalizations.soundmeterConfig,


### PR DESCRIPTION
## Summary
This PR resolves a critical bug where the **Sound Meter** instrument stopped updating real-time data after a user navigated to the Configuration screen and returned.

**Fixes:** #3069


## Root Cause
The navigation logic within `soundmeter_config_screen.dart` was using complex conditional route handling (such as `pushNamedAndRemoveUntil` or `popUntil`) instead of a standard back-stack pop. 

**This led to:**
**Unintended Rebuilds:** The Sound Meter screen was being re-initialized rather than resumed.
**Stream Interruption:** The active audio stream/listener was lost or reset during the route manipulation.
**UI Freezing:** The instrument state became unresponsive upon returning.

## Changes Made
* **Refactored Navigation:** Replaced custom/heavy route logic with a clean `Navigator.maybePop(context);`.
* **State Preservation:** Ensured the existing Sound Meter screen instance remains in the widget tree without being disposed of or rebuilt.
* **Stream Stability:** Prevented the audio listener from being interrupted by unnecessary route changes.


## Result
* [x] Sound Meter continues updating normally after returning from config.
* [x] Audio streams remain active and uninterrupted.
* [x] Instrument state is fully preserved.


> **Technical Note:** Using `maybePop` ensures that we don't accidentally pop the last remaining route in the stack, providing a safer navigation experience than a forced `pop`.

[FIXEDsm.webm](https://github.com/user-attachments/assets/53100513-6af1-4b58-85c6-578e4e584ac3)

## Summary by Sourcery

Simplify navigation from instrument configuration screens to preserve live instrument state and prevent unintended route resets.

Bug Fixes:
- Ensure navigating back from the Sound Meter configuration screen no longer restarts or freezes the Sound Meter instrument by using standard back-stack popping.

Enhancements:
- Simplify and standardize back navigation in the Sound Meter configuration screen using a safer back action.
- Add explicit back navigation handling to the Barometer configuration screen to fall back to reopening the barometer when no route can be popped.