### PR TITLE
fix: Sensors High Limit

### DIFF
--- a/lib/providers/accelerometer_state_provider.dart
+++ b/lib/providers/accelerometer_state_provider.dart
@@ -212,9 +212,12 @@ class AccelerometerStateProvider extends ChangeNotifier {
   }
 
   void _updateData() {
-    final x = _accelerometerEvent.x;
-    final y = _accelerometerEvent.y;
-    final z = _accelerometerEvent.z;
+    final double limit = (_configProvider.config.highLimit).toDouble();
+
+    final x = _accelerometerEvent.x.clamp(-limit, limit);
+    final y = _accelerometerEvent.y.clamp(-limit, limit);
+    final z = _accelerometerEvent.z.clamp(-limit, limit);
+
     if (_isRecording) {
       final now = DateTime.now();
       final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
@@ -241,12 +244,14 @@ class AccelerometerStateProvider extends ChangeNotifier {
     if (_yData.length > _maxLength) _yData.removeAt(0);
     if (_zData.length > _maxLength) _zData.removeAt(0);
 
-    _xMin = _xData.reduce(min);
-    _xMax = _xData.reduce(max);
-    _yMin = _yData.reduce(min);
-    _yMax = _yData.reduce(max);
-    _zMin = _zData.reduce(min);
-    _zMax = _zData.reduce(max);
+    if (_xData.isNotEmpty) {
+      _xMin = _xData.reduce(min);
+      _xMax = _xData.reduce(max);
+      _yMin = _yData.reduce(min);
+      _yMax = _yData.reduce(max);
+      _zMin = _zData.reduce(min);
+      _zMax = _zData.reduce(max);
+    }
 
     xData.clear();
     yData.clear();

--- a/lib/providers/accelerometer_state_provider.dart
+++ b/lib/providers/accelerometer_state_provider.dart
@@ -35,12 +35,11 @@ class AccelerometerStateProvider extends ChangeNotifier {
   bool get isRecording => _isRecording;
   bool get isPlayingBack => _isPlayingBack;
   bool get isPlaybackPaused => _isPlaybackPaused;
-
-  late AccelerometerConfigProvider _configProvider;
+  AccelerometerConfigProvider? _configProvider;
   StreamSubscription? _locationStream;
   Position? currentPosition;
   Function? onPlaybackEnd;
-
+  double? get _currentLimit => _configProvider?.config.highLimit.toDouble();
   void setConfigProvider(AccelerometerConfigProvider configProvider) {
     _configProvider = configProvider;
   }
@@ -212,11 +211,24 @@ class AccelerometerStateProvider extends ChangeNotifier {
   }
 
   void _updateData() {
-    final double limit = (_configProvider.config.highLimit).toDouble();
+    final limit = _currentLimit;
 
-    final x = _accelerometerEvent.x.clamp(-limit, limit);
-    final y = _accelerometerEvent.y.clamp(-limit, limit);
-    final z = _accelerometerEvent.z.clamp(-limit, limit);
+    final bool shouldClip = limit != null && !_isPlayingBack;
+
+    final x = (shouldClip && _accelerometerEvent.x > limit)
+        ? limit
+        : _accelerometerEvent.x;
+
+    final y = (shouldClip && _accelerometerEvent.y > limit)
+        ? limit
+        : _accelerometerEvent.y;
+
+    final z = (shouldClip && _accelerometerEvent.z > limit)
+        ? limit
+        : _accelerometerEvent.z;
+
+    _accelerometerEvent = AccelerometerEvent(x, y, z, DateTime.now());
+
     _accelerometerEvent = AccelerometerEvent(x, y, z, DateTime.now());
     if (_isRecording) {
       final now = DateTime.now();
@@ -227,10 +239,10 @@ class AccelerometerStateProvider extends ChangeNotifier {
         x.toStringAsFixed(6),
         y.toStringAsFixed(6),
         z.toStringAsFixed(6),
-        _configProvider.config.includeLocationData
+        _configProvider!.config.includeLocationData
             ? currentPosition?.latitude.toString() ?? 0
             : 0,
-        _configProvider.config.includeLocationData
+        _configProvider!.config.includeLocationData
             ? currentPosition?.longitude.toString() ?? 0
             : 0
       ]);
@@ -244,14 +256,12 @@ class AccelerometerStateProvider extends ChangeNotifier {
     if (_yData.length > _maxLength) _yData.removeAt(0);
     if (_zData.length > _maxLength) _zData.removeAt(0);
 
-    if (_xData.isNotEmpty) {
-      _xMin = _xData.reduce(min);
-      _xMax = _xData.reduce(max);
-      _yMin = _yData.reduce(min);
-      _yMax = _yData.reduce(max);
-      _zMin = _zData.reduce(min);
-      _zMax = _zData.reduce(max);
-    }
+    _xMin = _xData.reduce(min);
+    _xMax = _xData.reduce(max);
+    _yMin = _yData.reduce(min);
+    _yMax = _yData.reduce(max);
+    _zMin = _zData.reduce(min);
+    _zMax = _zData.reduce(max);
 
     xData.clear();
     yData.clear();
@@ -267,7 +277,7 @@ class AccelerometerStateProvider extends ChangeNotifier {
   }
 
   Future<void> startRecording() async {
-    if (_configProvider.config.includeLocationData) {
+    if (_configProvider!.config.includeLocationData) {
       await _startGeoLocationUpdates();
     }
     _isRecording = true;

--- a/lib/providers/accelerometer_state_provider.dart
+++ b/lib/providers/accelerometer_state_provider.dart
@@ -217,7 +217,7 @@ class AccelerometerStateProvider extends ChangeNotifier {
     final x = _accelerometerEvent.x.clamp(-limit, limit);
     final y = _accelerometerEvent.y.clamp(-limit, limit);
     final z = _accelerometerEvent.z.clamp(-limit, limit);
-
+    _accelerometerEvent = AccelerometerEvent(x, y, z, DateTime.now());
     if (_isRecording) {
       final now = DateTime.now();
       final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -418,15 +418,19 @@ class BarometerStateProvider extends ChangeNotifier {
   void _updateData() {
     if (!_sensorAvailable && !_isPlayingBack) return;
 
-    final pressure = _currentPressure;
+    final double limit = (_configProvider.config.highLimit).toDouble();
+    final double rawPressure = _currentPressure;
+    final double clippedPressure = rawPressure > limit ? limit : rawPressure;
+
     final time = _currentTime;
+
     if (_isRecording) {
       final now = DateTime.now();
       final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
       _recordedData.add([
         now.millisecondsSinceEpoch.toString(),
         dateFormat.format(now),
-        pressure.toStringAsFixed(2),
+        clippedPressure.toStringAsFixed(2),
         getCurrentAltitude().toStringAsFixed(2),
         _configProvider.config.includeLocationData
             ? currentPosition?.latitude.toString() ?? 0
@@ -436,9 +440,10 @@ class BarometerStateProvider extends ChangeNotifier {
             : 0
       ]);
     }
-    _pressureData.add(pressure);
+
+    _pressureData.add(clippedPressure);
     _timeData.add(time);
-    _pressureSum += pressure;
+    _pressureSum += clippedPressure;
     _dataCount++;
 
     if (_pressureData.length > _chartMaxLength) {
@@ -457,6 +462,7 @@ class BarometerStateProvider extends ChangeNotifier {
     for (int i = 0; i < _pressureData.length; i++) {
       pressureChartData.add(FlSpot(_timeData[i], _pressureData[i]));
     }
+
     notifyListeners();
   }
 

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -421,7 +421,7 @@ class BarometerStateProvider extends ChangeNotifier {
     final double limit = (_configProvider.config.highLimit).toDouble();
     final double rawPressure = _currentPressure;
     final double clippedPressure = rawPressure > limit ? limit : rawPressure;
-
+    _currentPressure = clippedPressure;
     final time = _currentTime;
 
     if (_isRecording) {

--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -52,6 +52,7 @@ class BarometerStateProvider extends ChangeNotifier {
   ScienceLab? _scienceLab;
 
   final BarometerConfigProvider _configProvider;
+  double? get _currentLimit => _configProvider.config.highLimit.toDouble();
   String _currentSensorType = 'In-built Sensor';
 
   Function(String)? onSensorError;
@@ -418,9 +419,15 @@ class BarometerStateProvider extends ChangeNotifier {
   void _updateData() {
     if (!_sensorAvailable && !_isPlayingBack) return;
 
-    final double limit = (_configProvider.config.highLimit).toDouble();
+    final limit = _currentLimit;
+
+    final bool shouldClip = !_isPlayingBack && limit != null;
+
     final double rawPressure = _currentPressure;
-    final double clippedPressure = rawPressure > limit ? limit : rawPressure;
+
+    final double clippedPressure =
+        shouldClip && rawPressure > limit ? limit : rawPressure;
+
     _currentPressure = clippedPressure;
     final time = _currentTime;
 

--- a/lib/providers/gyroscope_state_provider.dart
+++ b/lib/providers/gyroscope_state_provider.dart
@@ -50,8 +50,8 @@ class GyroscopeProvider extends ChangeNotifier {
   bool get isPlayingBack => _isPlayingBack;
   bool get isPlaybackPaused => _isPlaybackPaused;
 
-  late GyroscopeConfigProvider _configProvider;
-
+  GyroscopeConfigProvider? _configProvider;
+  double? get _currentLimit => _configProvider?.config.highLimit.toDouble();
   Position? currentPosition;
   StreamSubscription? _locationStream;
 
@@ -229,11 +229,19 @@ class GyroscopeProvider extends ChangeNotifier {
   }
 
   void _updateData() {
-    final double limit = (_configProvider.config.highLimit).toDouble();
+    final limit = _currentLimit;
 
-    final x = _gyroscopeEvent.x.clamp(-limit, limit);
-    final y = _gyroscopeEvent.y.clamp(-limit, limit);
-    final z = _gyroscopeEvent.z.clamp(-limit, limit);
+    final bool shouldClip = !_isPlayingBack && limit != null;
+
+    final double x =
+        (shouldClip && _gyroscopeEvent.x > limit) ? limit : _gyroscopeEvent.x;
+
+    final double y =
+        (shouldClip && _gyroscopeEvent.y > limit) ? limit : _gyroscopeEvent.y;
+
+    final double z =
+        (shouldClip && _gyroscopeEvent.z > limit) ? limit : _gyroscopeEvent.z;
+
     _gyroscopeEvent = GyroscopeEvent(x, y, z, DateTime.now());
     if (_isRecording) {
       final now = DateTime.now();
@@ -244,10 +252,10 @@ class GyroscopeProvider extends ChangeNotifier {
         x.toStringAsFixed(6),
         y.toStringAsFixed(6),
         z.toStringAsFixed(6),
-        _configProvider.config.includeLocationData
+        _configProvider!.config.includeLocationData
             ? currentPosition?.latitude.toString() ?? 0
             : 0,
-        _configProvider.config.includeLocationData
+        _configProvider!.config.includeLocationData
             ? currentPosition?.longitude.toString() ?? 0
             : 0
       ]);
@@ -288,7 +296,7 @@ class GyroscopeProvider extends ChangeNotifier {
   }
 
   Future<void> startRecording() async {
-    if (_configProvider.config.includeLocationData) {
+    if (_configProvider!.config.includeLocationData) {
       await _startGeoLocationUpdates();
     }
     _isRecording = true;

--- a/lib/providers/gyroscope_state_provider.dart
+++ b/lib/providers/gyroscope_state_provider.dart
@@ -229,9 +229,11 @@ class GyroscopeProvider extends ChangeNotifier {
   }
 
   void _updateData() {
-    final x = _gyroscopeEvent.x;
-    final y = _gyroscopeEvent.y;
-    final z = _gyroscopeEvent.z;
+    final double limit = (_configProvider.config.highLimit).toDouble();
+
+    final x = _gyroscopeEvent.x.clamp(-limit, limit);
+    final y = _gyroscopeEvent.y.clamp(-limit, limit);
+    final z = _gyroscopeEvent.z.clamp(-limit, limit);
 
     if (_isRecording) {
       final now = DateTime.now();
@@ -281,6 +283,7 @@ class GyroscopeProvider extends ChangeNotifier {
       yData.add(FlSpot(i.toDouble(), _yData[i]));
       zData.add(FlSpot(i.toDouble(), _zData[i]));
     }
+
     notifyListeners();
   }
 

--- a/lib/providers/gyroscope_state_provider.dart
+++ b/lib/providers/gyroscope_state_provider.dart
@@ -234,7 +234,7 @@ class GyroscopeProvider extends ChangeNotifier {
     final x = _gyroscopeEvent.x.clamp(-limit, limit);
     final y = _gyroscopeEvent.y.clamp(-limit, limit);
     final z = _gyroscopeEvent.z.clamp(-limit, limit);
-
+    _gyroscopeEvent = GyroscopeEvent(x, y, z, DateTime.now());
     if (_isRecording) {
       final now = DateTime.now();
       final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');

--- a/lib/providers/luxmeter_state_provider.dart
+++ b/lib/providers/luxmeter_state_provider.dart
@@ -408,17 +408,22 @@ class LuxMeterStateProvider extends ChangeNotifier {
   }
 
   void _updateData() {
-    final lux = _sensorAvailable || _isPlayingBack ? _currentLux : null;
+    final double? rawLux =
+        (_sensorAvailable || _isPlayingBack) ? _currentLux : null;
     final time = _currentTime;
 
-    if (lux != null) {
+    if (rawLux != null) {
+      final double limit =
+          (_configProvider?.config.highLimit ?? 40000).toDouble();
+      final double clippedLux = rawLux > limit ? limit : rawLux;
+
       if (_isRecording) {
         final now = DateTime.now();
         final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');
         _recordedData.add([
           now.millisecondsSinceEpoch.toString(),
           dateFormat.format(now),
-          lux.toStringAsFixed(2),
+          clippedLux.toStringAsFixed(2),
           _configProvider!.config.includeLocationData
               ? currentPosition?.latitude.toString() ?? 0
               : 0,
@@ -428,9 +433,9 @@ class LuxMeterStateProvider extends ChangeNotifier {
         ]);
       }
 
-      _luxData.add(lux);
+      _luxData.add(clippedLux);
       _timeData.add(time);
-      _luxSum += lux;
+      _luxSum += clippedLux;
       _dataCount++;
     }
 
@@ -450,6 +455,7 @@ class LuxMeterStateProvider extends ChangeNotifier {
     for (int i = 0; i < _luxData.length; i++) {
       luxChartData.add(FlSpot(_timeData[i], _luxData[i]));
     }
+
     notifyListeners();
   }
 

--- a/lib/providers/luxmeter_state_provider.dart
+++ b/lib/providers/luxmeter_state_provider.dart
@@ -416,7 +416,7 @@ class LuxMeterStateProvider extends ChangeNotifier {
       final double limit =
           (_configProvider?.config.highLimit ?? 40000).toDouble();
       final double clippedLux = rawLux > limit ? limit : rawLux;
-
+      _currentLux = clippedLux;
       if (_isRecording) {
         final now = DateTime.now();
         final dateFormat = DateFormat('yyyy-MM-dd HH:mm:ss.SSS');


### PR DESCRIPTION
Fixes #3083

## Changes
The high limits were not previously implemented, so the feature was not working as expected.
This has now been fixed by adding clipping to enforce the defined high limits.

## Screenshots / Recordings

https://github.com/user-attachments/assets/80dde031-5c08-48a9-8f14-84ba286756bd



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enforce configured high-limit clipping across sensor providers to ensure recorded and charted values stay within defined bounds.

Bug Fixes:
- Clamp accelerometer readings to the configured symmetric high limit before recording and charting.
- Apply high-limit clipping to lux meter values, including recorded data, aggregations, and chart data.
- Apply high-limit clipping to barometer pressure readings, including recorded data, aggregations, and chart data.
- Prevent accelerometer min/max calculations from executing on empty data sets to avoid runtime errors.

Enhancements:
- Standardize sensor providers to use configuration-driven limits when processing live data.