### PR TITLE
docs: fix Oscilloscope image source in documentation

### DIFF
--- a/docs/Oscilloscope.md
+++ b/docs/Oscilloscope.md
@@ -22,7 +22,7 @@ The layout of the oscilloscope graphical user interface contains three main part
 
 <table>
     <tr>
-        <td><img src="/docs/images/instrument_oscilloscope_channelparam.png"></td>
+        <td><img src="/docs/images/instrument_oscilloscope_channel_params.png"></td>
         <td><img src="/docs/images/instrument_oscilloscope_dataanalysis.png"></td>
     </tr>
 </table>

--- a/docs/Oscilloscope.md
+++ b/docs/Oscilloscope.md
@@ -22,7 +22,7 @@ The layout of the oscilloscope graphical user interface contains three main part
 
 <table>
     <tr>
-        <td><img src="/docs/images/instrument_oscilloscope_channel_params.png"></td>
+        <td><img src="/docs/images/oscilloscope_channel_params.png"></td>
         <td><img src="/docs/images/instrument_oscilloscope_dataanalysis.png"></td>
     </tr>
 </table>


### PR DESCRIPTION
Change instrument_oscilloscope_channelparam to oscilloscope_channel_params.png to fix the broken image link.

## Summary by Sourcery

Documentation:
- Fix broken oscilloscope channel parameters image link in the documentation.