### PR TITLE
fix: In-built Mic ftt crash

### DIFF
--- a/lib/others/audio_jack.dart
+++ b/lib/others/audio_jack.dart
@@ -5,11 +5,13 @@ import 'package:pslab/others/logger_service.dart';
 
 class AudioJack {
   static const int samplingRate = 44100;
+  static const int maxBufferSize = 1024;
+
   bool _isListening = false;
 
   AudioRecorder? _recorder;
   StreamSubscription<Uint8List>? _streamSubscription;
-  List<double> _audioBuffer = [];
+  final List<double> _audioBuffer = [];
 
   AudioJack();
 
@@ -51,7 +53,10 @@ class AudioJack {
       final sample = byteData.getInt16(i, Endian.little);
       tempBuffer.add(sample / 32768.0);
     }
-    _audioBuffer = tempBuffer;
+    _audioBuffer.addAll(tempBuffer);
+    if (_audioBuffer.length > maxBufferSize) {
+      _audioBuffer.removeRange(0, _audioBuffer.length - maxBufferSize);
+    }
   }
 
   void _onError(Object e) {
@@ -60,7 +65,7 @@ class AudioJack {
   }
 
   List<double> read() {
-    return _audioBuffer;
+    return List.from(_audioBuffer);
   }
 
   Future<void> close() async {
@@ -73,6 +78,7 @@ class AudioJack {
       await _recorder!.dispose();
       _recorder = null;
     }
+    _audioBuffer.clear();
   }
 
   Future<void> disposeHardware() async {

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -530,6 +530,9 @@ class OscilloscopeStateProvider extends ChangeNotifier {
         isTriggered = false;
         entries.add([]);
         List<double> buffer = _audioJack.read();
+
+        if (buffer.isEmpty) return;
+
         xDataString = List.filled(buffer.length, '');
         yDataString.add(List.filled(buffer.length, ''));
         int n = buffer.length;
@@ -541,7 +544,8 @@ class OscilloscopeStateProvider extends ChangeNotifier {
 
         List<Complex> fftOut = [];
         if (isFourierTransformSelected) {
-          List<Complex> yComplex = List.filled(buffer.length, const Complex(0));
+          List<Complex> yComplex =
+              List.filled(buffer.length, const Complex(0), growable: true);
           for (int j = 0; j < buffer.length; j++) {
             yComplex[j] = Complex(buffer[j] * 3);
           }
@@ -594,8 +598,8 @@ class OscilloscopeStateProvider extends ChangeNotifier {
           }
         }
 
-        for (int i = micStartIndex; i < n; i++) {
-          double audioValue = buffer[i] * 3;
+        for (int i = micStartIndex; i < n; i += 4) {
+          double audioValue = buffer[i] * 20;
 
           if (!isFourierTransformSelected) {
             entries.last.add(FlSpot(
@@ -605,7 +609,11 @@ class OscilloscopeStateProvider extends ChangeNotifier {
             if (i < n / 2) {
               double y = fftOut[i].abs() / samples;
               if (y > mA) mA = y;
-              entries.last.add(FlSpot((i / factor), y));
+
+              double frequency = i / factor;
+              entries.last.add(FlSpot(frequency, 0));
+              entries.last.add(FlSpot(frequency, y));
+              entries.last.add(FlSpot(frequency, 0));
             }
           }
           yDataString.last[i] = audioValue.toString();
@@ -683,11 +691,10 @@ class OscilloscopeStateProvider extends ChangeNotifier {
       }
 
       if (isFourierTransformSelected) {
-        oscilloscopeAxesScale.setYAxisScaleMax(_maxAmp);
+        oscilloscopeAxesScale.setYAxisScaleMax((_maxAmp > 0) ? _maxAmp : 1.0);
         oscilloscopeAxesScale.setYAxisScaleMin(0);
         oscilloscopeAxesScale.setXAxisScale(_maxFreq * 1000);
       }
-
       notifyListeners();
     } catch (e) {
       logger.e(e);

--- a/lib/view/widgets/oscilloscope_graph.dart
+++ b/lib/view/widgets/oscilloscope_graph.dart
@@ -63,11 +63,11 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                   show: true,
                   topTitles: AxisTitles(
                     axisNameWidget: Text(
-                      oscilloscopeStateProvider
-                                  .oscilloscopeAxesScale.xAxisScale ==
-                              875
-                          ? 'Time (\u00b5s)'
-                          : 'Time (ms)',
+                      provider.isFourierTransformSelected
+                          ? 'Frequency (Hz)'
+                          : (provider.oscilloscopeAxesScale.xAxisScale == 875
+                              ? 'Time (\u00b5s)'
+                              : 'Time (ms)'),
                       style: TextStyle(
                         fontSize: 10,
                         color: chartTextColor,
@@ -87,7 +87,9 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                       sideTitles: SideTitles(showTitles: false)),
                   leftTitles: AxisTitles(
                     axisNameWidget: Text(
-                      'CH1 (V)',
+                      provider.isFourierTransformSelected
+                          ? 'Magnitude (V)'
+                          : 'CH1 (V)',
                       style: TextStyle(
                         fontSize: 10,
                         color: chartTextColor,
@@ -104,7 +106,9 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
                   ),
                   rightTitles: AxisTitles(
                     axisNameWidget: Text(
-                      'CH2 (V)',
+                      provider.isFourierTransformSelected
+                          ? 'Magnitude (V)'
+                          : 'CH2 (V)',
                       style: TextStyle(
                         fontSize: 10,
                         color: chartTextColor,


### PR DESCRIPTION
Fixes #3163


## PR Description

This PR fixes crashes and improves the oscilloscope visualization when using the built-in microphone.

### Changes
- Fixed FFT crash that previously occurred because the audio buffer size was not guaranteed to be a **power of 2**. The buffer is now fixed to **1024**, preventing the FFT from crashing.
-  Increased the microphone gain multiplier from **3x to 20x** (`buffer[i] * 20`). Previously, the multiplier was too low, requiring very loud input to display a waveform. This change makes the signal clearly visible at normal speaking volumes.
- Corrected **axis labels for FFT mode**, which were previously inaccurate.

### Files Updated
- `lib/others/audio_jack.dart`
- `lib/providers/oscilloscope_state_provider.dart`
- `lib/view/widgets/oscilloscope_graph.dart`

## Screenshots / Recordings

https://github.com/user-attachments/assets/e8eb6ed5-99fa-45d8-b076-759566f9cc2b



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Resolve crashes and improve FFT-based oscilloscope visualization for built-in microphone input.

Bug Fixes:
- Prevent FFT processing from running on empty audio buffers and crashing.
- Limit and manage the internal audio buffer size to avoid non–power-of-two input causing FFT failures.
- Ensure a valid nonzero FFT Y-axis max value is always applied to avoid rendering issues.

Enhancements:
- Increase microphone signal gain and downsample plotted points to make built-in mic waveforms clearly visible at normal volumes while reducing plotting load.
- Render FFT output as vertical magnitude lines per frequency bin for a clearer spectrum view.
- Update oscilloscope axis labels to show frequency/magnitude when FFT mode is selected.