### PR TITLE
feat: implement Produce Sound functionality in Wave Generator

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -663,5 +663,6 @@
     "pin_cap_name": "CAP",
     "pin_cap_desc": "Capacitance Measurement Pin",
     "pin_res_name": "RES",
-    "pin_res_desc": "Resistance Measurement Pin"
+    "pin_res_desc": "Resistance Measurement Pin",
+    "stopSound" : "Stop Sound"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -4103,6 +4103,12 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Resistance Measurement Pin'**
   String get pin_res_desc;
+
+  /// No description provided for @stopSound.
+  ///
+  /// In en, this message translates to:
+  /// **'Stop Sound'**
+  String get stopSound;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_de.dart
+++ b/lib/l10n/app_localizations_de.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_es.dart
+++ b/lib/l10n/app_localizations_es.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_fr.dart
+++ b/lib/l10n/app_localizations_fr.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_he.dart
+++ b/lib/l10n/app_localizations_he.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_hi.dart
+++ b/lib/l10n/app_localizations_hi.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_id.dart
+++ b/lib/l10n/app_localizations_id.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_it.dart
+++ b/lib/l10n/app_localizations_it.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_ml.dart
+++ b/lib/l10n/app_localizations_ml.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsMl extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_my.dart
+++ b/lib/l10n/app_localizations_my.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsMy extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_nb.dart
+++ b/lib/l10n/app_localizations_nb.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsNb extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_pt.dart
+++ b/lib/l10n/app_localizations_pt.dart
@@ -2155,6 +2155,9 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }
 
 /// The translations for Portuguese, as used in Brazil (`pt_BR`).

--- a/lib/l10n/app_localizations_ru.dart
+++ b/lib/l10n/app_localizations_ru.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_te.dart
+++ b/lib/l10n/app_localizations_te.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_uk.dart
+++ b/lib/l10n/app_localizations_uk.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -2155,4 +2155,7 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -2155,6 +2155,9 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get pin_res_desc => 'Resistance Measurement Pin';
+
+  @override
+  String get stopSound => 'Stop Sound';
 }
 
 /// The translations for Chinese, using the Han script (`zh_Hant`).

--- a/lib/providers/wave_generator_state_provider.dart
+++ b/lib/providers/wave_generator_state_provider.dart
@@ -1,11 +1,13 @@
 import 'dart:convert';
 import 'dart:math';
 import 'dart:math' as math;
+import 'dart:typed_data';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:intl/intl.dart';
+import 'package:mp_audio_stream/mp_audio_stream.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/others/wave_generator_constants.dart';
@@ -65,6 +67,12 @@ class WaveGeneratorStateProvider extends ChangeNotifier {
 
   Position? currentPosition;
 
+  AudioStream? _audioStream;
+
+  bool isPlayingSound = false;
+
+  double _audioAngle = 0.0;
+
   WaveGeneratorStateProvider() {
     selectedAnalogWave = WaveConst.wave1;
 
@@ -81,6 +89,146 @@ class WaveGeneratorStateProvider extends ChangeNotifier {
 
   void setConfigProvider(WaveGeneratorConfigProvider configProvider) {
     _configProvider = configProvider;
+  }
+
+  void toggleSound() {
+    if (isPlayingSound) {
+      isPlayingSound = false;
+
+      _stopAudioStream();
+    } else {
+      isPlayingSound = true;
+
+      _startAudioStream();
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> _startAudioStream() async {
+    _audioStream = getAudioStream();
+
+    _audioStream!.init(bufferMilliSec: 1000, channels: 1, sampleRate: 44100);
+
+    _audioStream!.resume();
+
+    await Future.delayed(const Duration(milliseconds: 100));
+
+    _audioAngle = 0.0;
+
+    final int bufferSize = 4096;
+
+    final double bufferDurationMs = (bufferSize / 44100.0) * 1000.0;
+
+    final List<Float32List> bufferPool =
+        List.generate(5, (_) => Float32List(bufferSize));
+
+    int poolIndex = 0;
+
+    double generatedAudioMs = 0.0;
+
+    Stopwatch stopwatch = Stopwatch()..start();
+
+    for (int i = 0; i < 3; i++) {
+      final buffer = bufferPool[poolIndex];
+
+      poolIndex = (poolIndex + 1) % bufferPool.length;
+
+      _fillAudioBuffer(buffer, bufferSize);
+
+      _audioStream!.push(buffer);
+
+      generatedAudioMs += bufferDurationMs;
+    }
+
+    while (isPlayingSound) {
+      double elapsedRealTimeMs = stopwatch.elapsedMilliseconds.toDouble();
+
+      if (generatedAudioMs - elapsedRealTimeMs < 300.0) {
+        final buffer = bufferPool[poolIndex];
+
+        poolIndex = (poolIndex + 1) % bufferPool.length;
+
+        _fillAudioBuffer(buffer, bufferSize);
+
+        _audioStream!.push(buffer);
+
+        generatedAudioMs += bufferDurationMs;
+      } else {
+        await Future.delayed(const Duration(milliseconds: 20));
+      }
+
+      if (elapsedRealTimeMs > generatedAudioMs) {
+        generatedAudioMs = elapsedRealTimeMs;
+      }
+    }
+  }
+
+  void _fillAudioBuffer(Float32List buffer, int bufferSize) {
+    double frequency;
+
+    double duty = 0.5;
+
+    if (waveGeneratorConstants.modeSelected == WaveConst.square) {
+      frequency = waveGeneratorConstants
+          .wave[selectedAnalogWave]![WaveConst.frequency]!
+          .toDouble();
+    } else {
+      frequency = waveGeneratorConstants
+          .wave[WaveConst.sqr1]![WaveConst.frequency]!
+          .toDouble();
+
+      int currentDuty =
+          waveGeneratorConstants.wave[selectedDigitalWave]![WaveConst.duty] ??
+              50;
+
+      duty = currentDuty / 100.0;
+    }
+
+    if (frequency <= 0) frequency = 1;
+
+    double increment = (2 * math.pi * frequency) / 44100.0;
+
+    const double volume = 0.15;
+
+    for (int i = 0; i < bufferSize; i++) {
+      if (waveGeneratorConstants.modeSelected == WaveConst.pwm) {
+        buffer[i] = (_audioAngle < (2 * math.pi * duty)) ? volume : -volume;
+      } else {
+        double safeSin = math.sin(_audioAngle).clamp(-1.0, 1.0);
+
+        double sample = safeSin;
+
+        if (waveGeneratorConstants
+                .wave[selectedAnalogWave]![WaveConst.waveType] ==
+            triangular) {
+          sample = (2 / math.pi) * math.asin(safeSin);
+        }
+
+        buffer[i] = sample * volume;
+      }
+
+      _audioAngle += increment;
+
+      if (_audioAngle >= 2 * math.pi) {
+        _audioAngle -= 2 * math.pi;
+      }
+    }
+  }
+
+  void _stopAudioStream() {
+    if (_audioStream != null) {
+      _audioStream!.uninit();
+
+      _audioStream = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _stopAudioStream();
+
+    super.dispose();
   }
 
   Future<void> _getCurrentLocation() async {

--- a/lib/providers/wave_generator_state_provider.dart
+++ b/lib/providers/wave_generator_state_provider.dart
@@ -227,7 +227,7 @@ class WaveGeneratorStateProvider extends ChangeNotifier {
   @override
   void dispose() {
     _stopAudioStream();
-
+    isPlayingSound = false;
     super.dispose();
   }
 

--- a/lib/view/wave_generator_screen.dart
+++ b/lib/view/wave_generator_screen.dart
@@ -269,21 +269,30 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
                                   Expanded(
                                     child: TextButton(
                                       style: TextButton.styleFrom(
-                                        backgroundColor: primaryRed,
+                                        backgroundColor: provider.isPlayingSound
+                                            ? Colors.grey[800]
+                                            : primaryRed,
                                         shape: RoundedRectangleBorder(
                                           borderRadius:
                                               BorderRadius.circular(6),
                                         ),
                                       ),
                                       child: Text(
-                                        appLocalizations.produceSound,
+                                        provider.isPlayingSound
+                                            ? appLocalizations.stopSound
+                                            : appLocalizations.produceSound,
                                         textAlign: TextAlign.center,
                                         style: TextStyle(
                                           color: Colors.white,
                                           fontSize: 14,
+                                          fontWeight: provider.isPlayingSound
+                                              ? FontWeight.bold
+                                              : FontWeight.normal,
                                         ),
                                       ),
-                                      onPressed: () => {},
+                                      onPressed: () {
+                                        provider.toggleSound();
+                                      },
                                     ),
                                   ),
                                   const SizedBox(width: 4),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -73,6 +73,7 @@ dependencies:
   image: ^4.1.3
   serial: ^0.0.7+1
   web: ^1.1.1
+  mp_audio_stream: ^0.2.2
 dependency_overrides:
   ffi: ^2.1.3
 


### PR DESCRIPTION
Fixes #3101

## Changes
Previously, the **"Produce Sound"** feature was missing from the Wave Generator. It has now been implemented using  `mp_audio_stream` package . The following functions were added in `wave_generator_state_provider.dart` to handle audio generation.

### Functions

**toggleSound()**  
Controls the audio playback state. It updates the `isPlayingSound` flag.

**_startAudioStream()**  
Initializes the audio using an `AudioStream` .

**_fillAudioBuffer()**  
Generates the waveform samples. It calculates the amplitude for each of the samples based on frequency and duty cycle, using trigonometric calculations for Sine and Triangular waves and conditional logic (High& Low) for PWM.

**_stopAudioStream() & dispose()**  
Handles cleanup. `_stopAudioStream` shuts down the audio hardware, while `dispose` ensures audio stops immediately if the user leaves the screen, preventing memory leaks and unnecessary battery usage.

### UI Update
The `wave_generator_screen.dart` file was also updated because the `onPressed` method for the **Produce Sound** button was missing. It has now been connected to the audio functionality.

## Screenshots / Recordings

https://github.com/user-attachments/assets/29d34f32-90b9-4922-921c-5c31d08ef56f


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add audio playback support to the Wave Generator so it can produce and stop sound based on the configured waveform.

New Features:
- Introduce audio streaming in the wave generator using mp_audio_stream to synthesize sound from the selected waveform, frequency, and duty cycle.
- Expose a toggleSound control in the WaveGeneratorStateProvider to start and stop audio output and track playback state.
- Update the Wave Generator UI button to control sound playback and reflect playing state with dynamic label and styling.

Enhancements:
- Add localized "Stop Sound" string across all supported languages for the updated Wave Generator control.

Build:
- Declare mp_audio_stream as a new dependency in pubspec.yaml.