### PR TITLE
Fix dependabot target branch (#3124)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
                         reviewers:
                               - "mariobehling"
                                     - "cloudypadmal"
-                                  - package-ecosystem: "gradle"
-                                      target-branch: "development"
-                                          directory: "/"
-                                              schedule:
-                                                    interval: "weekly"
+                                      - package-ecosystem: "gradle"
+                                          target-branch: "development"
+                                              directory: "/"
+                                                  schedule:
+                                                        interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
                         reviewers:
                               - "mariobehling"
                                     - "cloudypadmal"
-                                      - package-ecosystem: "gradle"
-                                          target-branch: "development"
-                                              directory: "/"
-                                                  schedule:
-                                                        interval: "weekly"
+                                  - package-ecosystem: "gradle"
+                                      target-branch: "development"
+                                          directory: "/"
+                                              schedule:
+                                                    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,15 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - "mariobehling"
-      - "cloudypadmal"
-
-  - package-ecosystem: "gradle"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - "mariobehling"
-      - "cloudypadmal"
+      target-branch: "development"
+          directory: "/"
+              schedule:
+                    interval: "weekly"
+                        reviewers:
+                              - "mariobehling"
+                                    - "cloudypadmal"
+                                      - package-ecosystem: "gradle"
+                                          target-branch: "development"
+                                              directory: "/"
+                                                  schedule:
+                                                        interval: "weekly"


### PR DESCRIPTION
Fixes #3124.
Fixes Dependabot failing to run on the active development branch by explicitly targeting `development`. 
## Summary by Sourcery

CI:
- Configure Dependabot to open dependency update PRs against the `development` branch for GitHub Actions and Gradle projects.