### PR TITLE
ci: ignore markdown files from triggering CI builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,8 @@ name: Build
 on:
   pull_request:
     branches: ["flutter"]
-
+    paths-ignore:
+      - '**.md'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,15 @@ on:
     branches: ["flutter"]
     paths-ignore:
       - '**.md'
+      - 'docs/**'
+      - '**.png'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.gif'
+      - '**.svg'
+      - '**.webp'
+      - '**.txt'
+      - '**.arb'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -2,7 +2,9 @@ name: Push
 
 on:
   push:
-    branches: [ "flutter" ]
+    branches: ["flutter"]
+    paths-ignore:
+      - '**.md'
 
 env:
   ANDROID_EMULATOR_API: 34

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -5,6 +5,15 @@ on:
     branches: ["flutter"]
     paths-ignore:
       - '**.md'
+      - 'docs/**'
+      - '**.png'
+      - '**.jpg'
+      - '**.jpeg'
+      - '**.gif'
+      - '**.svg'
+      - '**.webp'
+      - '**.txt'
+      - '**.arb'
 
 env:
   ANDROID_EMULATOR_API: 34


### PR DESCRIPTION
Fixes #3122

CI workflows were triggering even when only markdown (.md) files were modified.

This PR updates the workflow triggers in:
- .github/workflows/pull-request.yml
- .github/workflows/push-event.yml

by adding `paths-ignore` for markdown files.

This prevents unnecessary CI runs when only documentation files are changed.

## Summary by Sourcery

Update CI workflows to skip running on commits that only change markdown files.

CI:
- Configure push workflow to ignore changes limited to markdown files.
- Configure pull request workflow to ignore changes limited to markdown files.