### PR TITLE
chore: remove dark mode implementation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,6 @@ import 'package:pslab/view/settings_screen.dart';
 import 'package:pslab/view/about_us_screen.dart';
 import 'package:pslab/view/software_licenses_screen.dart';
 import 'package:pslab/view/compass_screen.dart';
-import 'package:pslab/theme/app_theme.dart';
 import 'package:pslab/view/soundmeter_screen.dart';
 import 'package:pslab/view/thermometer_screen.dart';
 import 'package:pslab/view/wave_generator_screen.dart';
@@ -72,17 +71,10 @@ class MyApp extends StatelessWidget {
                 appLocalizations = getIt.get<AppLocalizations>();
                 return child!;
               },
-              theme: AppTheme.lightTheme,
-              darkTheme: AppTheme.darkTheme,
-              themeMode: () {
-                if (provider.config.theme == "Light") {
-                  return ThemeMode.light;
-                } else if (provider.config.theme == "Dark (Experimental)") {
-                  return ThemeMode.dark;
-                } else {
-                  return ThemeMode.system;
-                }
-              }(),
+              theme: ThemeData(
+                colorSchemeSeed: Colors.white,
+                useMaterial3: true,
+              ),
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
               initialRoute: '/',

--- a/lib/models/settings_config.dart
+++ b/lib/models/settings_config.dart
@@ -1,23 +1,19 @@
 class SettingsConfig {
   final bool autoStart;
   final String exportFormat;
-  final String theme;
 
   const SettingsConfig({
     this.autoStart = true,
     this.exportFormat = 'CSV',
-    this.theme = 'Light',
   });
 
   SettingsConfig copyWith({
     bool? autoStart,
     String? exportFormat,
-    String? theme,
   }) {
     return SettingsConfig(
       autoStart: autoStart ?? this.autoStart,
       exportFormat: exportFormat ?? this.exportFormat,
-      theme: theme ?? this.theme,
     );
   }
 
@@ -25,7 +21,6 @@ class SettingsConfig {
     return {
       'autoStart': autoStart,
       'exportFormat': exportFormat,
-      'theme': theme,
     };
   }
 
@@ -33,7 +28,6 @@ class SettingsConfig {
     return SettingsConfig(
       autoStart: json['autoStart'] ?? true,
       exportFormat: json['exportFormat'] ?? 'CSV',
-      theme: json['theme'] ?? 'Light',
     );
   }
 }

--- a/lib/providers/settings_config_provider.dart
+++ b/lib/providers/settings_config_provider.dart
@@ -61,17 +61,6 @@ class SettingsConfigProvider extends ChangeNotifier {
     _saveConfigToPrefs();
   }
 
-  void updateTheme(String theme) {
-    if (theme != "Light" &&
-        theme != "Dark (Experimental)" &&
-        theme != "System") {
-      theme = "Light";
-    }
-    _config = _config.copyWith(theme: theme);
-    notifyListeners();
-    _saveConfigToPrefs();
-  }
-
   void resetToDefaults() {
     _config = const SettingsConfig();
     notifyListeners();

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -19,22 +19,4 @@ class AppTheme {
       }),
     ),
   );
-
-  static final darkTheme = ThemeData(
-    brightness: Brightness.dark,
-    useMaterial3: true,
-    scaffoldBackgroundColor: Colors.black,
-    colorSchemeSeed: Colors.black,
-    checkboxTheme: const CheckboxThemeData(
-      side: BorderSide(color: Colors.black, width: 2),
-    ),
-    radioTheme: RadioThemeData(
-      fillColor: WidgetStateProperty.resolveWith<Color>((states) {
-        if (states.contains(WidgetState.selected)) {
-          return radioButtonActiveColor;
-        }
-        return Colors.black;
-      }),
-    ),
-  );
 }

--- a/lib/view/about_us_screen.dart
+++ b/lib/view/about_us_screen.dart
@@ -100,7 +100,6 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                 iconAboutUs,
                 width: 250,
                 height: 250,
-                color: Theme.of(context).colorScheme.onSurface,
               ),
             ),
             Center(

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -160,29 +160,20 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                     Icon(
                       Icons.search_off,
                       size: 64,
-                      color: Theme.of(context)
-                          .colorScheme
-                          .onSurface
-                          .withAlpha(128),
+                      color: Colors.black.withAlpha(128),
                     ),
                     const SizedBox(height: 16),
                     Text(
                       appLocalizations.noInstrumentsFoundMessage,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withAlpha(179),
+                            color: Colors.black.withAlpha(179),
                           ),
                     ),
                     const SizedBox(height: 8),
                     Text(
                       appLocalizations.tryDifferentSearchSuggestion,
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withAlpha(128),
+                            color: Colors.black.withAlpha(128),
                           ),
                     ),
                   ],

--- a/lib/view/settings_screen.dart
+++ b/lib/view/settings_screen.dart
@@ -31,7 +31,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.surface,
+      backgroundColor: Colors.white,
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
         iconTheme: IconThemeData(color: appBarContentColor),
@@ -75,24 +75,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       ],
                       onChanged: (value) {
                         provider.updateExportFormat(value);
-                      },
-                    ),
-                    ConfigDropdownItem(
-                      title: appLocalizations.theme,
-                      selectedValue: provider.config.theme,
-                      options: [
-                        ConfigOption(
-                            value: 'Light',
-                            displayName: appLocalizations.light),
-                        ConfigOption(
-                            value: 'Dark (Experimental)',
-                            displayName: appLocalizations.darkExperimental),
-                        ConfigOption(
-                            value: 'System',
-                            displayName: appLocalizations.system),
-                      ],
-                      onChanged: (value) {
-                        provider.updateTheme(value);
                       },
                     ),
                   ],

--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -83,7 +83,7 @@ class _MainScaffoldState extends State<MainScaffold>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.surface,
+      backgroundColor: Colors.white,
       resizeToAvoidBottomInset: true,
       appBar: AppBar(
         systemOverlayStyle: SystemUiOverlayStyle(

--- a/lib/view/widgets/navigation_drawer.dart
+++ b/lib/view/widgets/navigation_drawer.dart
@@ -32,7 +32,7 @@ class _NavDrawerState extends State<NavDrawer> {
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.zero,
       ),
-      backgroundColor: Theme.of(context).colorScheme.surface,
+      backgroundColor: Colors.white,
       child: ScrollConfiguration(
         behavior: const ScrollBehavior(),
         child: ListView(
@@ -77,7 +77,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 0
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -103,7 +103,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 13
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -135,7 +135,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 1
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -168,7 +168,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 2
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -200,7 +200,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 3
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -222,7 +222,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 4
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -254,7 +254,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 5
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -285,7 +285,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 6
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -314,7 +314,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 7
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -352,7 +352,7 @@ class _NavDrawerState extends State<NavDrawer> {
                   style: TextStyle(
                     color: widget.selectedIndex == 8
                         ? selectedMenuColor
-                        : Theme.of(context).colorScheme.onSurface,
+                        : Colors.black,
                     fontWeight: FontWeight.bold,
                     fontSize: 14,
                   ),
@@ -379,7 +379,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 9
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -410,7 +410,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 10
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -434,7 +434,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 11
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),
@@ -463,7 +463,7 @@ class _NavDrawerState extends State<NavDrawer> {
                 style: TextStyle(
                   color: widget.selectedIndex == 12
                       ? selectedMenuColor
-                      : Theme.of(context).colorScheme.onSurface,
+                      : Colors.black,
                   fontWeight: FontWeight.bold,
                   fontSize: 14,
                 ),


### PR DESCRIPTION
Fixes #2999 

## Changes
This PR entirely removes the current, incomplete dark mode implementation. As noted in the issue, the previous approach of simply adjusting background colors to black caused visual inconsistencies, clashed with older screens, and impacted overall UI stability. 

By removing the dark mode code and settings, the app now consistently defaults to the standard light theme across all screens.

## Screenshots / Recordings
[remove_dark_mode.webm](https://github.com/user-attachments/assets/96a8bc1d-58a9-4e00-9d73-b0ae7c1fc1ae)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.