### PR TITLE
fix: correct pulse count parsing using getInt instead of getVoltageSummation

### DIFF
--- a/lib/communication/science_lab.dart
+++ b/lib/communication/science_lab.dart
@@ -858,8 +858,9 @@ class ScienceLab {
     try {
       mPacketHandler.sendByte(mCommandsProto.common);
       mPacketHandler.sendByte(mCommandsProto.fetchCount);
-      int count = await mPacketHandler.getVoltageSummation();
-      return 10 * count;
+
+      int count = await mPacketHandler.getInt();
+      return count;
     } catch (e) {
       logger.e("Error in readPulseCount: $e");
     }


### PR DESCRIPTION
Fixes #3102

## Problem
Pulse count mode in the multimeter always returns `0`, even when valid input signals are present.

## Root Cause
The response from the `fetchCount` command was being parsed using `getVoltageSummation()`, which is intended for ADC/voltage data and reads a 3-byte response.

Pulse count is a raw integer value, so using a voltage-specific parser leads to incorrect decoding and results in constant zero values.

## Fix
Replaced the parsing method:
- `getVoltageSummation()` → incorrect for this use case
- `getInt()` → correct raw integer parser

## Changes
- Updated `readPulseCount()` in `science_lab.dart` to use `getInt()`

## Notes
- No UI changes
- Hardware-dependent behavior cannot be fully tested in web mode

## Checklist
- [x] No hard coding
- [x] No end of file edits
- [x] Code formatted using `dart format`
- [x] Code passes `flutter analyze`

## Summary by Sourcery

Bug Fixes:
- Correct pulse count parsing in readPulseCount() so that valid hardware pulse inputs are reported instead of always returning zero.