### PR TITLE
fix: add snackbar for empty logged data

### DIFF
--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -113,7 +113,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
         ),
       );
       return;
-  }
+    }
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) {

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -103,7 +103,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
 
   Future<void> _deleteAllFiles() async {
     if (_isLoading) {
-       return; 
+      return; 
     }
     if (_files.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -103,7 +103,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
 
   Future<void> _deleteAllFiles() async {
     if (_isLoading) {
-      return; 
+      return;
     }
     if (_files.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -102,6 +102,18 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
   }
 
   Future<void> _deleteAllFiles() async {
+    if (_files.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            appLocalizations.noLoggedData,
+            style: TextStyle(color: snackBarContentColor),
+          ),
+          backgroundColor: snackBarBackgroundColor,
+        ),
+      );
+      return;
+   }
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) {

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -103,7 +103,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
 
   Future<void> _deleteAllFiles() async {
     if (_isLoading) {
-      return;
+      return;
     }
     if (_files.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -113,7 +113,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
         ),
       );
       return;
-   }
+  }
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) {

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -103,9 +103,8 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
 
   Future<void> _deleteAllFiles() async {
     if (_isLoading) {
-      return; 
+       return; 
     }
-    
     if (_files.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -102,6 +102,10 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
   }
 
   Future<void> _deleteAllFiles() async {
+    if (_isLoading) {
+      return; 
+    }
+    
     if (_files.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(


### PR DESCRIPTION
**What does this PR do?**
This PR updates the _deleteAllFiles() function in logged_data_screen.dart.

**Why is this change needed?**
Previously, if the user clicked "Delete All Files" when the list was empty, it would still show the delete confirmation dialog. 
This update adds a check so that if _files.isEmpty is true, it shows a Snackbar.

## Summary by Sourcery

Handle attempts to delete logged data when no files are present by providing user feedback instead of showing a confirmation dialog.

Bug Fixes:
- Prevent the delete-all confirmation dialog from appearing when there are no logged data files to delete.

Enhancements:
- Show a localized snackbar message to inform the user when there is no logged data to delete.