### PR TITLE
fix: count pulse returns 0

### DIFF
--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -842,30 +842,6 @@ class ScienceLab {
     return null;
   }
 
-  Future<void> countPulses(String? channel) async {
-    channel ??= 'RES';
-    try {
-      mPacketHandler.sendByte(mCommandsProto.common);
-      mPacketHandler.sendByte(mCommandsProto.startCounting);
-      mPacketHandler.sendByte(calculateDigitalChannel(channel)!);
-      await mPacketHandler.getAcknowledgement();
-    } catch (e) {
-      logger.e("Error in countPulses: $e");
-    }
-  }
-
-  Future<int> readPulseCount() async {
-    try {
-      mPacketHandler.sendByte(mCommandsProto.common);
-      mPacketHandler.sendByte(mCommandsProto.fetchCount);
-      int count = await mPacketHandler.getVoltageSummation();
-      return 10 * count;
-    } catch (e) {
-      logger.e("Error in readPulseCount: $e");
-    }
-    return -1;
-  }
-
   int calcCHOSA(String channelName) {
     channelName = channelName.toUpperCase();
     AnalogInputSource? source = analogInputSources[channelName];

--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -33,7 +33,7 @@ class MultimeterStateProvider extends ChangeNotifier {
   late bool _isRecording;
   bool get isRecording => _isRecording;
   List<List<dynamic>> _recordedData = [];
-
+  int _currentPulseCount = 0;
   Position? currentPosition;
   StreamSubscription? _locationStream;
 
@@ -112,11 +112,15 @@ class MultimeterStateProvider extends ChangeNotifier {
 
   void setSelectedIndex(int index) {
     _selectedIndex = index;
+    _currentPulseCount = 0;
     notifyListeners();
   }
 
   void setSwitch(bool checked) {
     isSwitchChecked = checked;
+    if (isSwitchChecked) {
+      _currentPulseCount = 0;
+    }
     notifyListeners();
   }
 
@@ -242,16 +246,23 @@ class MultimeterStateProvider extends ChangeNotifier {
 
   Future<void> getIDData() async {
     try {
+      String channel = knobMarker[_selectedIndex];
+      double frequency = await _scienceLab.getFrequency(channel);
+
       if (!isSwitchChecked) {
-        double frequency =
-            await _scienceLab.getFrequency(knobMarker[_selectedIndex]);
         value = frequency.toStringAsFixed(2);
         unit = appLocalizations.unitHz;
       } else {
-        await _scienceLab.countPulses(knobMarker[_selectedIndex]);
-        int pulseCount = await _scienceLab.readPulseCount();
-        value = pulseCount.toString();
-        unit = "";
+        double elapsedSeconds = _configProvider!.config.updatePeriod / 1000.0;
+
+        int newPulses = (frequency * elapsedSeconds).round();
+
+        _currentPulseCount += newPulses;
+
+        final formatter = NumberFormat('#,##0');
+        value = formatter.format(_currentPulseCount);
+
+        unit = "Pulses";
       }
     } catch (e) {
       value = "Cannot measure!";

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -326,15 +326,19 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                                     flex: 75,
                                     child: Container(
                                       padding: const EdgeInsets.only(
-                                          right: 10, bottom: 10),
+                                          right: 10, bottom: 10, left: 10),
                                       alignment: Alignment.centerRight,
-                                      child: Text(
-                                        provider.value,
-                                        style: TextStyle(
-                                          fontSize: 50,
-                                          fontStyle: FontStyle.italic,
-                                          fontFamily: 'Digital-7',
-                                          color: multimeterBorderBlack,
+                                      child: FittedBox(
+                                        fit: BoxFit.scaleDown,
+                                        alignment: Alignment.centerRight,
+                                        child: Text(
+                                          provider.value,
+                                          style: TextStyle(
+                                            fontSize: 50,
+                                            fontStyle: FontStyle.italic,
+                                            fontFamily: 'Digital-7',
+                                            color: multimeterBorderBlack,
+                                          ),
                                         ),
                                       ),
                                     ),


### PR DESCRIPTION
Fixes #3102 

## Changes

The app previously used deprecated firmware commands (`START_COUNTING`, `FETCH_COUNT`), which are no longer supported.  
As a result, the PSLab device ignored these commands and the UI always displayed `0` pulses.

This fix replaces the old approach by estimating the pulse count using the `getFrequency` method and accumulating pulses over time.

By calculating `frequency × user-configured period`, we maintain an accurate running pulse count without relying on removed firmware commands.

Large pulse counts were difficult to read and could overflow the layout.  
Comma formatting using `NumberFormat('#,##0')` improves readability of large numbers.  
Additionally, `BoxFit.scaleDown` with `FittedBox` ensures the pulse count text size automatically scales down if overflow happens, preventing UI overflow or layout errors.

## Screenshots / Recordings

https://github.com/user-attachments/assets/9175596a-5f9e-4790-9b3b-cc9c17f7d7b4



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Estimate and display pulse counts in the multimeter using frequency measurements instead of deprecated firmware pulse-count commands, improving readability and preventing UI overflow for large values.

New Features:
- Accumulate pulse counts in the multimeter by deriving pulses from measured frequency over the configured update period instead of relying on device pulse-count commands.

Enhancements:
- Reset the running pulse count when the selected channel changes or the pulse-counting switch is toggled to ensure accurate readings.
- Format large pulse counts with thousands separators and wrap the value text in a scaling layout to keep the multimeter display readable and avoid overflow.