### PR TITLE
feat: Enable web version with serial communication

### DIFF
--- a/lib/communication/commands_proto.dart
+++ b/lib/communication/commands_proto.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 class CommandsProto {
   int acknowledge = 254;
@@ -204,7 +204,10 @@ class CommandsProto {
   int stopStreaming = 253;
 
   CommandsProto() {
-    if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    if (!kIsWeb &&
+        (defaultTargetPlatform == TargetPlatform.windows ||
+            defaultTargetPlatform == TargetPlatform.linux ||
+            defaultTargetPlatform == TargetPlatform.macOS)) {
       dataSplitting = 30;
     } else {
       dataSplitting = 60;

--- a/lib/communication/handler/io_router.dart
+++ b/lib/communication/handler/io_router.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+import 'base.dart';
+import 'android_comms_handler.dart';
+import 'desktop_comms_handler.dart';
+import 'ios_comms_handler.dart';
+
+CommunicationHandler getCommunicationHandler() {
+  if (Platform.isAndroid) {
+    return AndroidUSBCommunicationHandler();
+  } else if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
+    return DesktopUSBCommunicationHandler();
+  } else {
+    return IosNoOpCommunicationHandler();
+  }
+}

--- a/lib/communication/handler/web_comms_handler.dart
+++ b/lib/communication/handler/web_comms_handler.dart
@@ -1,0 +1,127 @@
+import 'dart:async';
+import 'dart:collection';
+import 'dart:js_interop';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+import 'package:serial/serial.dart';
+
+import '../../others/logger_service.dart';
+import 'base.dart';
+
+@JS()
+extension type ReadResult._(JSObject _) implements JSObject {
+  external bool get done;
+  external JSUint8Array? get value;
+}
+
+class WebCommsHandler implements CommunicationHandler {
+  @override
+  bool connected = false;
+
+  @override
+  bool deviceFound = false;
+
+  SerialPort? _port;
+  web.ReadableStreamDefaultReader? _reader;
+  web.WritableStreamDefaultWriter? _writer;
+
+  final Queue<int> _rxBuffer = ListQueue<int>();
+  bool _isReading = false;
+
+  @override
+  Future<void> initialize() async {
+    deviceFound = true;
+  }
+
+  @override
+  Future<void> open() async {
+    try {
+      _rxBuffer.clear();
+      _port = await web.window.navigator.serial.requestPort().toDart;
+      await _port!.open(baudRate: 1000000).toDart;
+
+      await _port!
+          .setSignals(dataTerminalReady: true, requestToSend: true)
+          .toDart;
+      await Future.delayed(const Duration(milliseconds: 2000));
+
+      _writer = _port!.writable!.getWriter();
+      _reader = _port!.readable!.getReader() as web.ReadableStreamDefaultReader;
+
+      connected = true;
+      _isReading = true;
+
+      _startBackgroundReader();
+    } catch (e) {
+      connected = false;
+      logger.e("User cancelled or connection failed: $e");
+    }
+  }
+
+  void _startBackgroundReader() async {
+    try {
+      while (_isReading && connected && _reader != null) {
+        final resultJS = await _reader!.read().toDart;
+        final result = resultJS as ReadResult;
+
+        if (result.done) {
+          connected = false;
+          break;
+        }
+
+        if (result.value != null) {
+          final chunk = result.value!.toDart;
+          for (int i = 0; i < chunk.length; i++) {
+            _rxBuffer.add(chunk[i]);
+          }
+        }
+      }
+    } catch (e) {
+      logger.e("Stream closed or device disconnected: $e");
+      connected = false;
+    }
+  }
+
+  @override
+  bool isDeviceFound() => deviceFound;
+
+  @override
+  bool isConnected() => connected;
+
+  @override
+  void close() {
+    _isReading = false;
+    _reader?.cancel().toDart;
+    _writer?.close().toDart;
+    _port?.close().toDart;
+    connected = false;
+  }
+
+  @override
+  void write(Uint8List src, int timeoutMillis) {
+    if (_writer != null) {
+      _writer!.write(src.toJS).toDart;
+    }
+  }
+
+  @override
+  Future<int> read(Uint8List dest, int bytesToRead, int timeoutMillis) async {
+    int elapsed = 0;
+    const int interval = 5;
+
+    while (_rxBuffer.length < bytesToRead && elapsed < timeoutMillis) {
+      await Future.delayed(const Duration(milliseconds: interval));
+      elapsed += interval;
+    }
+
+    int bytesRead = 0;
+
+    while (bytesRead < bytesToRead && _rxBuffer.isNotEmpty) {
+      dest[bytesRead] = _rxBuffer.removeFirst();
+      bytesRead++;
+    }
+
+    return bytesRead;
+  }
+}

--- a/lib/communication/handler/web_comms_handler.dart
+++ b/lib/communication/handler/web_comms_handler.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
 import 'dart:typed_data';
 
 import 'package:web/web.dart' as web;
@@ -31,7 +32,10 @@ class WebCommsHandler implements CommunicationHandler {
 
   @override
   Future<void> initialize() async {
-    deviceFound = true;
+    final navigator = web.window.navigator as JSObject;
+    final hasSerial = navigator.hasProperty('serial'.toJS).toDart;
+
+    deviceFound = web.window.isSecureContext && hasSerial;
   }
 
   @override
@@ -92,9 +96,9 @@ class WebCommsHandler implements CommunicationHandler {
   @override
   void close() {
     _isReading = false;
-    _reader?.cancel().toDart;
-    _writer?.close().toDart;
-    _port?.close().toDart;
+    _reader?.cancel().toDart.catchError((_) => null);
+    _writer?.close().toDart.catchError((_) => null);
+    _port?.close().toDart.catchError((_) => null);
     connected = false;
   }
 

--- a/lib/communication/handler/web_router.dart
+++ b/lib/communication/handler/web_router.dart
@@ -1,0 +1,6 @@
+import 'base.dart';
+import 'web_comms_handler.dart';
+
+CommunicationHandler getCommunicationHandler() {
+  return WebCommsHandler();
+}

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/others/logger_service.dart';
@@ -42,8 +41,9 @@ class BoardStateProvider extends ChangeNotifier {
       await fetchFirmwareVersion();
     }
     _isProcessing = false;
+
     if (configProvider.config.autoStart) {
-      if (Platform.isAndroid) {
+      if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
         UsbSerial.usbEventStream?.listen(
           (UsbEvent usbEvent) async {
             if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
@@ -67,6 +67,7 @@ class BoardStateProvider extends ChangeNotifier {
         );
       }
     }
+
     Connectivity()
         .onConnectivityChanged
         .listen((List<ConnectivityResult> results) {

--- a/lib/providers/locator.dart
+++ b/lib/providers/locator.dart
@@ -1,11 +1,9 @@
-import 'dart:io';
-
 import 'package:get_it/get_it.dart';
-import 'package:pslab/communication/handler/desktop_comms_handler.dart';
 import 'package:pslab/l10n/app_localizations.dart';
-import 'package:pslab/communication/handler/android_comms_handler.dart';
 import 'package:pslab/communication/handler/base.dart';
-import 'package:pslab/communication/handler/ios_comms_handler.dart';
+import 'package:pslab/communication/handler/io_router.dart'
+    if (dart.library.js_interop) 'package:pslab/communication/handler/web_router.dart';
+
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/communication/socket_client.dart';
 import 'package:pslab/others/science_lab_common.dart';
@@ -15,15 +13,9 @@ import 'package:pslab/providers/sht21_provider.dart';
 final GetIt getIt = GetIt.instance;
 
 void setupLocator() {
-  getIt.registerLazySingleton<CommunicationHandler>(() {
-    if (Platform.isAndroid) {
-      return AndroidUSBCommunicationHandler();
-    } else if (Platform.isWindows || Platform.isLinux || Platform.isMacOS) {
-      return DesktopUSBCommunicationHandler();
-    } else {
-      return IosNoOpCommunicationHandler();
-    }
-  });
+  getIt.registerLazySingleton<CommunicationHandler>(
+      () => getCommunicationHandler());
+
   getIt.registerLazySingleton<SocketClient>(() => SocketClient());
   getIt.registerLazySingleton<ScienceLabCommon>(
       () => ScienceLabCommon(getIt.get<CommunicationHandler>()));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,8 @@ dependencies:
   geolocator: ^14.0.2
   wakelock_plus: ^1.3.3
   image: ^4.1.3
+  serial: ^0.0.7+1
+  web: ^1.1.1
 dependency_overrides:
   ffi: ^2.1.3
 


### PR DESCRIPTION
Fixes #3108 


## Changes

Previously, attempting to run the app on the web resulted in major blockers.

### 1. Compiler Crashes

Mixing native `dart:io` libraries with web libraries in the same file caused immediate compilation failures.

To resolve this, `web_comms_handler.dart` is introduced to properly handle web communication. Additionally, conditional imports were implemented to load platform-specific implementations depending on the target system (Android, Desktop, Web, etc.).

### Conditional Import Routing

Created:

- `io_router.dart`
- `web_router.dart`

Used conditional imports in `locator.dart` to ensure proper platform isolation between native and web dependencies.

This enables the web version of the app and the app can now be successfully run and used in modern web browsers.
## Screenshots / Recordings

https://github.com/user-attachments/assets/7cdf42f2-6b6d-4334-8e2c-7b1d4254b7c6


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enable running the app in web browsers by introducing a web-specific communication handler and platform-aware routing for communication services.

New Features:
- Add a web communication handler that uses the Web Serial API to talk to connected devices from the browser.

Enhancements:
- Introduce platform-specific communication routing via conditional imports to select native or web handlers without mixing incompatible libraries.
- Update platform detection logic in shared communication code to use Flutter’s target platform and web checks instead of dart:io Platform APIs.

Build:
- Add serial and web packages as dependencies for browser-based serial communication support.