### PR TITLE
fix: microphone permission for MacOS

### DIFF
--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/oscilloscope_state_provider.dart';
+import 'package:flutter_macos_permissions/flutter_macos_permissions.dart';
 
 import '../../theme/colors.dart';
 
@@ -249,7 +252,11 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
                       onChanged: (bool? value) async {
-                        await Permission.microphone.request();
+                        if (Platform.isMacOS) {
+                          await FlutterMacosPermissions.requestMicrophone();
+                        }else{
+                          await Permission.microphone.request();
+                        }
                         setState(
                           () {
                             if (value == null) {

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.location</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -30,5 +30,7 @@
 	<string>NSApplication</string>
 	<key>NSLocationUsageDescription</key>
 	<string>This app needs access to location.</string>
+	<key>NSMicrophoneUsageDescription</key>
+    <string>Some message to describe why you need this permission</string>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -31,6 +31,6 @@
 	<key>NSLocationUsageDescription</key>
 	<string>This app needs access to location.</string>
 	<key>NSMicrophoneUsageDescription</key>
-    <string>Some message to describe why you need this permission</string>
+	<string>This app uses the microphone to capture and analyze audio for oscilloscope and recording features.</string>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.location</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,7 @@ dependencies:
   serial: ^0.0.7+1
   web: ^1.1.1
   mp_audio_stream: ^0.2.2
+  flutter_macos_permissions: ^2.0.8
 dependency_overrides:
   ffi: ^2.1.3
 


### PR DESCRIPTION
Fixes #3181

## Changes
I added MacOS exception for microphone. To do that I import a new library : [flutter_macos_permissions](https://pub.dev/packages/flutter_macos_permissions), under licence GPL-3.0

I also added microphone permission in Configs file in macos -> Runner folder

I didn't find any other permission requests
## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [ ] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add macOS-specific handling for requesting microphone permissions when selecting the in-built microphone and declare the corresponding macOS permission usage metadata.

New Features:
- Introduce macOS microphone permission request using the flutter_macos_permissions package.

Enhancements:
- Update the channel parameters widget to conditionally request microphone permissions differently on macOS versus other platforms.

Build:
- Add flutter_macos_permissions dependency and configure macOS Info.plist with microphone usage description.