### PR TITLE
fix: microphone permission for MacOS

### DIFF
--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
@@ -249,7 +251,9 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
                       onChanged: (bool? value) async {
-                        await Permission.microphone.request();
+                        if(!Platform.isMacOS) {
+                          await Permission.microphone.request();
+                        }
                         setState(
                           () {
                             if (value == null) {

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
@@ -251,7 +252,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
                       onChanged: (bool? value) async {
-                        if (!Platform.isMacOS) {
+                        if (!kIsWeb && !Platform.isMacOS) {
                           await Permission.microphone.request();
                         }
                         setState(

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -251,7 +251,7 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
                       onChanged: (bool? value) async {
-                        if(!Platform.isMacOS) {
+                        if (!Platform.isMacOS) {
                           await Permission.microphone.request();
                         }
                         setState(

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -12,5 +12,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.location</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -30,5 +30,7 @@
 	<string>NSApplication</string>
 	<key>NSLocationUsageDescription</key>
 	<string>This app needs access to location.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>This app needs access to microphone for oscilloscope.</string>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.location</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes #3181 

## Changes
Add exclusion for MacOS platform in permission handler because `permission_handler` library doesn't support MacOS. Microphone permissions is already managed by the [record](https://pub.dev/packages/record) library, as marked in documentation.

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [ ] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Handle microphone permission behavior differently on macOS to align with platform support and existing recording library handling.

Bug Fixes:
- Avoid requesting microphone permission via permission_handler on macOS where the plugin is unsupported.

Enhancements:
- Declare macOS microphone usage description in Info.plist for oscilloscope functionality.