### PR TITLE
fix: Reset _currentLux to 0 on sensor change

### DIFF
--- a/lib/providers/luxmeter_state_provider.dart
+++ b/lib/providers/luxmeter_state_provider.dart
@@ -468,6 +468,7 @@ class LuxMeterStateProvider extends ChangeNotifier {
     _luxMin = 0;
     _luxMax = 0;
     _currentTime = 0;
+    _currentLux = 0;
     _startTime = DateTime.now().millisecondsSinceEpoch / 1000.0;
     notifyListeners();
   }


### PR DESCRIPTION
Fixes #3184

Ensures the Lux Meter gauge resets instantly when switching between active sensors instead of incorrectly displaying the previous sensor's value.

## Summary by Sourcery

Bug Fixes:
- Clear the current lux reading when changing the active sensor to prevent showing stale values on the gauge.