### PR TITLE
chore: ignore non-code files from triggering builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,17 +3,7 @@ name: Build
 on:
   pull_request:
     branches: ["flutter"]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '**.png'
-      - '**.jpg'
-      - '**.jpeg'
-      - '**.gif'
-      - '**.svg'
-      - '**.webp'
-      - '**.txt'
-      - '**.arb'
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,138 +15,229 @@ env:
   IPAD_DEVICE_MODEL: iPad Pro 13-inch (M4)
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      is_code: ${{ steps.check.outputs.is_code }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - id: check
+        run: |
+          # Diff the actual commit SHAs. 
+          # grep -vE removes your media/doc extensions. grep -v removes the docs folder.
+          # If anything is left over, it's code. If the output is empty, it's just docs.
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -vE '\.(md|png|jpg|jpeg|gif|svg|webp|txt|arb)$' | grep -v '^docs/'; then
+            echo "is_code=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_code=false" >> $GITHUB_OUTPUT
+          fi
+
   common:
     name: Common Build
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: Common Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/common
 
       - name: Save PR number
+        if: needs.changes.outputs.is_code == 'true'
         run: |
           mkdir -p ./pr
           echo ${{ github.event.number }} > ./pr/NR
 
       - uses: actions/upload-artifact@v7
+        if: needs.changes.outputs.is_code == 'true'
         with:
           name: pr
           path: pr/
 
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
+
   android:
     name: Android Flutter Build
-    needs: common
+    needs: [changes, common]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: Android Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/android
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
 
   ios:
     name: iOS Flutter Build
-    needs: common
-    runs-on: macos-latest
+    needs: [changes, common]
+    runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     steps:
       - name: Set up Xcode
+        if: needs.changes.outputs.is_code == 'true'
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
           xcode-version: '16.4.0'
-          
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: iOS Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/ios
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
 
   screenshots-android:
     name: Screenshots (Android)
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: Android Screenshot Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/screenshot-android
         with:
           ANDROID_EMULATOR_API: ${{ env.ANDROID_EMULATOR_API }}
           ANDROID_EMULATOR_ARCH: ${{ env.ANDROID_EMULATOR_ARCH }}
 
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
+
   screenshots-iphone:
     name: Screenshots (iPhone)
-    runs-on: macos-latest
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - name: Set up Xcode
+        if: needs.changes.outputs.is_code == 'true'
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
           xcode-version: '16.4.0'
 
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: iPhone Screenshot Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/screenshot-iphone
         with:
           IPHONE_DEVICE_MODEL: ${{ env.IPHONE_DEVICE_MODEL }}
-  
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
+
   screenshots-ipad:
     name: Screenshots (iPad)
-    runs-on: macos-latest
+    needs: changes
+    runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - name: Set up Xcode
+        if: needs.changes.outputs.is_code == 'true'
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
           xcode-version: '16.4.0'
 
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: iPad Screenshot Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/screenshot-ipad
         with:
           IPAD_DEVICE_MODEL: ${{ env.IPAD_DEVICE_MODEL }}
-  
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
+
   windows:
     name: Windows Flutter Build
-    needs: common
-    runs-on: windows-latest
+    needs: [changes, common]
+    runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'windows-latest' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: Windows Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/windows
-  
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
+
   linux:
     name: Linux Flutter Build
-    needs: common
+    needs: [changes, common]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: Linux Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/linux
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
 
   linux-arm64:
     name: Linux ARM64 Flutter Build
-    needs: common
-    runs-on: ubuntu-24.04-arm
+    needs: [changes, common]
+    runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: Linux ARM64 Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/linux-arm64
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
 
   macos:
     name: macOS Flutter Build
-    needs: common
-    runs-on: macos-latest
+    needs: [changes, common]
+    runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     steps:
       - name: Set up Xcode
+        if: needs.changes.outputs.is_code == 'true'
         uses: maxim-lobanov/setup-xcode@v1.7.0
         with:
           xcode-version: '16.4.0'
 
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
 
       - name: macOS Workflow
+        if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/macos
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."


### PR DESCRIPTION
Fixes #3168

## Changes
Previously, `paths-ignore` was used to skip CI builds for documentation and media files.  
Since Android and iOS builds are marked as **required checks**, skipping these jobs meant no status was reported, which blocked the **Merge** button even for documentation-only PRs.

### Solution
Added a **Detect Changes** gatekeeper job that checks the PR diff.  
Instead of skipping the workflow, heavy build/test steps are skipped for non-code changes while still reporting successful CI checks.

## How It Works

### Detect Changes Logic
The **Detect Changes** job determines whether a PR contains code changes or only documentation/media files.

1. **Git Diff Check**
   - Runs `git diff --name-only` between the PR **base SHA** and **head SHA**.
   - This checks the **entire PR change**, even if it contains multiple commits.

2. **Filtering Non-Code Files**
   The file list is filtered using `grep`:
   - **Extension filter:** removes files like `.md`, `.png`, `.jpg`, `.svg`, `.txt`, `.arb`
   - **Path filter:** removes files inside the `docs/` directory

3. **Decision**
   - If files remain → `is_code = true` (code changes detected)
   - If nothing remains → `is_code = false` (documentation/media only)

---

### CI Workflow Behavior

- **Doc-only changes**
  - Build and test steps are skipped
  - CI finishes in a few seconds

- **Code changes**
  - Full CI pipeline runs

- **Mixed changes**
  - Full CI pipeline runs

---
## Result

I tested the changes in my fork: https://github.com/rahul31124/pslab-android/pull/35

The CI workflow runs successfully and required checks are reported correctly.  
Documentation-only changes now skip heavy build steps while still completing the required CI jobs.

As a result, PR #3150 can now be merged.

## Screenshots / Recordings
 N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Introduce a change-detection gate in the pull request workflow so required CI jobs always report status while heavy build steps are skipped for non-code changes.

Build:
- Replace pull_request paths-ignore filters with a Detect Changes job that classifies PRs as code vs non-code changes and exposes this via a workflow output.

CI:
- Condition all platform build and screenshot jobs on the Detect Changes result so code changes run full builds while documentation/media-only PRs complete quickly with lightweight no-op steps.