### PR TITLE
fix(soundmeter): prevent rebuild on back navigation

### DIFF
--- a/lib/view/soundmeter_config_screen.dart
+++ b/lib/view/soundmeter_config_screen.dart
@@ -9,21 +9,15 @@ import '../theme/colors.dart';
 
 class SoundMeterConfigScreen extends StatefulWidget {
   const SoundMeterConfigScreen({super.key});
+
   @override
-  State<SoundMeterConfigScreen> createState() => _SoundMeterConfigScreenState();
+  State<SoundMeterConfigScreen> createState() =>
+      _SoundMeterConfigScreenState();
 }
 
-class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
+class _SoundMeterConfigScreenState
+    extends State<SoundMeterConfigScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
-  @override
-  void initState() {
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -36,26 +30,15 @@ class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
-        leading: Builder(builder: (context) {
-          return IconButton(
-            onPressed: () {
-              if (Navigator.canPop(context) &&
-                  ModalRoute.of(context)?.settings.name == '/Soundmeter') {
-                Navigator.popUntil(context, ModalRoute.withName('/Soundmeter'));
-              } else {
-                Navigator.pushNamedAndRemoveUntil(
-                  context,
-                  '/soundmeter',
-                  (route) => route.isFirst,
-                );
-              }
-            },
-            icon: Icon(
-              Icons.arrow_back,
-              color: appBarContentColor,
-            ),
-          );
-        }),
+        leading: IconButton(
+          onPressed: () {
+            Navigator.maybePop(context);
+          },
+          icon: Icon(
+            Icons.arrow_back,
+            color: appBarContentColor,
+          ),
+        ),
         backgroundColor: primaryRed,
         title: Text(
           appLocalizations.soundmeterConfig,

--- a/lib/view/soundmeter_config_screen.dart
+++ b/lib/view/soundmeter_config_screen.dart
@@ -11,12 +11,10 @@ class SoundMeterConfigScreen extends StatefulWidget {
   const SoundMeterConfigScreen({super.key});
 
   @override
-  State<SoundMeterConfigScreen> createState() =>
-      _SoundMeterConfigScreenState();
+  State<SoundMeterConfigScreen> createState() => _SoundMeterConfigScreenState();
 }
 
-class _SoundMeterConfigScreenState
-    extends State<SoundMeterConfigScreen> {
+class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
   @override

--- a/lib/view/soundmeter_config_screen.dart
+++ b/lib/view/soundmeter_config_screen.dart
@@ -39,16 +39,7 @@ class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
         leading: Builder(builder: (context) {
           return IconButton(
             onPressed: () {
-              if (Navigator.canPop(context) &&
-                  ModalRoute.of(context)?.settings.name == '/Soundmeter') {
-                Navigator.popUntil(context, ModalRoute.withName('/Soundmeter'));
-              } else {
-                Navigator.pushNamedAndRemoveUntil(
-                  context,
-                  '/soundmeter',
-                  (route) => route.isFirst,
-                );
-              }
+              Navigator.maybePop(context);
             },
             icon: Icon(
               Icons.arrow_back,

--- a/lib/view/soundmeter_config_screen.dart
+++ b/lib/view/soundmeter_config_screen.dart
@@ -9,13 +9,21 @@ import '../theme/colors.dart';
 
 class SoundMeterConfigScreen extends StatefulWidget {
   const SoundMeterConfigScreen({super.key});
-
   @override
   State<SoundMeterConfigScreen> createState() => _SoundMeterConfigScreenState();
 }
 
 class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,15 +36,26 @@ class _SoundMeterConfigScreenState extends State<SoundMeterConfigScreen> {
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
-        leading: IconButton(
-          onPressed: () {
-            Navigator.maybePop(context);
-          },
-          icon: Icon(
-            Icons.arrow_back,
-            color: appBarContentColor,
-          ),
-        ),
+        leading: Builder(builder: (context) {
+          return IconButton(
+            onPressed: () {
+              if (Navigator.canPop(context) &&
+                  ModalRoute.of(context)?.settings.name == '/Soundmeter') {
+                Navigator.popUntil(context, ModalRoute.withName('/Soundmeter'));
+              } else {
+                Navigator.pushNamedAndRemoveUntil(
+                  context,
+                  '/soundmeter',
+                  (route) => route.isFirst,
+                );
+              }
+            },
+            icon: Icon(
+              Icons.arrow_back,
+              color: appBarContentColor,
+            ),
+          );
+        }),
         backgroundColor: primaryRed,
         title: Text(
           appLocalizations.soundmeterConfig,


### PR DESCRIPTION
**Fixes:** #3069

## Summary
This PR resolves a critical bug where the **Sound Meter** instrument stopped updating real-time data after a user navigated to the Configuration screen and returned.

## Root Cause
The navigation logic within `soundmeter_config_screen.dart` was using complex conditional route handling (such as `pushNamedAndRemoveUntil` or `popUntil`) instead of a standard back-stack pop. 

**This led to:**
-**Unintended Rebuilds:** The Sound Meter screen was being re-initialized rather than resumed.
-**Stream Interruption:** The active audio stream/listener was lost or reset during the route manipulation.
-**UI Freezing:** The instrument state became unresponsive upon returning.

## Changes Made
* **Refactored Navigation:** Replaced custom/heavy route logic with a clean `Navigator.maybePop(context);`.
* **State Preservation:** Ensured the existing Sound Meter screen instance remains in the widget tree without being disposed of or rebuilt.
* **Stream Stability:** Prevented the audio listener from being interrupted by unnecessary route changes.

## Result
* [x] Sound Meter continues updating normally after returning from config.
* [x] Audio streams remain active and uninterrupted.
* [x] Instrument state is fully preserved.

[FIXEDsm.webm](https://github.com/user-attachments/assets/c83b6e7c-33be-4f35-a545-97fda4037b59)

> **Technical Note:** Using `maybePop` ensures that we don't accidentally pop the last remaining route in the stack, providing a safer navigation experience than a forced `pop`.