### PR TITLE
fix(audio): stabilize built-in microphone streaming on desktop

### DIFF
--- a/lib/others/audio_jack.dart
+++ b/lib/others/audio_jack.dart
@@ -1,40 +1,82 @@
-import 'package:flutter_audio_capture/flutter_audio_capture.dart';
+import 'dart:async';
+import 'dart:typed_data';
+import 'package:record/record.dart';
 import 'package:pslab/others/logger_service.dart';
 
 class AudioJack {
   static const int samplingRate = 44100;
   bool _isListening = false;
-  final FlutterAudioCapture flutterAudioCapture = FlutterAudioCapture();
 
+  AudioRecorder? _recorder;
+  StreamSubscription<Uint8List>? _streamSubscription;
   List<double> _audioBuffer = [];
 
   AudioJack();
 
   Future<void> initialize() async {
-    await flutterAudioCapture.init();
+    /*The record package handles initialization internally during start() or permission checks.*/
   }
 
   Future<void> start() async {
-    await flutterAudioCapture.start(_listener, _onError,
-        sampleRate: samplingRate);
-    _isListening = true;
+    if (_isListening) return;
+
+    try {
+      _recorder = AudioRecorder();
+
+      if (await _recorder!.hasPermission()) {
+        const config = RecordConfig(
+          encoder: AudioEncoder.pcm16bits,
+          sampleRate: samplingRate,
+          numChannels: 1,
+          autoGain: false,
+          echoCancel: false,
+          noiseSuppress: false,
+        );
+
+        final stream = await _recorder!.startStream(config);
+        _streamSubscription = stream.listen(_listener, onError: _onError);
+        _isListening = true;
+      } else {
+        logger.e("Microphone permission denied.");
+      }
+    } catch (e) {
+      logger.e("Error starting audio record stream: $e");
+    }
+  }
+
+  void _listener(Uint8List data) {
+    final byteData = ByteData.sublistView(data);
+    List<double> tempBuffer = [];
+    for (int i = 0; i < byteData.lengthInBytes - 1; i += 2) {
+      final sample = byteData.getInt16(i, Endian.little);
+      tempBuffer.add(sample / 32768.0);
+    }
+    _audioBuffer = tempBuffer;
+  }
+
+  void _onError(Object e) {
+    logger.e("Audio Stream Error: $e");
+    _isListening = false;
   }
 
   List<double> read() {
     return _audioBuffer;
   }
 
-  void _listener(dynamic obj) {
-    _audioBuffer = obj.cast<double>();
-  }
-
-  void _onError(Object e) {
-    logger.e(e);
-  }
-
   Future<void> close() async {
-    await flutterAudioCapture.stop();
     _isListening = false;
+    await _streamSubscription?.cancel();
+    _streamSubscription = null;
+
+    if (_recorder != null) {
+      await _recorder!.stop();
+      await _recorder!.dispose();
+      _recorder = null;
+    }
+  }
+
+  Future<void> disposeHardware() async {
+    await close();
   }
 
   bool isListening() {

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -1069,7 +1069,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     if (_wakelockEnabled) {
       WakelockPlus.disable();
     }
-    _audioJack.close();
+    _audioJack.disposeHardware();
     super.dispose();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,10 +44,7 @@ dependencies:
   provider: ^6.1.5
   usb_serial: ^0.5.0
   get_it: ^9.2.1
-  flutter_audio_capture:
-    git:
-      url: https://github.com/AsCress/flutter_audio_capture.git
-      ref: master
+  record: ^6.2.0
   data: ^0.15.1
   permission_handler: ^12.0.1
   logger: ^2.6.1


### PR DESCRIPTION
Fixes #3117 
## Description
Stabilizes built-in microphone capture on desktop and fixes MIC plotting in the Oscilloscope.

## Changes
-Replaced the previous audio capture package with the record package for microphone input handling.
-Updated the audio capture implementation accordingly in AudioJack.
-Verified that the Oscilloscope and Sound Meter features are working as expected across platforms including Android, Desktop, and Web.

## Tested
- Windows desktop (built-in microphone)

https://github.com/user-attachments/assets/03e40bf4-c6b4-4e89-9420-46221241d60c


https://github.com/user-attachments/assets/476015cc-f9fa-4442-85a8-4a0deac56de7

## Summary by Sourcery

Stabilize desktop microphone capture by reworking the audio input path and tightening oscilloscope cleanup of audio resources.

Bug Fixes:
- Improve reliability of desktop microphone streaming by switching to a recorder-based PCM stream and handling permission and error cases.
- Ensure oscilloscope disposes microphone resources correctly when the state provider is disposed.

Enhancements:
- Refactor AudioJack to use the record package with a streaming API, updating internal buffering and lifecycle management while retaining the existing read interface.