### PR TITLE
fix: replace filename truncation with user warning

### DIFF
--- a/lib/view/accelerometer_screen.dart
+++ b/lib/view/accelerometer_screen.dart
@@ -184,6 +184,7 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
         return AlertDialog(
           title: Text(appLocalizations.saveRecording),
           content: TextField(
+            maxLength: 200,
             controller: filenameController,
             decoration: InputDecoration(
               hintText: appLocalizations.enterFileName,
@@ -193,11 +194,22 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
+              child: Text(appLocalizations.cancel),
             ),
             ElevatedButton(
               onPressed: () {
-                Navigator.pop(context, filenameController.text);
+                final text = filenameController.text.trim();
+                if (text.length > 200) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'File name must be less than 200 characters.',
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                Navigator.pop(context, text);
               },
               child: Text(appLocalizations.save),
             ),

--- a/lib/view/gyroscope_screen.dart
+++ b/lib/view/gyroscope_screen.dart
@@ -175,6 +175,7 @@ class _GyroscopeScreenState extends State<GyroscopeScreen> {
         return AlertDialog(
           title: Text(appLocalizations.saveRecording),
           content: TextField(
+            maxLength: 200,
             controller: filenameController,
             decoration: InputDecoration(
               hintText: appLocalizations.enterFileName,
@@ -184,11 +185,22 @@ class _GyroscopeScreenState extends State<GyroscopeScreen> {
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
+              child: Text(appLocalizations.cancel),
             ),
             ElevatedButton(
               onPressed: () {
-                Navigator.pop(context, filenameController.text);
+                final text = filenameController.text.trim();
+                if (text.length > 200) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'File name must be less than 200 characters.',
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                Navigator.pop(context, text);
               },
               child: Text(appLocalizations.save),
             ),

--- a/lib/view/luxmeter_screen.dart
+++ b/lib/view/luxmeter_screen.dart
@@ -160,6 +160,7 @@ class _LuxMeterScreenState extends State<LuxMeterScreen> {
         return AlertDialog(
           title: Text(appLocalizations.saveRecording),
           content: TextField(
+            maxLength: 200,
             controller: filenameController,
             decoration: InputDecoration(
               hintText: appLocalizations.enterFileName,
@@ -169,11 +170,22 @@ class _LuxMeterScreenState extends State<LuxMeterScreen> {
           actions: [
             TextButton(
               onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
+              child: Text(appLocalizations.cancel),
             ),
             ElevatedButton(
               onPressed: () {
-                Navigator.pop(context, filenameController.text);
+                final text = filenameController.text.trim();
+                if (text.length > 200) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'File name must be less than 200 characters.',
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                Navigator.pop(context, text);
               },
               child: Text(appLocalizations.save),
             ),

--- a/lib/view/soundmeter_screen.dart
+++ b/lib/view/soundmeter_screen.dart
@@ -147,6 +147,7 @@ class _SoundMeterScreenState extends State<SoundMeterScreen> {
         return AlertDialog(
           title: Text(appLocalizations.saveRecording),
           content: TextField(
+            maxLength: 200,
             controller: filenameController,
             decoration: InputDecoration(
               hintText: appLocalizations.enterFileName,
@@ -160,14 +161,23 @@ class _SoundMeterScreenState extends State<SoundMeterScreen> {
             ),
             ElevatedButton(
               onPressed: () {
-                Navigator.pop(context, filenameController.text);
+                final text = filenameController.text.trim();
+                if (text.length > 200) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'File name must be less than 200 characters.',
+                      ),
+                    ),
+                  );
+                  return;
+                }
+                Navigator.pop(context, text);
               },
               child: Text(appLocalizations.save),
             ),
           ],
         );
-      },
-    );
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/soundmeter_screen.dart
+++ b/lib/view/soundmeter_screen.dart
@@ -178,6 +178,8 @@ class _SoundMeterScreenState extends State<SoundMeterScreen> {
             ),
           ],
         );
+      },
+    );
 
     if (fileName != null) {
       _csvService.writeMetaData(


### PR DESCRIPTION
Added validation to prevent users from saving filenames longer than 200 characters and surfacing a warning via Snackbar instead of silently truncating the input.

## Summary by Sourcery

Bug Fixes:
- Prevent filenames longer than 200 characters from being saved by validating input before closing the dialog.