### PR TITLE
chore: add upload of ARM64 build to apk branch

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -352,6 +352,48 @@ jobs:
           git branch -m apk
           git push --force origin apk
 
+  linux-arm64:
+    name: Linux ARM64 Flutter Build
+    needs: common
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Linux ARM64 Workflow
+        uses: ./.github/actions/linux-arm64
+        with:
+          VERSION_NAME: ${{needs.common.outputs.VERSION_NAME}}
+          VERSION_CODE: ${{needs.common.outputs.VERSION_CODE}}
+      
+      - name: Upload packages to apk branch
+        if: ${{ github.repository == 'fossasia/pslab-app' }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git clone --branch=apk https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} apk
+          cd apk
+          
+          branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}
+
+          echo "Removing previous files from branch"
+
+          rm -rf *.deb *.rpm
+
+          echo "Copying new build files"
+
+          cp -v ../*.deb .
+          cp -v ../*.rpm .
+
+          echo "Pushing to apk branch"
+
+          git checkout --orphan temporary
+          git add --all .
+          git commit -am "[Auto] Update Linux ARM64 Packages from $branch ($(date +%Y-%m-%d.%H:%M:%S))"
+          git branch -D apk
+          git branch -m apk
+          git push --force origin apk
+
   macos:
     name: macOS Flutter Build
     needs: common

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -211,7 +211,7 @@ jobs:
 
   update-release:
     name: Update Draft Release
-    needs: [ common, android, ios, windows, linux, macos ]
+    needs: [ common, android, ios, windows, linux, linux-arm64, macos ]
     runs-on: ubuntu-latest
     steps:
       - name: Run Release Drafter

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -336,7 +336,7 @@ jobs:
 
           echo "Removing previous files from branch"
 
-          rm -rf *.deb *.rpm
+          rm -rf !(*arm64*).deb !(*aarch64*).rpm
 
           echo "Copying new build files"
 
@@ -378,7 +378,7 @@ jobs:
 
           echo "Removing previous files from branch"
 
-          rm -rf *.deb *.rpm
+          rm -rf *arm64*.deb *aarch64*.rpm
 
           echo "Copying new build files"
 

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -336,7 +336,8 @@ jobs:
 
           echo "Removing previous files from branch"
 
-          rm -rf !(*arm64*).deb !(*aarch64*).rpm
+          find . -maxdepth 1 -type f -name '*.deb' ! -name '*arm64*' -delete
+          find . -maxdepth 1 -type f -name '*.rpm' ! -name '*aarch64*' -delete
 
           echo "Copying new build files"
 


### PR DESCRIPTION
Fixes #3111

## Changes
- add step which builds and adds Linux ARM64 packages to apk branch

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add Linux ARM64 build and publishing to the apk branch and integrate it into the release workflow.

Build:
- Update apk branch cleanup logic to preserve ARM64/AArch64 package files.

CI:
- Add a Linux ARM64 build job that uploads Debian and RPM packages to the apk branch and include it as a dependency of the release update job.