### PR TITLE
fix(ui): improve accelerometer screen responsiveness

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -666,5 +666,7 @@
     "pin_res_desc": "Resistance Measurement Pin",
     "stopSound" : "Stop Sound",
     "saw" : "Saw",
-    "comingSoon": "Coming Soon"
+    "comingSoon": "Coming Soon",
+    "startRecording": "Start Recording",
+    "stopRecording": "Stop Recording"
 }

--- a/lib/view/accelerometer_screen.dart
+++ b/lib/view/accelerometer_screen.dart
@@ -250,40 +250,68 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
                   : appLocalizations.accelerometerTitle,
               onGuidePressed: _showInstrumentGuide,
               onOptionsPressed:
-                  provider.isPlayingBack ? null : _showOptionsMenu,
+              provider.isPlayingBack ? null : _showOptionsMenu,
               onRecordPressed: provider.isPlayingBack ? null : _toggleRecording,
               isRecording: provider.isRecording,
               isPlayingBack: provider.isPlayingBack,
               isPlaybackPaused: provider.isPlaybackPaused,
               onPlaybackPauseResume: provider.isPlayingBack
                   ? (provider.isPlaybackPaused
-                      ? _provider.resumePlayback
-                      : _provider.pausePlayback)
+                  ? _provider.resumePlayback
+                  : _provider.pausePlayback)
                   : null,
               onPlaybackStop: provider.isPlayingBack
                   ? () async {
-                      await _provider.stopPlayback();
-                    }
+                await _provider.stopPlayback();
+              }
                   : null,
               body: SafeArea(
-                child: Column(
-                  children: [
-                    Expanded(
-                      child: AccelerometerCard(
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    // Each card needs ~150dp minimum to render its compact
+                    // header + a usable chart. Three cards = ~450dp. If the
+                    // available height falls below that, switch to screen-
+                    // level vertical scrolling with a fixed per-card height
+                    // so nothing overflows. Above the threshold we keep the
+                    // current Expanded layout so cards fill the screen.
+                    const double kPerCardMin = 150.0;
+                    const double kPerCardScrollHeight = 220.0;
+                    final double available = constraints.maxHeight;
+                    final bool needsScroll = available < kPerCardMin * 3;
+
+                    final List<Widget> cards = [
+                      AccelerometerCard(
                           color: xOrientationChartLineColor,
                           axis: appLocalizations.xAxis),
-                    ),
-                    Expanded(
-                      child: AccelerometerCard(
+                      AccelerometerCard(
                           color: yOrientationChartLineColor,
                           axis: appLocalizations.yAxis),
-                    ),
-                    Expanded(
-                      child: AccelerometerCard(
+                      AccelerometerCard(
                           color: zOrientationChartLineColor,
                           axis: appLocalizations.zAxis),
-                    ),
-                  ],
+                    ];
+
+                    if (needsScroll) {
+                      return SingleChildScrollView(
+                        physics: const ClampingScrollPhysics(),
+                        child: Column(
+                          children: [
+                            for (final card in cards)
+                              SizedBox(
+                                height: kPerCardScrollHeight,
+                                child: card,
+                              ),
+                          ],
+                        ),
+                      );
+                    }
+
+                    return Column(
+                      children: [
+                        for (final card in cards) Expanded(child: card),
+                      ],
+                    );
+                  },
                 ),
               ),
             );

--- a/lib/view/accelerometer_screen.dart
+++ b/lib/view/accelerometer_screen.dart
@@ -250,20 +250,20 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
                   : appLocalizations.accelerometerTitle,
               onGuidePressed: _showInstrumentGuide,
               onOptionsPressed:
-              provider.isPlayingBack ? null : _showOptionsMenu,
+                  provider.isPlayingBack ? null : _showOptionsMenu,
               onRecordPressed: provider.isPlayingBack ? null : _toggleRecording,
               isRecording: provider.isRecording,
               isPlayingBack: provider.isPlayingBack,
               isPlaybackPaused: provider.isPlaybackPaused,
               onPlaybackPauseResume: provider.isPlayingBack
                   ? (provider.isPlaybackPaused
-                  ? _provider.resumePlayback
-                  : _provider.pausePlayback)
+                      ? _provider.resumePlayback
+                      : _provider.pausePlayback)
                   : null,
               onPlaybackStop: provider.isPlayingBack
                   ? () async {
-                await _provider.stopPlayback();
-              }
+                      await _provider.stopPlayback();
+                    }
                   : null,
               body: SafeArea(
                 child: LayoutBuilder(

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -331,7 +331,8 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                                     maxLines: 1,
                                     softWrap: false,
                                     style: TextStyle(
-                                      color: cardContentColor.withOpacity(0.8),
+                                      color: cardContentColor.withValues(
+                                          alpha: 0.8),
                                       fontSize: minMaxFontSize,
                                       height: 1.1,
                                     ),
@@ -343,7 +344,8 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                                     maxLines: 1,
                                     softWrap: false,
                                     style: TextStyle(
-                                      color: cardContentColor.withOpacity(0.8),
+                                      color: cardContentColor.withValues(
+                                          alpha: 0.8),
                                       fontSize: minMaxFontSize,
                                       height: 1.1,
                                     ),

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -107,9 +107,9 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   }
 
   Widget _sideTitleWidget(
-      TitleMeta meta, {
-        required double fontSize,
-      }) {
+    TitleMeta meta, {
+    required double fontSize,
+  }) {
     return SideTitleWidget(
       meta: meta,
       child: Text(
@@ -131,7 +131,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required double scale,
   }) {
     final double safeMaxX =
-    dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
+        dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
     final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
     final bool showTopTitle = width >= _kTinyWidth;
@@ -141,19 +141,17 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
 
     final double widthFactor = (width / _kBaselineWidth).clamp(0.55, 1.15);
 
-    final double tickFontSize =
-    (10.0 * scale).clamp(8.0, 10.5).toDouble();
-    final double axisLabelFontSize =
-    (10.5 * scale).clamp(7.5, 11.0).toDouble();
+    final double tickFontSize = (10.0 * scale).clamp(8.0, 10.5).toDouble();
+    final double axisLabelFontSize = (10.5 * scale).clamp(7.5, 11.0).toDouble();
     final double topAxisNameSize =
-    showTopTitle ? (15.0 * scale).clamp(9.0, 17.0).toDouble() : 0.0;
+        showTopTitle ? (15.0 * scale).clamp(9.0, 17.0).toDouble() : 0.0;
     final double leftAxisNameSize =
-    (12.0 * widthFactor).clamp(9.0, 14.0).toDouble();
+        (12.0 * widthFactor).clamp(9.0, 14.0).toDouble();
     final double reservedSize = !showLeftTickLabels
         ? 4.0
         : sparseTicks
-        ? (tickFontSize * 2.0 + 4.0).clamp(16.0, 22.0).toDouble()
-        : (tickFontSize * 2.2 + 4.0).clamp(18.0, 26.0).toDouble();
+            ? (tickFontSize * 2.0 + 4.0).clamp(16.0, 22.0).toDouble()
+            : (tickFontSize * 2.2 + 4.0).clamp(18.0, 26.0).toDouble();
     final double lineBarWidth = (2.0 * scale).clamp(1.0, 2.2);
     final double leftPadding = (1.5 * scale).clamp(0.0, 2.0);
     final double rightPadding = (6.0 * scale).clamp(2.0, 8.0);
@@ -198,16 +196,16 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                 topTitles: AxisTitles(
                   axisNameWidget: showTopTitle
                       ? FittedBox(
-                    fit: BoxFit.scaleDown,
-                    child: Text(
-                      appLocalizations.timeAxisLabel,
-                      style: TextStyle(
-                        fontSize: axisLabelFontSize,
-                        color: chartTextColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  )
+                          fit: BoxFit.scaleDown,
+                          child: Text(
+                            appLocalizations.timeAxisLabel,
+                            style: TextStyle(
+                              fontSize: axisLabelFontSize,
+                              color: chartTextColor,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        )
                       : null,
                   axisNameSize: topAxisNameSize,
                   sideTitles: const SideTitles(showTitles: false),
@@ -261,7 +259,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   @override
   Widget build(BuildContext context) {
     final AccelerometerStateProvider provider =
-    Provider.of<AccelerometerStateProvider>(context);
+        Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
     final double currVal = provider.getCurrent(widget.axis);
@@ -284,15 +282,15 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
 
         final double effectiveHeight = boundedHeight
             ? (constraints.maxHeight - outerVMargin * 2)
-            .clamp(60.0, double.infinity)
-            .toDouble()
+                .clamp(60.0, double.infinity)
+                .toDouble()
             : targetHeight;
         final double heightScale = effectiveHeight / 200.0;
 
         final double scale =
-        (widthScale < heightScale ? widthScale : heightScale)
-            .clamp(0.55, 1.15)
-            .toDouble();
+            (widthScale < heightScale ? widthScale : heightScale)
+                .clamp(0.55, 1.15)
+                .toDouble();
 
         final bool isCompact = width < _kCompactWidth;
         final bool isTiny = width < _kTinyWidth;
@@ -313,30 +311,27 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         double imageSize = isTiny ? 12.0 : (isCompact ? 16.0 : 20.0);
         final double imageGap = isTiny ? 3.0 : (isCompact ? 6.0 : 8.0);
 
-        final double currentFontSize =
-        isTiny ? 9.5 : (isCompact ? 12.0 : 13.5);
-        final double minMaxFontSize =
-        isTiny ? 8.5 : (isCompact ? 11.0 : 12.5);
-        final double currentToMinGap =
-        isTiny ? 3.0 : (isCompact ? 6.0 : 12.0);
+        final double currentFontSize = isTiny ? 9.5 : (isCompact ? 12.0 : 13.5);
+        final double minMaxFontSize = isTiny ? 8.5 : (isCompact ? 11.0 : 12.5);
+        final double currentToMinGap = isTiny ? 3.0 : (isCompact ? 6.0 : 12.0);
         final double minToMaxGap = isTiny ? 4.0 : (isCompact ? 8.0 : 12.0);
 
         final double estimatedHeaderBase =
             rowTopPad + imageSize + rowBottomPad + 1.0;
         final double availableForChart =
-        (effectiveHeight - estimatedHeaderBase).clamp(0.0, effectiveHeight);
+            (effectiveHeight - estimatedHeaderBase).clamp(0.0, effectiveHeight);
 
         double chartMinHeight =
-        (effectiveHeight * 0.55).clamp(80.0, 220.0).toDouble();
+            (effectiveHeight * 0.55).clamp(80.0, 220.0).toDouble();
         if (chartMinHeight > availableForChart) {
           chartMinHeight = availableForChart;
         }
         final double headerBudget =
-        (effectiveHeight - chartMinHeight - 1.0).clamp(28.0, 200.0);
+            (effectiveHeight - chartMinHeight - 1.0).clamp(28.0, 200.0);
         final double estimatedHeader = rowTopPad + imageSize + rowBottomPad;
         if (estimatedHeader > headerBudget) {
           final double shrink =
-          (headerBudget / estimatedHeader).clamp(0.55, 1.0).toDouble();
+              (headerBudget / estimatedHeader).clamp(0.55, 1.0).toDouble();
           rowTopPad = (rowTopPad * shrink).clamp(3.0, rowTopPad).toDouble();
           rowBottomPad =
               (rowBottomPad * shrink).clamp(2.0, rowBottomPad).toDouble();

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -24,10 +24,10 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
   Widget sideTitleWidgets(
-      double value,
-      TitleMeta meta, {
-        required bool compact,
-      }) {
+    double value,
+    TitleMeta meta, {
+    required bool compact,
+  }) {
     return SideTitleWidget(
       meta: meta,
       child: Text(
@@ -52,7 +52,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required bool centered,
   }) {
     final double imageSize =
-    (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
+        (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
 
     final double labelWidth = isNarrow ? 110 : 130;
 
@@ -93,8 +93,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                 width: centered ? null : labelWidth,
                 child: FittedBox(
                   fit: BoxFit.scaleDown,
-                  alignment:
-                  centered ? Alignment.center : Alignment.centerLeft,
+                  alignment: centered ? Alignment.center : Alignment.centerLeft,
                   child: Text(
                     "${appLocalizations.minValue} ${minVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
                     textAlign: centered ? TextAlign.center : TextAlign.left,
@@ -113,8 +112,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                 width: centered ? null : labelWidth,
                 child: FittedBox(
                   fit: BoxFit.scaleDown,
-                  alignment:
-                  centered ? Alignment.center : Alignment.centerLeft,
+                  alignment: centered ? Alignment.center : Alignment.centerLeft,
                   child: Text(
                     "${appLocalizations.maxValue} ${maxVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
                     textAlign: centered ? TextAlign.center : TextAlign.left,
@@ -138,10 +136,9 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required bool isNarrow,
   }) {
     final double safeMaxX =
-    dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
+        dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
 
-    final List<FlSpot> safeSpots =
-    spots.isEmpty ? [const FlSpot(0, 0)] : spots;
+    final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
     return KeyedSubtree(
       key: ValueKey('accelerometer-chart-${widget.axis}-$isNarrow'),
@@ -240,7 +237,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   @override
   Widget build(BuildContext context) {
     final AccelerometerStateProvider provider =
-    Provider.of<AccelerometerStateProvider>(context);
+        Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
     final double currVal = provider.getCurrent(widget.axis);
@@ -287,33 +284,33 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
 
             final Widget content = useVerticalLayout
                 ? Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                SizedBox(
-                  height: 165,
-                  child: infoSection,
-                ),
-                SizedBox(
-                  height: 180,
-                  child: chartSection,
-                ),
-              ],
-            )
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      SizedBox(
+                        height: 165,
+                        child: infoSection,
+                      ),
+                      SizedBox(
+                        height: 180,
+                        child: chartSection,
+                      ),
+                    ],
+                  )
                 : SizedBox(
-              height: 220,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  SizedBox(
-                    width: 170,
-                    child: infoSection,
-                  ),
-                  Expanded(
-                    child: chartSection,
-                  ),
-                ],
-              ),
-            );
+                    height: 220,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        SizedBox(
+                          width: 170,
+                          child: infoSection,
+                        ),
+                        Expanded(
+                          child: chartSection,
+                        ),
+                      ],
+                    ),
+                  );
 
             if (useFallbackScroll) {
               return SingleChildScrollView(

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -283,18 +283,20 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
             );
 
             final Widget content = useVerticalLayout
-                ? Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      SizedBox(
-                        height: 165,
-                        child: infoSection,
-                      ),
-                      SizedBox(
-                        height: 180,
-                        child: chartSection,
-                      ),
-                    ],
+                ? SingleChildScrollView(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        SizedBox(
+                          height: 165,
+                          child: infoSection,
+                        ),
+                        SizedBox(
+                          height: 180,
+                          child: chartSection,
+                        ),
+                      ],
+                    ),
                   )
                 : SizedBox(
                     height: 220,

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -23,8 +23,14 @@ class AccelerometerCard extends StatefulWidget {
 class _AccelerometerCardState extends State<AccelerometerCard> {
   final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
+  // Practical mobile breakpoints (logical pixels). Anything ≥ 360 is treated
+  // as the design baseline; below 320 we begin shedding non-essential chrome.
+  static const double _kBaselineWidth = 360.0;
+  static const double _kCompactWidth = 320.0;
+  static const double _kTinyWidth = 260.0;
+  static const double _kMicroWidth = 220.0;
+
   Widget _sideTitleWidget(
-    double value,
     TitleMeta meta, {
     required double fontSize,
   }) {
@@ -42,92 +48,35 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     );
   }
 
-  Widget _scalingText(String text, double fontSize) {
-    return FittedBox(
-      fit: BoxFit.scaleDown,
-      alignment: Alignment.center,
-      child: Text(
-        text,
-        maxLines: 1,
-        softWrap: false,
-        textAlign: TextAlign.center,
-        style: TextStyle(
-          color: cardContentColor,
-          fontSize: fontSize,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildInfoSection({
-    required String axisImage,
-    required double currentValue,
-    required double minValue,
-    required double maxValue,
-    required double imageSize,
-    required double valueFontSize,
-    required double labelFontSize,
-    required double horizontalPadding,
-    required double verticalPadding,
-    required double spacing,
-  }) {
-    final String axisLabel = appLocalizations.accelerationAxisLabel;
-    return Padding(
-      padding: EdgeInsets.symmetric(
-        horizontal: horizontalPadding,
-        vertical: verticalPadding,
-      ),
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Image.asset(
-            axisImage,
-            width: imageSize,
-            height: imageSize,
-            fit: BoxFit.contain,
-          ),
-          SizedBox(height: spacing),
-          _scalingText(
-            '${currentValue.toStringAsFixed(1)} $axisLabel',
-            valueFontSize,
-          ),
-          SizedBox(height: spacing * 0.5),
-          _scalingText(
-            '${appLocalizations.minValue} ${minValue.toStringAsFixed(1)} $axisLabel',
-            labelFontSize,
-          ),
-          SizedBox(height: spacing * 0.25),
-          _scalingText(
-            '${appLocalizations.maxValue} ${maxValue.toStringAsFixed(1)} $axisLabel',
-            labelFontSize,
-          ),
-        ],
-      ),
-    );
-  }
-
   Widget _buildChartSection({
     required List<FlSpot> spots,
     required int dataLength,
-    required double titleFontSize,
-    required double axisNameSize,
-    required double reservedSize,
-    required double leftPadding,
-    required double rightPadding,
-    required double topPadding,
-    required double bottomPadding,
-    required double lineBarWidth,
+    required double width,
+    required double scale,
   }) {
     final double safeMaxX =
         dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
-
     final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
+    // Progressively shed chart chrome at smaller widths.
+    final bool showTopTitle = width >= _kTinyWidth;
+    final bool showLeftTickLabels = width >= _kMicroWidth;
+
+    final double tickFontSize = (10.5 * scale).clamp(7.0, 11.0);
+    final double axisLabelFontSize = (11.0 * scale).clamp(7.5, 11.5);
+    final double topAxisNameSize =
+        showTopTitle ? (16.0 * scale).clamp(10.0, 18.0).toDouble() : 0.0;
+    final double leftAxisNameSize = (14.0 * scale).clamp(9.0, 16.0);
+    final double reservedSize =
+        showLeftTickLabels ? (22.0 * scale).clamp(14.0, 26.0).toDouble() : 6.0;
+    final double lineBarWidth = (2.0 * scale).clamp(1.0, 2.2);
+    final double leftPadding = (2.0 * scale).clamp(0.0, 3.0);
+    final double rightPadding = (8.0 * scale).clamp(2.0, 10.0);
+    final double topPadding = (4.0 * scale).clamp(2.0, 6.0);
+    final double bottomPadding = (6.0 * scale).clamp(2.0, 8.0);
+
     return ClipRect(
-      child: Container(
-        color: chartBackgroundColor,
+      child: Padding(
         padding: EdgeInsets.only(
           left: leftPadding,
           right: rightPadding,
@@ -137,7 +86,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         child: RepaintBoundary(
           child: LineChart(
             LineChartData(
-              backgroundColor: chartBackgroundColor,
+              backgroundColor: Colors.black,
               minX: 0,
               maxX: safeMaxX,
               minY: -20,
@@ -162,18 +111,20 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
               titlesData: FlTitlesData(
                 show: true,
                 topTitles: AxisTitles(
-                  axisNameWidget: FittedBox(
-                    fit: BoxFit.scaleDown,
-                    child: Text(
-                      appLocalizations.timeAxisLabel,
-                      style: TextStyle(
-                        fontSize: titleFontSize,
-                        color: chartTextColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                  axisNameSize: axisNameSize,
+                  axisNameWidget: showTopTitle
+                      ? FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: Text(
+                            appLocalizations.timeAxisLabel,
+                            style: TextStyle(
+                              fontSize: axisLabelFontSize,
+                              color: chartTextColor,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        )
+                      : null,
+                  axisNameSize: topAxisNameSize,
                   sideTitles: const SideTitles(showTitles: false),
                 ),
                 bottomTitles: const AxisTitles(
@@ -185,22 +136,19 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                     child: Text(
                       appLocalizations.accelerationAxisLabel,
                       style: TextStyle(
-                        fontSize: titleFontSize,
+                        fontSize: axisLabelFontSize,
                         color: chartTextColor,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
                   ),
-                  axisNameSize: axisNameSize,
+                  axisNameSize: leftAxisNameSize,
                   sideTitles: SideTitles(
                     reservedSize: reservedSize,
-                    showTitles: true,
+                    showTitles: showLeftTickLabels,
                     interval: 10,
-                    getTitlesWidget: (value, meta) => _sideTitleWidget(
-                      value,
-                      meta,
-                      fontSize: titleFontSize,
-                    ),
+                    getTitlesWidget: (value, meta) =>
+                        _sideTitleWidget(meta, fontSize: tickFontSize),
                   ),
                 ),
                 rightTitles: const AxisTitles(
@@ -231,101 +179,237 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
-    final double currentValue = provider.getCurrent(widget.axis);
-    final double minValue = provider.getMin(widget.axis);
-    final double maxValue = provider.getMax(widget.axis);
+    final double currVal = provider.getCurrent(widget.axis);
+    final double minVal = provider.getMin(widget.axis);
+    final double maxVal = provider.getMax(widget.axis);
     final int dataLength = provider.getDataLength(widget.axis);
     final String axisImage = 'assets/images/phone_${widget.axis}_axis.png';
+    final String axisLabel = appLocalizations.accelerationAxisLabel;
 
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(5),
-      ),
-      elevation: 2,
-      child: Container(
-        decoration: BoxDecoration(
-          color: cardBackgroundColor,
-          borderRadius: BorderRadius.circular(5),
-        ),
-        child: LayoutBuilder(
-          builder: (context, constraints) {
-            final double width = constraints.maxWidth;
-            final double height = constraints.hasBoundedHeight
-                ? constraints.maxHeight
-                : (width * 0.42).clamp(90.0, 220.0);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final double width = constraints.maxWidth;
+        final bool boundedHeight = constraints.maxHeight.isFinite;
+        final double targetHeight = (width * 0.55).clamp(140.0, 300.0);
 
-            // Use the smaller of width and height (normalised) so the card
-            // scales proportionally on narrow or short layouts.
-            final double scaleBase =
-                width < height * 2.4 ? width : height * 2.4;
+        // Practical scale model: 1.0 at the design baseline (360dp width,
+        // 200dp card height), with a sane floor so things stay legible.
+        final double widthScale = width / _kBaselineWidth;
 
-            final double leftWidth = (width * 0.34).clamp(80.0, 220.0);
+        const double outerHMargin = 8.0;
+        const double outerVMargin = 6.0;
 
-            final double imageSize = (scaleBase * 0.10)
-                .clamp(16.0, 48.0)
-                .clamp(0.0, height * 0.38);
+        final double effectiveHeight = boundedHeight
+            ? (constraints.maxHeight - outerVMargin * 2)
+                .clamp(60.0, double.infinity)
+                .toDouble()
+            : targetHeight;
+        final double heightScale = effectiveHeight / 200.0;
 
-            final double valueFontSize = (scaleBase * 0.028).clamp(9.0, 14.0);
-            final double labelFontSize = (scaleBase * 0.022).clamp(7.5, 11.5);
-            final double chartFontSize = (scaleBase * 0.020).clamp(7.0, 11.0);
-            final double axisNameSize = (scaleBase * 0.04).clamp(9.0, 20.0);
-            final double reservedSize = (scaleBase * 0.05).clamp(14.0, 30.0);
-            final double lineBarWidth = (scaleBase * 0.005).clamp(1.0, 2.0);
+        final double scale =
+            (widthScale < heightScale ? widthScale : heightScale)
+                .clamp(0.55, 1.15)
+                .toDouble();
 
-            final double horizontalPadding =
-                (scaleBase * 0.015).clamp(2.0, 8.0);
-            final double verticalPadding = (scaleBase * 0.015).clamp(2.0, 8.0);
-            final double spacing = (scaleBase * 0.012).clamp(2.0, 6.0);
+        final bool isCompact = width < _kCompactWidth;
+        final bool isTiny = width < _kTinyWidth;
 
-            final double chartLeftPadding =
-                (scaleBase * 0.005).clamp(0.0, 2.0);
-            final double chartRightPadding =
-                (scaleBase * 0.015).clamp(2.0, 8.0);
-            final double chartTopPadding = (scaleBase * 0.012).clamp(2.0, 6.0);
-            final double chartBottomPadding =
-                (scaleBase * 0.015).clamp(2.0, 8.0);
+        // Card chrome.
+        final double cardTopOffset = (8.0 * scale).clamp(5.0, 10.0);
+        final double borderRadius = isCompact ? 4.0 : 6.0;
+        final double borderWidth = isCompact ? 1.0 : 1.2;
 
-            return SizedBox(
-              height: height,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  SizedBox(
-                    width: leftWidth,
-                    child: _buildInfoSection(
-                      axisImage: axisImage,
-                      currentValue: currentValue,
-                      minValue: minValue,
-                      maxValue: maxValue,
-                      imageSize: imageSize,
-                      valueFontSize: valueFontSize,
-                      labelFontSize: labelFontSize,
-                      horizontalPadding: horizontalPadding,
-                      verticalPadding: verticalPadding,
-                      spacing: spacing,
+        // Title chip (overlaps the top border).
+        final double titleFontSize = isTiny
+            ? 10.5
+            : (isCompact ? 11.5 : (12.5 * scale).clamp(11.0, 13.0));
+        final double titleHPadding = isCompact ? 6.0 : 8.0;
+        const double titleVPadding = 1.0;
+
+        // Top info row — designed for ≥320dp; compact mins for tighter widths.
+        double rowTopPad = isTiny ? 6.0 : (isCompact ? 8.0 : 10.0);
+        double rowBottomPad = isTiny ? 4.0 : (isCompact ? 5.0 : 6.0);
+        final double rowHPad = isTiny ? 6.0 : (isCompact ? 8.0 : 10.0);
+        double imageSize = isTiny ? 14.0 : (isCompact ? 16.0 : 20.0);
+        final double imageGap = isTiny ? 5.0 : (isCompact ? 6.0 : 8.0);
+
+        final double currentFontSize =
+            isTiny ? 10.5 : (isCompact ? 12.0 : 13.5);
+        final double minMaxFontSize = isTiny ? 9.5 : (isCompact ? 11.0 : 12.5);
+        final double currentToMinGap = isTiny ? 8.0 : (isCompact ? 14.0 : 20.0);
+        final double minToMaxGap = isTiny ? 6.0 : (isCompact ? 10.0 : 14.0);
+
+        // Chart-first vertical budgeting: reserve at least ~55% of the card
+        // for the plot. If the row + paddings would push past the budget,
+        // shrink them proportionally so the chart keeps a usable slice.
+        // Important: at ultra-small heights, do NOT impose a chart floor
+        // larger than what Expanded can actually deliver — otherwise the
+        // ConstrainedBox would fight the parent and force overflow. The
+        // floor is capped against the realistic remaining space.
+        final double estimatedHeaderBase =
+            rowTopPad + imageSize + rowBottomPad + 1.0;
+        final double availableForChart =
+            (effectiveHeight - estimatedHeaderBase).clamp(0.0, effectiveHeight);
+        double chartMinHeight =
+            (effectiveHeight * 0.55).clamp(80.0, 220.0).toDouble();
+        if (chartMinHeight > availableForChart) {
+          chartMinHeight = availableForChart;
+        }
+        final double headerBudget =
+            (effectiveHeight - chartMinHeight - 1.0).clamp(28.0, 200.0);
+        final double estimatedHeader = rowTopPad + imageSize + rowBottomPad;
+        if (estimatedHeader > headerBudget) {
+          final double shrink =
+              (headerBudget / estimatedHeader).clamp(0.55, 1.0).toDouble();
+          rowTopPad = (rowTopPad * shrink).clamp(3.0, rowTopPad).toDouble();
+          rowBottomPad =
+              (rowBottomPad * shrink).clamp(2.0, rowBottomPad).toDouble();
+          imageSize = (imageSize * shrink).clamp(10.0, imageSize).toDouble();
+        }
+
+        return Container(
+          margin: const EdgeInsets.symmetric(
+            vertical: outerVMargin,
+            horizontal: outerHMargin,
+          ),
+          height: boundedHeight ? null : effectiveHeight,
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              // LAYER 1: bordered card body.
+              Container(
+                margin: EdgeInsets.only(top: cardTopOffset),
+                clipBehavior: Clip.antiAlias,
+                decoration: BoxDecoration(
+                  color: cardBackgroundColor,
+                  border: Border.all(width: borderWidth, color: Colors.red),
+                  borderRadius: BorderRadius.circular(borderRadius),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Padding(
+                      padding: EdgeInsets.fromLTRB(
+                        rowHPad,
+                        rowTopPad,
+                        rowHPad,
+                        rowBottomPad,
+                      ),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Image.asset(
+                            axisImage,
+                            width: imageSize,
+                            height: imageSize,
+                            fit: BoxFit.contain,
+                          ),
+                          SizedBox(width: imageGap),
+                          Expanded(
+                            child: FittedBox(
+                              fit: BoxFit.scaleDown,
+                              alignment: Alignment.centerLeft,
+                              child: Row(
+                                crossAxisAlignment: CrossAxisAlignment.center,
+                                children: [
+                                  Text(
+                                    'Current: ${currVal.toStringAsFixed(1)} '
+                                    '$axisLabel',
+                                    maxLines: 1,
+                                    softWrap: false,
+                                    style: TextStyle(
+                                      color: widget.color,
+                                      fontWeight: FontWeight.bold,
+                                      fontSize: currentFontSize,
+                                      height: 1.1,
+                                    ),
+                                  ),
+                                  SizedBox(width: currentToMinGap),
+                                  Text(
+                                    '${appLocalizations.minValue}'
+                                    '${minVal.toStringAsFixed(1)}',
+                                    maxLines: 1,
+                                    softWrap: false,
+                                    style: TextStyle(
+                                      color: cardContentColor.withOpacity(0.8),
+                                      fontSize: minMaxFontSize,
+                                      height: 1.1,
+                                    ),
+                                  ),
+                                  SizedBox(width: minToMaxGap),
+                                  Text(
+                                    '${appLocalizations.maxValue}'
+                                    '${maxVal.toStringAsFixed(1)}',
+                                    maxLines: 1,
+                                    softWrap: false,
+                                    style: TextStyle(
+                                      color: cardContentColor.withOpacity(0.8),
+                                      fontSize: minMaxFontSize,
+                                      height: 1.1,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                  Expanded(
-                    child: _buildChartSection(
-                      spots: spots,
-                      dataLength: dataLength,
-                      titleFontSize: chartFontSize,
-                      axisNameSize: axisNameSize,
-                      reservedSize: reservedSize,
-                      leftPadding: chartLeftPadding,
-                      rightPadding: chartRightPadding,
-                      topPadding: chartTopPadding,
-                      bottomPadding: chartBottomPadding,
-                      lineBarWidth: lineBarWidth,
+                    Divider(
+                      height: 1,
+                      thickness: 1,
+                      color: Colors.red.withOpacity(0.5),
                     ),
-                  ),
-                ],
+                    Expanded(
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(minHeight: chartMinHeight),
+                        child: Container(
+                          color: Colors.black,
+                          child: _buildChartSection(
+                            spots: spots,
+                            dataLength: dataLength,
+                            width: width,
+                            scale: scale,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            );
-          },
-        ),
-      ),
+
+              // LAYER 2: title chip overlapping the top border.
+              Positioned(
+                left: 0,
+                right: 0,
+                top: 0,
+                child: Align(
+                  alignment: Alignment.center,
+                  child: Container(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: titleHPadding,
+                      vertical: titleVPadding,
+                    ),
+                    color: cardBackgroundColor,
+                    child: Text(
+                      '${widget.axis.toUpperCase()} AXIS',
+                      maxLines: 1,
+                      softWrap: false,
+                      style: TextStyle(
+                        color: Colors.red,
+                        fontWeight: FontWeight.bold,
+                        fontSize: titleFontSize,
+                        height: 1.0,
+                        letterSpacing: 0.4,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -23,17 +23,93 @@ class AccelerometerCard extends StatefulWidget {
 class _AccelerometerCardState extends State<AccelerometerCard> {
   final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
-  // Practical mobile breakpoints (logical pixels). Anything ≥ 360 is treated
-  // as the design baseline; below 320 we begin shedding non-essential chrome.
   static const double _kBaselineWidth = 360.0;
   static const double _kCompactWidth = 320.0;
   static const double _kTinyWidth = 260.0;
   static const double _kMicroWidth = 220.0;
 
-  Widget _sideTitleWidget(
-    TitleMeta meta, {
-    required double fontSize,
+  Widget _buildTopInfoRow({
+    required String axisImage,
+    required String axisLabel,
+    required double currVal,
+    required double minVal,
+    required double maxVal,
+    required double imageSize,
+    required double imageGap,
+    required double currentFontSize,
+    required double minMaxFontSize,
+    required double currentToMinGap,
+    required double minToMaxGap,
   }) {
+    final TextStyle currentStyle = TextStyle(
+      color: Colors.black,
+      fontWeight: FontWeight.bold,
+      fontSize: currentFontSize,
+      height: 1.1,
+    );
+    final TextStyle minMaxStyle = TextStyle(
+      color: cardContentColor.withValues(alpha: 0.8),
+      fontSize: minMaxFontSize,
+      height: 1.1,
+    );
+
+    final Widget currentText = Text(
+      'Current: ${currVal.toStringAsFixed(1)} $axisLabel',
+      maxLines: 1,
+      softWrap: false,
+      overflow: TextOverflow.ellipsis,
+      style: currentStyle,
+    );
+    final Widget minText = Text(
+      '${appLocalizations.minValue}${minVal.toStringAsFixed(1)}',
+      maxLines: 1,
+      softWrap: false,
+      style: minMaxStyle,
+    );
+    final Widget maxText = Text(
+      '${appLocalizations.maxValue}${maxVal.toStringAsFixed(1)}',
+      maxLines: 1,
+      softWrap: false,
+      style: minMaxStyle,
+    );
+
+    final Widget axisImg = Image.asset(
+      axisImage,
+      width: imageSize,
+      height: imageSize,
+      fit: BoxFit.contain,
+    );
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        axisImg,
+        SizedBox(width: imageGap),
+        Expanded(
+          child: FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: currentText,
+          ),
+        ),
+        SizedBox(width: currentToMinGap),
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            minText,
+            SizedBox(width: minToMaxGap),
+            maxText,
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _sideTitleWidget(
+      TitleMeta meta, {
+        required double fontSize,
+      }) {
     return SideTitleWidget(
       meta: meta,
       child: Text(
@@ -55,25 +131,34 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required double scale,
   }) {
     final double safeMaxX =
-        dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
+    dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
     final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
-    // Progressively shed chart chrome at smaller widths.
     final bool showTopTitle = width >= _kTinyWidth;
     final bool showLeftTickLabels = width >= _kMicroWidth;
+    final bool sparseTicks = width < _kCompactWidth;
+    final double tickInterval = sparseTicks ? 20.0 : 10.0;
 
-    final double tickFontSize = (10.5 * scale).clamp(7.0, 11.0);
-    final double axisLabelFontSize = (11.0 * scale).clamp(7.5, 11.5);
+    final double widthFactor = (width / _kBaselineWidth).clamp(0.55, 1.15);
+
+    final double tickFontSize =
+    (10.0 * scale).clamp(8.0, 10.5).toDouble();
+    final double axisLabelFontSize =
+    (10.5 * scale).clamp(7.5, 11.0).toDouble();
     final double topAxisNameSize =
-        showTopTitle ? (16.0 * scale).clamp(10.0, 18.0).toDouble() : 0.0;
-    final double leftAxisNameSize = (14.0 * scale).clamp(9.0, 16.0);
-    final double reservedSize =
-        showLeftTickLabels ? (22.0 * scale).clamp(14.0, 26.0).toDouble() : 6.0;
+    showTopTitle ? (15.0 * scale).clamp(9.0, 17.0).toDouble() : 0.0;
+    final double leftAxisNameSize =
+    (12.0 * widthFactor).clamp(9.0, 14.0).toDouble();
+    final double reservedSize = !showLeftTickLabels
+        ? 4.0
+        : sparseTicks
+        ? (tickFontSize * 2.0 + 4.0).clamp(16.0, 22.0).toDouble()
+        : (tickFontSize * 2.2 + 4.0).clamp(18.0, 26.0).toDouble();
     final double lineBarWidth = (2.0 * scale).clamp(1.0, 2.2);
-    final double leftPadding = (2.0 * scale).clamp(0.0, 3.0);
-    final double rightPadding = (8.0 * scale).clamp(2.0, 10.0);
-    final double topPadding = (4.0 * scale).clamp(2.0, 6.0);
-    final double bottomPadding = (6.0 * scale).clamp(2.0, 8.0);
+    final double leftPadding = (1.5 * scale).clamp(0.0, 2.0);
+    final double rightPadding = (6.0 * scale).clamp(2.0, 8.0);
+    final double topPadding = (3.0 * scale).clamp(1.5, 5.0);
+    final double bottomPadding = (5.0 * scale).clamp(2.0, 7.0);
 
     return ClipRect(
       child: Padding(
@@ -92,11 +177,11 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
               minY: -20,
               maxY: 20,
               clipData: const FlClipData.all(),
-              gridData: const FlGridData(
+              gridData: FlGridData(
                 show: true,
                 drawHorizontalLine: true,
                 drawVerticalLine: true,
-                horizontalInterval: 10,
+                horizontalInterval: tickInterval,
                 verticalInterval: 10,
               ),
               borderData: FlBorderData(
@@ -113,16 +198,16 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                 topTitles: AxisTitles(
                   axisNameWidget: showTopTitle
                       ? FittedBox(
-                          fit: BoxFit.scaleDown,
-                          child: Text(
-                            appLocalizations.timeAxisLabel,
-                            style: TextStyle(
-                              fontSize: axisLabelFontSize,
-                              color: chartTextColor,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        )
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      appLocalizations.timeAxisLabel,
+                      style: TextStyle(
+                        fontSize: axisLabelFontSize,
+                        color: chartTextColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  )
                       : null,
                   axisNameSize: topAxisNameSize,
                   sideTitles: const SideTitles(showTitles: false),
@@ -146,7 +231,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                   sideTitles: SideTitles(
                     reservedSize: reservedSize,
                     showTitles: showLeftTickLabels,
-                    interval: 10,
+                    interval: tickInterval,
                     getTitlesWidget: (value, meta) =>
                         _sideTitleWidget(meta, fontSize: tickFontSize),
                   ),
@@ -176,7 +261,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   @override
   Widget build(BuildContext context) {
     final AccelerometerStateProvider provider =
-        Provider.of<AccelerometerStateProvider>(context);
+    Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
     final double currVal = provider.getCurrent(widget.axis);
@@ -192,8 +277,6 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         final bool boundedHeight = constraints.maxHeight.isFinite;
         final double targetHeight = (width * 0.55).clamp(140.0, 300.0);
 
-        // Practical scale model: 1.0 at the design baseline (360dp width,
-        // 200dp card height), with a sane floor so things stay legible.
         final double widthScale = width / _kBaselineWidth;
 
         const double outerHMargin = 8.0;
@@ -201,66 +284,59 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
 
         final double effectiveHeight = boundedHeight
             ? (constraints.maxHeight - outerVMargin * 2)
-                .clamp(60.0, double.infinity)
-                .toDouble()
+            .clamp(60.0, double.infinity)
+            .toDouble()
             : targetHeight;
         final double heightScale = effectiveHeight / 200.0;
 
         final double scale =
-            (widthScale < heightScale ? widthScale : heightScale)
-                .clamp(0.55, 1.15)
-                .toDouble();
+        (widthScale < heightScale ? widthScale : heightScale)
+            .clamp(0.55, 1.15)
+            .toDouble();
 
         final bool isCompact = width < _kCompactWidth;
         final bool isTiny = width < _kTinyWidth;
 
-        // Card chrome.
         final double cardTopOffset = (8.0 * scale).clamp(5.0, 10.0);
         final double borderRadius = isCompact ? 4.0 : 6.0;
         final double borderWidth = isCompact ? 1.0 : 1.2;
 
-        // Title chip (overlaps the top border).
         final double titleFontSize = isTiny
             ? 10.5
             : (isCompact ? 11.5 : (12.5 * scale).clamp(11.0, 13.0));
         final double titleHPadding = isCompact ? 6.0 : 8.0;
         const double titleVPadding = 1.0;
 
-        // Top info row — designed for ≥320dp; compact mins for tighter widths.
         double rowTopPad = isTiny ? 6.0 : (isCompact ? 8.0 : 10.0);
         double rowBottomPad = isTiny ? 4.0 : (isCompact ? 5.0 : 6.0);
-        final double rowHPad = isTiny ? 6.0 : (isCompact ? 8.0 : 10.0);
-        double imageSize = isTiny ? 14.0 : (isCompact ? 16.0 : 20.0);
-        final double imageGap = isTiny ? 5.0 : (isCompact ? 6.0 : 8.0);
+        final double rowHPad = isTiny ? 5.0 : (isCompact ? 8.0 : 10.0);
+        double imageSize = isTiny ? 12.0 : (isCompact ? 16.0 : 20.0);
+        final double imageGap = isTiny ? 3.0 : (isCompact ? 6.0 : 8.0);
 
         final double currentFontSize =
-            isTiny ? 10.5 : (isCompact ? 12.0 : 13.5);
-        final double minMaxFontSize = isTiny ? 9.5 : (isCompact ? 11.0 : 12.5);
-        final double currentToMinGap = isTiny ? 8.0 : (isCompact ? 14.0 : 20.0);
-        final double minToMaxGap = isTiny ? 6.0 : (isCompact ? 10.0 : 14.0);
+        isTiny ? 9.5 : (isCompact ? 12.0 : 13.5);
+        final double minMaxFontSize =
+        isTiny ? 8.5 : (isCompact ? 11.0 : 12.5);
+        final double currentToMinGap =
+        isTiny ? 3.0 : (isCompact ? 6.0 : 12.0);
+        final double minToMaxGap = isTiny ? 4.0 : (isCompact ? 8.0 : 12.0);
 
-        // Chart-first vertical budgeting: reserve at least ~55% of the card
-        // for the plot. If the row + paddings would push past the budget,
-        // shrink them proportionally so the chart keeps a usable slice.
-        // Important: at ultra-small heights, do NOT impose a chart floor
-        // larger than what Expanded can actually deliver — otherwise the
-        // ConstrainedBox would fight the parent and force overflow. The
-        // floor is capped against the realistic remaining space.
         final double estimatedHeaderBase =
             rowTopPad + imageSize + rowBottomPad + 1.0;
         final double availableForChart =
-            (effectiveHeight - estimatedHeaderBase).clamp(0.0, effectiveHeight);
+        (effectiveHeight - estimatedHeaderBase).clamp(0.0, effectiveHeight);
+
         double chartMinHeight =
-            (effectiveHeight * 0.55).clamp(80.0, 220.0).toDouble();
+        (effectiveHeight * 0.55).clamp(80.0, 220.0).toDouble();
         if (chartMinHeight > availableForChart) {
           chartMinHeight = availableForChart;
         }
         final double headerBudget =
-            (effectiveHeight - chartMinHeight - 1.0).clamp(28.0, 200.0);
+        (effectiveHeight - chartMinHeight - 1.0).clamp(28.0, 200.0);
         final double estimatedHeader = rowTopPad + imageSize + rowBottomPad;
         if (estimatedHeader > headerBudget) {
           final double shrink =
-              (headerBudget / estimatedHeader).clamp(0.55, 1.0).toDouble();
+          (headerBudget / estimatedHeader).clamp(0.55, 1.0).toDouble();
           rowTopPad = (rowTopPad * shrink).clamp(3.0, rowTopPad).toDouble();
           rowBottomPad =
               (rowBottomPad * shrink).clamp(2.0, rowBottomPad).toDouble();
@@ -276,7 +352,6 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
           child: Stack(
             clipBehavior: Clip.none,
             children: [
-              // LAYER 1: bordered card body.
               Container(
                 margin: EdgeInsets.only(top: cardTopOffset),
                 clipBehavior: Clip.antiAlias,
@@ -295,72 +370,24 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                         rowHPad,
                         rowBottomPad,
                       ),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Image.asset(
-                            axisImage,
-                            width: imageSize,
-                            height: imageSize,
-                            fit: BoxFit.contain,
-                          ),
-                          SizedBox(width: imageGap),
-                          Expanded(
-                            child: FittedBox(
-                              fit: BoxFit.scaleDown,
-                              alignment: Alignment.centerLeft,
-                              child: Row(
-                                crossAxisAlignment: CrossAxisAlignment.center,
-                                children: [
-                                  Text(
-                                    'Current: ${currVal.toStringAsFixed(1)} '
-                                    '$axisLabel',
-                                    maxLines: 1,
-                                    softWrap: false,
-                                    style: TextStyle(
-                                      color: widget.color,
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: currentFontSize,
-                                      height: 1.1,
-                                    ),
-                                  ),
-                                  SizedBox(width: currentToMinGap),
-                                  Text(
-                                    '${appLocalizations.minValue}'
-                                    '${minVal.toStringAsFixed(1)}',
-                                    maxLines: 1,
-                                    softWrap: false,
-                                    style: TextStyle(
-                                      color: cardContentColor.withValues(
-                                          alpha: 0.8),
-                                      fontSize: minMaxFontSize,
-                                      height: 1.1,
-                                    ),
-                                  ),
-                                  SizedBox(width: minToMaxGap),
-                                  Text(
-                                    '${appLocalizations.maxValue}'
-                                    '${maxVal.toStringAsFixed(1)}',
-                                    maxLines: 1,
-                                    softWrap: false,
-                                    style: TextStyle(
-                                      color: cardContentColor.withValues(
-                                          alpha: 0.8),
-                                      fontSize: minMaxFontSize,
-                                      height: 1.1,
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ),
-                        ],
+                      child: _buildTopInfoRow(
+                        axisImage: axisImage,
+                        axisLabel: axisLabel,
+                        currVal: currVal,
+                        minVal: minVal,
+                        maxVal: maxVal,
+                        imageSize: imageSize,
+                        imageGap: imageGap,
+                        currentFontSize: currentFontSize,
+                        minMaxFontSize: minMaxFontSize,
+                        currentToMinGap: currentToMinGap,
+                        minToMaxGap: minToMaxGap,
                       ),
                     ),
                     Divider(
                       height: 1,
                       thickness: 1,
-                      color: Colors.red.withOpacity(0.5),
+                      color: Colors.red.withValues(alpha: 0.5),
                     ),
                     Expanded(
                       child: ConstrainedBox(
@@ -379,8 +406,6 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                   ],
                 ),
               ),
-
-              // LAYER 2: title chip overlapping the top border.
               Positioned(
                 left: 0,
                 right: 0,

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -23,10 +23,10 @@ class AccelerometerCard extends StatefulWidget {
 class _AccelerometerCardState extends State<AccelerometerCard> {
   final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
-  Widget sideTitleWidgets(
+  Widget _sideTitleWidget(
     double value,
     TitleMeta meta, {
-    required bool compact,
+    required double fontSize,
   }) {
     return SideTitleWidget(
       meta: meta,
@@ -36,96 +36,74 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         overflow: TextOverflow.ellipsis,
         style: TextStyle(
           color: chartTextColor,
-          fontSize: compact ? 8 : 9,
+          fontSize: fontSize,
+        ),
+      ),
+    );
+  }
+
+  Widget _scalingText(String text, double fontSize) {
+    return FittedBox(
+      fit: BoxFit.scaleDown,
+      alignment: Alignment.center,
+      child: Text(
+        text,
+        maxLines: 1,
+        softWrap: false,
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          color: cardContentColor,
+          fontSize: fontSize,
         ),
       ),
     );
   }
 
   Widget _buildInfoSection({
-    required BoxConstraints constraints,
     required String axisImage,
-    required double currVal,
-    required double minVal,
-    required double maxVal,
-    required bool isNarrow,
-    required bool centered,
+    required double currentValue,
+    required double minValue,
+    required double maxValue,
+    required double imageSize,
+    required double valueFontSize,
+    required double labelFontSize,
+    required double horizontalPadding,
+    required double verticalPadding,
+    required double spacing,
   }) {
-    final double imageSize =
-        (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
-
-    final double labelWidth = isNarrow ? 110 : 130;
-
-    return KeyedSubtree(
-      key: ValueKey('accelerometer-info-${widget.axis}-$centered'),
-      child: Padding(
-        padding: EdgeInsets.symmetric(
-          horizontal: isNarrow ? 10 : 12,
-          vertical: isNarrow ? 10 : 12,
-        ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          mainAxisSize: MainAxisSize.max,
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            Image.asset(
-              axisImage,
-              width: imageSize,
-              height: imageSize,
-              fit: BoxFit.contain,
-            ),
-            SizedBox(height: isNarrow ? 6 : 8),
-            FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Text(
-                "${currVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: cardContentColor,
-                  fontSize: isNarrow ? 12 : 14,
-                ),
-              ),
-            ),
-            SizedBox(height: isNarrow ? 6 : 8),
-            Align(
-              alignment: centered ? Alignment.center : Alignment.centerLeft,
-              child: SizedBox(
-                width: centered ? null : labelWidth,
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  alignment: centered ? Alignment.center : Alignment.centerLeft,
-                  child: Text(
-                    "${appLocalizations.minValue} ${minVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                    textAlign: centered ? TextAlign.center : TextAlign.left,
-                    style: TextStyle(
-                      color: cardContentColor,
-                      fontSize: isNarrow ? 8 : 10,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(height: 4),
-            Align(
-              alignment: centered ? Alignment.center : Alignment.centerLeft,
-              child: SizedBox(
-                width: centered ? null : labelWidth,
-                child: FittedBox(
-                  fit: BoxFit.scaleDown,
-                  alignment: centered ? Alignment.center : Alignment.centerLeft,
-                  child: Text(
-                    "${appLocalizations.maxValue} ${maxVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                    textAlign: centered ? TextAlign.center : TextAlign.left,
-                    style: TextStyle(
-                      color: cardContentColor,
-                      fontSize: isNarrow ? 8 : 10,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
+    final String axisLabel = appLocalizations.accelerationAxisLabel;
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: horizontalPadding,
+        vertical: verticalPadding,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Image.asset(
+            axisImage,
+            width: imageSize,
+            height: imageSize,
+            fit: BoxFit.contain,
+          ),
+          SizedBox(height: spacing),
+          _scalingText(
+            '${currentValue.toStringAsFixed(1)} $axisLabel',
+            valueFontSize,
+          ),
+          SizedBox(height: spacing * 0.5),
+          _scalingText(
+            '${appLocalizations.minValue} ${minValue.toStringAsFixed(1)} $axisLabel',
+            labelFontSize,
+          ),
+          SizedBox(height: spacing * 0.25),
+          _scalingText(
+            '${appLocalizations.maxValue} ${maxValue.toStringAsFixed(1)} $axisLabel',
+            labelFontSize,
+          ),
+        ],
       ),
     );
   }
@@ -133,95 +111,108 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   Widget _buildChartSection({
     required List<FlSpot> spots,
     required int dataLength,
-    required bool isNarrow,
+    required double titleFontSize,
+    required double axisNameSize,
+    required double reservedSize,
+    required double leftPadding,
+    required double rightPadding,
+    required double topPadding,
+    required double bottomPadding,
+    required double lineBarWidth,
   }) {
     final double safeMaxX =
         dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
 
     final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
-    return KeyedSubtree(
-      key: ValueKey('accelerometer-chart-${widget.axis}-$isNarrow'),
+    return ClipRect(
       child: Container(
-        padding: EdgeInsets.only(
-          left: isNarrow ? 8 : 0,
-          right: isNarrow ? 10 : 20,
-          top: isNarrow ? 8 : 10,
-          bottom: isNarrow ? 10 : 16,
-        ),
         color: chartBackgroundColor,
+        padding: EdgeInsets.only(
+          left: leftPadding,
+          right: rightPadding,
+          top: topPadding,
+          bottom: bottomPadding,
+        ),
         child: RepaintBoundary(
           child: LineChart(
             LineChartData(
               backgroundColor: chartBackgroundColor,
+              minX: 0,
+              maxX: safeMaxX,
+              minY: -20,
+              maxY: 20,
+              clipData: const FlClipData.all(),
+              gridData: const FlGridData(
+                show: true,
+                drawHorizontalLine: true,
+                drawVerticalLine: true,
+                horizontalInterval: 10,
+                verticalInterval: 10,
+              ),
+              borderData: FlBorderData(
+                show: true,
+                border: Border(
+                  left: BorderSide(color: chartBorderColor),
+                  bottom: BorderSide(color: chartBorderColor),
+                  top: BorderSide(color: chartBorderColor),
+                  right: BorderSide(color: chartBorderColor),
+                ),
+              ),
               titlesData: FlTitlesData(
                 show: true,
                 topTitles: AxisTitles(
-                  axisNameWidget: Padding(
-                    padding: EdgeInsets.only(left: isNarrow ? 0 : 18),
+                  axisNameWidget: FittedBox(
+                    fit: BoxFit.scaleDown,
                     child: Text(
                       appLocalizations.timeAxisLabel,
                       style: TextStyle(
-                        fontSize: isNarrow ? 8 : 10,
+                        fontSize: titleFontSize,
                         color: chartTextColor,
                         fontWeight: FontWeight.bold,
                       ),
                     ),
                   ),
-                  axisNameSize: isNarrow ? 16 : 20,
+                  axisNameSize: axisNameSize,
                   sideTitles: const SideTitles(showTitles: false),
                 ),
                 bottomTitles: const AxisTitles(
                   sideTitles: SideTitles(showTitles: false),
                 ),
                 leftTitles: AxisTitles(
-                  axisNameWidget: Text(
-                    appLocalizations.accelerationAxisLabel,
-                    style: TextStyle(
-                      fontSize: isNarrow ? 8 : 10,
-                      color: chartTextColor,
-                      fontWeight: FontWeight.bold,
+                  axisNameWidget: FittedBox(
+                    fit: BoxFit.scaleDown,
+                    child: Text(
+                      appLocalizations.accelerationAxisLabel,
+                      style: TextStyle(
+                        fontSize: titleFontSize,
+                        color: chartTextColor,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
-                  axisNameSize: isNarrow ? 16 : 20,
+                  axisNameSize: axisNameSize,
                   sideTitles: SideTitles(
-                    reservedSize: isNarrow ? 22 : 30,
+                    reservedSize: reservedSize,
                     showTitles: true,
-                    getTitlesWidget: (value, meta) =>
-                        sideTitleWidgets(value, meta, compact: isNarrow),
                     interval: 10,
+                    getTitlesWidget: (value, meta) => _sideTitleWidget(
+                      value,
+                      meta,
+                      fontSize: titleFontSize,
+                    ),
                   ),
                 ),
                 rightTitles: const AxisTitles(
                   sideTitles: SideTitles(showTitles: false),
                 ),
               ),
-              gridData: const FlGridData(
-                show: true,
-                drawHorizontalLine: true,
-                drawVerticalLine: true,
-                horizontalInterval: 10,
-              ),
-              borderData: FlBorderData(
-                show: true,
-                border: Border(
-                  bottom: BorderSide(color: chartBorderColor),
-                  left: BorderSide(color: chartBorderColor),
-                  top: BorderSide(color: chartBorderColor),
-                  right: BorderSide(color: chartBorderColor),
-                ),
-              ),
-              minY: -20,
-              maxY: 20,
-              minX: 0,
-              maxX: safeMaxX,
-              clipData: const FlClipData.all(),
               lineBarsData: [
                 LineChartBarData(
                   spots: safeSpots,
                   isCurved: safeSpots.length > 2,
                   color: widget.color,
-                  barWidth: 2,
+                  barWidth: lineBarWidth,
                   isStrokeCapRound: true,
                   dotData: const FlDotData(show: false),
                   belowBarData: BarAreaData(show: false),
@@ -240,9 +231,9 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
-    final double currVal = provider.getCurrent(widget.axis);
-    final double minVal = provider.getMin(widget.axis);
-    final double maxVal = provider.getMax(widget.axis);
+    final double currentValue = provider.getCurrent(widget.axis);
+    final double minValue = provider.getMin(widget.axis);
+    final double maxValue = provider.getMax(widget.axis);
     final int dataLength = provider.getDataLength(widget.axis);
     final String axisImage = 'assets/images/phone_${widget.axis}_axis.png';
 
@@ -260,70 +251,78 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         child: LayoutBuilder(
           builder: (context, constraints) {
             final double width = constraints.maxWidth;
-            final double height = constraints.maxHeight;
+            final double height = constraints.hasBoundedHeight
+                ? constraints.maxHeight
+                : (width * 0.42).clamp(90.0, 220.0);
 
-            final bool useVerticalLayout = width < 420;
-            final bool isNarrow = width < 400;
-            final bool useFallbackScroll = width < 320 || height < 180;
+            // Use the smaller of width and height (normalised) so the card
+            // scales proportionally on narrow or short layouts.
+            final double scaleBase =
+                width < height * 2.4 ? width : height * 2.4;
 
-            final Widget infoSection = _buildInfoSection(
-              constraints: constraints,
-              axisImage: axisImage,
-              currVal: currVal,
-              minVal: minVal,
-              maxVal: maxVal,
-              isNarrow: isNarrow,
-              centered: useVerticalLayout,
-            );
+            final double leftWidth = (width * 0.34).clamp(80.0, 220.0);
 
-            final Widget chartSection = _buildChartSection(
-              spots: spots,
-              dataLength: dataLength,
-              isNarrow: isNarrow,
-            );
+            final double imageSize = (scaleBase * 0.10)
+                .clamp(16.0, 48.0)
+                .clamp(0.0, height * 0.38);
 
-            final Widget content = useVerticalLayout
-                ? SingleChildScrollView(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        SizedBox(
-                          height: 165,
-                          child: infoSection,
-                        ),
-                        SizedBox(
-                          height: 180,
-                          child: chartSection,
-                        ),
-                      ],
+            final double valueFontSize = (scaleBase * 0.028).clamp(9.0, 14.0);
+            final double labelFontSize = (scaleBase * 0.022).clamp(7.5, 11.5);
+            final double chartFontSize = (scaleBase * 0.020).clamp(7.0, 11.0);
+            final double axisNameSize = (scaleBase * 0.04).clamp(9.0, 20.0);
+            final double reservedSize = (scaleBase * 0.05).clamp(14.0, 30.0);
+            final double lineBarWidth = (scaleBase * 0.005).clamp(1.0, 2.0);
+
+            final double horizontalPadding =
+                (scaleBase * 0.015).clamp(2.0, 8.0);
+            final double verticalPadding = (scaleBase * 0.015).clamp(2.0, 8.0);
+            final double spacing = (scaleBase * 0.012).clamp(2.0, 6.0);
+
+            final double chartLeftPadding =
+                (scaleBase * 0.005).clamp(0.0, 2.0);
+            final double chartRightPadding =
+                (scaleBase * 0.015).clamp(2.0, 8.0);
+            final double chartTopPadding = (scaleBase * 0.012).clamp(2.0, 6.0);
+            final double chartBottomPadding =
+                (scaleBase * 0.015).clamp(2.0, 8.0);
+
+            return SizedBox(
+              height: height,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  SizedBox(
+                    width: leftWidth,
+                    child: _buildInfoSection(
+                      axisImage: axisImage,
+                      currentValue: currentValue,
+                      minValue: minValue,
+                      maxValue: maxValue,
+                      imageSize: imageSize,
+                      valueFontSize: valueFontSize,
+                      labelFontSize: labelFontSize,
+                      horizontalPadding: horizontalPadding,
+                      verticalPadding: verticalPadding,
+                      spacing: spacing,
                     ),
-                  )
-                : SizedBox(
-                    height: 220,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        SizedBox(
-                          width: 170,
-                          child: infoSection,
-                        ),
-                        Expanded(
-                          child: chartSection,
-                        ),
-                      ],
+                  ),
+                  Expanded(
+                    child: _buildChartSection(
+                      spots: spots,
+                      dataLength: dataLength,
+                      titleFontSize: chartFontSize,
+                      axisNameSize: axisNameSize,
+                      reservedSize: reservedSize,
+                      leftPadding: chartLeftPadding,
+                      rightPadding: chartRightPadding,
+                      topPadding: chartTopPadding,
+                      bottomPadding: chartBottomPadding,
+                      lineBarWidth: lineBarWidth,
                     ),
-                  );
-
-            if (useFallbackScroll) {
-              return SingleChildScrollView(
-                child: ConstrainedBox(
-                  constraints: BoxConstraints(minWidth: width),
-                  child: content,
-                ),
-              );
-            }
-
-            return content;
+                  ),
+                ],
+              ),
+            );
           },
         ),
       ),

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -24,10 +24,10 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
   Widget sideTitleWidgets(
-    double value,
-    TitleMeta meta, {
-    required bool compact,
-  }) {
+      double value,
+      TitleMeta meta, {
+        required bool compact,
+      }) {
     return SideTitleWidget(
       meta: meta,
       child: Text(
@@ -52,50 +52,56 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required bool centered,
   }) {
     final double imageSize =
-        (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
+    (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
+
+    final double labelWidth = isNarrow ? 110 : 130;
 
     return KeyedSubtree(
       key: ValueKey('accelerometer-info-${widget.axis}-$centered'),
       child: Padding(
-        padding: EdgeInsets.all(isNarrow ? 8 : 12),
+        padding: EdgeInsets.symmetric(
+          horizontal: isNarrow ? 10 : 12,
+          vertical: isNarrow ? 10 : 12,
+        ),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.spaceAround,
-          crossAxisAlignment:
-              centered ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.max,
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            Center(
-              child: Image.asset(
-                axisImage,
-                width: imageSize,
-                height: imageSize,
-                fit: BoxFit.contain,
-              ),
+            Image.asset(
+              axisImage,
+              width: imageSize,
+              height: imageSize,
+              fit: BoxFit.contain,
             ),
             SizedBox(height: isNarrow ? 6 : 8),
-            Center(
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                child: Text(
-                  "${currVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: cardContentColor,
-                    fontSize: isNarrow ? 12 : 14,
-                  ),
+            FittedBox(
+              fit: BoxFit.scaleDown,
+              child: Text(
+                "${currVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: cardContentColor,
+                  fontSize: isNarrow ? 12 : 14,
                 ),
               ),
             ),
             SizedBox(height: isNarrow ? 6 : 8),
             Align(
               alignment: centered ? Alignment.center : Alignment.centerLeft,
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                child: Text(
-                  "${appLocalizations.minValue} ${minVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                  style: TextStyle(
-                    color: cardContentColor,
-                    fontSize: isNarrow ? 8 : 10,
+              child: SizedBox(
+                width: centered ? null : labelWidth,
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment:
+                  centered ? Alignment.center : Alignment.centerLeft,
+                  child: Text(
+                    "${appLocalizations.minValue} ${minVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
+                    textAlign: centered ? TextAlign.center : TextAlign.left,
+                    style: TextStyle(
+                      color: cardContentColor,
+                      fontSize: isNarrow ? 8 : 10,
+                    ),
                   ),
                 ),
               ),
@@ -103,13 +109,19 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
             const SizedBox(height: 4),
             Align(
               alignment: centered ? Alignment.center : Alignment.centerLeft,
-              child: FittedBox(
-                fit: BoxFit.scaleDown,
-                child: Text(
-                  "${appLocalizations.maxValue} ${maxVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                  style: TextStyle(
-                    color: cardContentColor,
-                    fontSize: isNarrow ? 8 : 10,
+              child: SizedBox(
+                width: centered ? null : labelWidth,
+                child: FittedBox(
+                  fit: BoxFit.scaleDown,
+                  alignment:
+                  centered ? Alignment.center : Alignment.centerLeft,
+                  child: Text(
+                    "${appLocalizations.maxValue} ${maxVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
+                    textAlign: centered ? TextAlign.center : TextAlign.left,
+                    style: TextStyle(
+                      color: cardContentColor,
+                      fontSize: isNarrow ? 8 : 10,
+                    ),
                   ),
                 ),
               ),
@@ -126,19 +138,19 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required bool isNarrow,
   }) {
     final double safeMaxX =
-        dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
+    dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
 
-    final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
+    final List<FlSpot> safeSpots =
+    spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
     return KeyedSubtree(
       key: ValueKey('accelerometer-chart-${widget.axis}-$isNarrow'),
       child: Container(
-        constraints: const BoxConstraints(minHeight: 120),
         padding: EdgeInsets.only(
-          left: isNarrow ? 6 : 0,
-          right: isNarrow ? 8 : 25,
+          left: isNarrow ? 8 : 0,
+          right: isNarrow ? 10 : 20,
           top: isNarrow ? 8 : 10,
-          bottom: isNarrow ? 10 : 20,
+          bottom: isNarrow ? 10 : 16,
         ),
         color: chartBackgroundColor,
         child: RepaintBoundary(
@@ -149,7 +161,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
                 show: true,
                 topTitles: AxisTitles(
                   axisNameWidget: Padding(
-                    padding: EdgeInsets.only(left: isNarrow ? 0 : 25),
+                    padding: EdgeInsets.only(left: isNarrow ? 0 : 18),
                     child: Text(
                       appLocalizations.timeAxisLabel,
                       style: TextStyle(
@@ -228,7 +240,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   @override
   Widget build(BuildContext context) {
     final AccelerometerStateProvider provider =
-        Provider.of<AccelerometerStateProvider>(context);
+    Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
     final double currVal = provider.getCurrent(widget.axis);
@@ -250,8 +262,12 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
         ),
         child: LayoutBuilder(
           builder: (context, constraints) {
-            final bool useVerticalLayout = constraints.maxWidth < 420;
-            final bool isNarrow = constraints.maxWidth < 400;
+            final double width = constraints.maxWidth;
+            final double height = constraints.maxHeight;
+
+            final bool useVerticalLayout = width < 420;
+            final bool isNarrow = width < 400;
+            final bool useFallbackScroll = width < 320 || height < 180;
 
             final Widget infoSection = _buildInfoSection(
               constraints: constraints,
@@ -271,38 +287,44 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
 
             final Widget content = useVerticalLayout
                 ? Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: [
-                      infoSection,
-                      SizedBox(
-                        height: 200,
-                        child: chartSection,
-                      ),
-                    ],
-                  )
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(
+                  height: 165,
+                  child: infoSection,
+                ),
+                SizedBox(
+                  height: 180,
+                  child: chartSection,
+                ),
+              ],
+            )
                 : SizedBox(
-                    height: 220,
-                    child: Row(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Expanded(
-                          flex: 30,
-                          child: infoSection,
-                        ),
-                        Expanded(
-                          flex: 70,
-                          child: chartSection,
-                        ),
-                      ],
-                    ),
-                  );
-
-            return SingleChildScrollView(
-              child: ConstrainedBox(
-                constraints: BoxConstraints(minWidth: constraints.maxWidth),
-                child: content,
+              height: 220,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  SizedBox(
+                    width: 170,
+                    child: infoSection,
+                  ),
+                  Expanded(
+                    child: chartSection,
+                  ),
+                ],
               ),
             );
+
+            if (useFallbackScroll) {
+              return SingleChildScrollView(
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minWidth: width),
+                  child: content,
+                ),
+              );
+            }
+
+            return content;
           },
         ),
       ),

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -24,10 +24,10 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
   Widget sideTitleWidgets(
-      double value,
-      TitleMeta meta, {
-        required bool compact,
-      }) {
+    double value,
+    TitleMeta meta, {
+    required bool compact,
+  }) {
     return SideTitleWidget(
       meta: meta,
       child: Text(
@@ -52,7 +52,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required bool centered,
   }) {
     final double imageSize =
-    (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
+        (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
 
     return KeyedSubtree(
       key: ValueKey('accelerometer-info-${widget.axis}-$centered'),
@@ -62,7 +62,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
           mainAxisSize: MainAxisSize.min,
           mainAxisAlignment: MainAxisAlignment.spaceAround,
           crossAxisAlignment:
-          centered ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+              centered ? CrossAxisAlignment.center : CrossAxisAlignment.start,
           children: [
             Center(
               child: Image.asset(
@@ -126,10 +126,9 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
     required bool isNarrow,
   }) {
     final double safeMaxX =
-    dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
+        dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
 
-    final List<FlSpot> safeSpots =
-    spots.isEmpty ? [const FlSpot(0, 0)] : spots;
+    final List<FlSpot> safeSpots = spots.isEmpty ? [const FlSpot(0, 0)] : spots;
 
     return KeyedSubtree(
       key: ValueKey('accelerometer-chart-${widget.axis}-$isNarrow'),
@@ -229,7 +228,7 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
   @override
   Widget build(BuildContext context) {
     final AccelerometerStateProvider provider =
-    Provider.of<AccelerometerStateProvider>(context);
+        Provider.of<AccelerometerStateProvider>(context);
 
     final List<FlSpot> spots = provider.getAxisData(widget.axis);
     final double currVal = provider.getCurrent(widget.axis);
@@ -272,31 +271,31 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
 
             final Widget content = useVerticalLayout
                 ? Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                infoSection,
-                SizedBox(
-                  height: 200,
-                  child: chartSection,
-                ),
-              ],
-            )
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      infoSection,
+                      SizedBox(
+                        height: 200,
+                        child: chartSection,
+                      ),
+                    ],
+                  )
                 : SizedBox(
-              height: 220,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    flex: 30,
-                    child: infoSection,
-                  ),
-                  Expanded(
-                    flex: 70,
-                    child: chartSection,
-                  ),
-                ],
-              ),
-            );
+                    height: 220,
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Expanded(
+                          flex: 30,
+                          child: infoSection,
+                        ),
+                        Expanded(
+                          flex: 70,
+                          child: chartSection,
+                        ),
+                      ],
+                    ),
+                  );
 
             return SingleChildScrollView(
               child: ConstrainedBox(

--- a/lib/view/widgets/accelerometer_card.dart
+++ b/lib/view/widgets/accelerometer_card.dart
@@ -1,48 +1,242 @@
-import 'package:flutter/material.dart';
-import 'package:pslab/l10n/app_localizations.dart';
-import 'package:pslab/providers/locator.dart';
-import 'package:pslab/providers/accelerometer_state_provider.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/accelerometer_state_provider.dart';
+import 'package:pslab/providers/locator.dart';
 import 'package:pslab/theme/colors.dart';
 
 class AccelerometerCard extends StatefulWidget {
   final String axis;
   final Color color;
 
-  const AccelerometerCard({required this.axis, required this.color, super.key});
+  const AccelerometerCard({
+    required this.axis,
+    required this.color,
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() => _AccelerometerCardState();
 }
 
 class _AccelerometerCardState extends State<AccelerometerCard> {
-  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
-  Widget sideTitleWidgets(double value, TitleMeta meta) {
-    final style = TextStyle(
-      color: chartTextColor,
-      fontSize: 9,
-    );
+  final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
+  Widget sideTitleWidgets(
+      double value,
+      TitleMeta meta, {
+        required bool compact,
+      }) {
     return SideTitleWidget(
       meta: meta,
       child: Text(
-        maxLines: 1,
         meta.formattedValue,
-        style: style,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          color: chartTextColor,
+          fontSize: compact ? 8 : 9,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoSection({
+    required BoxConstraints constraints,
+    required String axisImage,
+    required double currVal,
+    required double minVal,
+    required double maxVal,
+    required bool isNarrow,
+    required bool centered,
+  }) {
+    final double imageSize =
+    (constraints.maxWidth * 0.15).clamp(30.0, 50.0).toDouble();
+
+    return KeyedSubtree(
+      key: ValueKey('accelerometer-info-${widget.axis}-$centered'),
+      child: Padding(
+        padding: EdgeInsets.all(isNarrow ? 8 : 12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          crossAxisAlignment:
+          centered ? CrossAxisAlignment.center : CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Image.asset(
+                axisImage,
+                width: imageSize,
+                height: imageSize,
+                fit: BoxFit.contain,
+              ),
+            ),
+            SizedBox(height: isNarrow ? 6 : 8),
+            Center(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  "${currVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: cardContentColor,
+                    fontSize: isNarrow ? 12 : 14,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: isNarrow ? 6 : 8),
+            Align(
+              alignment: centered ? Alignment.center : Alignment.centerLeft,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  "${appLocalizations.minValue} ${minVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
+                  style: TextStyle(
+                    color: cardContentColor,
+                    fontSize: isNarrow ? 8 : 10,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Align(
+              alignment: centered ? Alignment.center : Alignment.centerLeft,
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  "${appLocalizations.maxValue} ${maxVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
+                  style: TextStyle(
+                    color: cardContentColor,
+                    fontSize: isNarrow ? 8 : 10,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChartSection({
+    required List<FlSpot> spots,
+    required int dataLength,
+    required bool isNarrow,
+  }) {
+    final double safeMaxX =
+    dataLength <= 1 ? 50 : (dataLength > 50 ? 50 : dataLength.toDouble());
+
+    final List<FlSpot> safeSpots =
+    spots.isEmpty ? [const FlSpot(0, 0)] : spots;
+
+    return KeyedSubtree(
+      key: ValueKey('accelerometer-chart-${widget.axis}-$isNarrow'),
+      child: Container(
+        constraints: const BoxConstraints(minHeight: 120),
+        padding: EdgeInsets.only(
+          left: isNarrow ? 6 : 0,
+          right: isNarrow ? 8 : 25,
+          top: isNarrow ? 8 : 10,
+          bottom: isNarrow ? 10 : 20,
+        ),
+        color: chartBackgroundColor,
+        child: RepaintBoundary(
+          child: LineChart(
+            LineChartData(
+              backgroundColor: chartBackgroundColor,
+              titlesData: FlTitlesData(
+                show: true,
+                topTitles: AxisTitles(
+                  axisNameWidget: Padding(
+                    padding: EdgeInsets.only(left: isNarrow ? 0 : 25),
+                    child: Text(
+                      appLocalizations.timeAxisLabel,
+                      style: TextStyle(
+                        fontSize: isNarrow ? 8 : 10,
+                        color: chartTextColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  axisNameSize: isNarrow ? 16 : 20,
+                  sideTitles: const SideTitles(showTitles: false),
+                ),
+                bottomTitles: const AxisTitles(
+                  sideTitles: SideTitles(showTitles: false),
+                ),
+                leftTitles: AxisTitles(
+                  axisNameWidget: Text(
+                    appLocalizations.accelerationAxisLabel,
+                    style: TextStyle(
+                      fontSize: isNarrow ? 8 : 10,
+                      color: chartTextColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  axisNameSize: isNarrow ? 16 : 20,
+                  sideTitles: SideTitles(
+                    reservedSize: isNarrow ? 22 : 30,
+                    showTitles: true,
+                    getTitlesWidget: (value, meta) =>
+                        sideTitleWidgets(value, meta, compact: isNarrow),
+                    interval: 10,
+                  ),
+                ),
+                rightTitles: const AxisTitles(
+                  sideTitles: SideTitles(showTitles: false),
+                ),
+              ),
+              gridData: const FlGridData(
+                show: true,
+                drawHorizontalLine: true,
+                drawVerticalLine: true,
+                horizontalInterval: 10,
+              ),
+              borderData: FlBorderData(
+                show: true,
+                border: Border(
+                  bottom: BorderSide(color: chartBorderColor),
+                  left: BorderSide(color: chartBorderColor),
+                  top: BorderSide(color: chartBorderColor),
+                  right: BorderSide(color: chartBorderColor),
+                ),
+              ),
+              minY: -20,
+              maxY: 20,
+              minX: 0,
+              maxX: safeMaxX,
+              clipData: const FlClipData.all(),
+              lineBarsData: [
+                LineChartBarData(
+                  spots: safeSpots,
+                  isCurved: safeSpots.length > 2,
+                  color: widget.color,
+                  barWidth: 2,
+                  isStrokeCapRound: true,
+                  dotData: const FlDotData(show: false),
+                  belowBarData: BarAreaData(show: false),
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    AccelerometerStateProvider provider =
-        Provider.of<AccelerometerStateProvider>(context);
-    List<FlSpot> spots = provider.getAxisData(widget.axis);
-    double currVal = provider.getCurrent(widget.axis);
-    double minVal = provider.getMin(widget.axis);
-    double maxVal = provider.getMax(widget.axis);
-    int dataLength = provider.getDataLength(widget.axis);
-    String axisImage = 'assets/images/phone_${widget.axis}_axis.png';
+    final AccelerometerStateProvider provider =
+    Provider.of<AccelerometerStateProvider>(context);
+
+    final List<FlSpot> spots = provider.getAxisData(widget.axis);
+    final double currVal = provider.getCurrent(widget.axis);
+    final double minVal = provider.getMin(widget.axis);
+    final double maxVal = provider.getMax(widget.axis);
+    final int dataLength = provider.getDataLength(widget.axis);
+    final String axisImage = 'assets/images/phone_${widget.axis}_axis.png';
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
@@ -52,134 +246,65 @@ class _AccelerometerCardState extends State<AccelerometerCard> {
       elevation: 2,
       child: Container(
         decoration: BoxDecoration(
-            color: cardBackgroundColor, borderRadius: BorderRadius.circular(5)),
-        child: Row(
-          children: [
-            Expanded(
-              flex: 30,
-              child: Column(children: [
-                Container(
-                  margin: const EdgeInsets.all(15),
-                  child: Image.asset(
-                    axisImage,
-                    width: 50,
-                    height: 50,
-                  ),
+          color: cardBackgroundColor,
+          borderRadius: BorderRadius.circular(5),
+        ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final bool useVerticalLayout = constraints.maxWidth < 420;
+            final bool isNarrow = constraints.maxWidth < 400;
+
+            final Widget infoSection = _buildInfoSection(
+              constraints: constraints,
+              axisImage: axisImage,
+              currVal: currVal,
+              minVal: minVal,
+              maxVal: maxVal,
+              isNarrow: isNarrow,
+              centered: useVerticalLayout,
+            );
+
+            final Widget chartSection = _buildChartSection(
+              spots: spots,
+              dataLength: dataLength,
+              isNarrow: isNarrow,
+            );
+
+            final Widget content = useVerticalLayout
+                ? Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                infoSection,
+                SizedBox(
+                  height: 200,
+                  child: chartSection,
                 ),
-                Container(
-                  margin: const EdgeInsets.only(top: 8, bottom: 12),
-                  child: Text(
-                    "${currVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                    style: TextStyle(color: cardContentColor, fontSize: 14),
+              ],
+            )
+                : SizedBox(
+              height: 220,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Expanded(
+                    flex: 30,
+                    child: infoSection,
                   ),
-                ),
-                Container(
-                  alignment: Alignment.topLeft,
-                  margin: const EdgeInsets.only(left: 8, top: 4),
-                  child: Text(
-                    "${appLocalizations.minValue} ${minVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                    style: TextStyle(color: cardContentColor, fontSize: 10),
+                  Expanded(
+                    flex: 70,
+                    child: chartSection,
                   ),
-                ),
-                Container(
-                  alignment: Alignment.topLeft,
-                  margin: const EdgeInsets.only(left: 8, top: 2),
-                  child: Text(
-                    "${appLocalizations.maxValue} ${maxVal.toStringAsFixed(1)} ${appLocalizations.accelerationAxisLabel}",
-                    style: TextStyle(color: cardContentColor, fontSize: 10),
-                  ),
-                ),
-              ]),
-            ),
-            Expanded(
-              flex: 70,
-              child: Container(
-                padding: const EdgeInsets.only(bottom: 20, top: 10, right: 25),
-                color: chartBackgroundColor,
-                child: LineChart(
-                  LineChartData(
-                    backgroundColor: chartBackgroundColor,
-                    titlesData: FlTitlesData(
-                      show: true,
-                      topTitles: AxisTitles(
-                        axisNameWidget: Padding(
-                          padding: const EdgeInsets.only(left: 25),
-                          child: Text(
-                            appLocalizations.timeAxisLabel,
-                            style: TextStyle(
-                              fontSize: 10,
-                              color: chartTextColor,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                        axisNameSize: 20,
-                      ),
-                      bottomTitles: const AxisTitles(
-                          sideTitles: SideTitles(showTitles: false)),
-                      leftTitles: AxisTitles(
-                        axisNameWidget: Text(
-                          appLocalizations.accelerationAxisLabel,
-                          style: TextStyle(
-                            fontSize: 10,
-                            color: chartTextColor,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        sideTitles: SideTitles(
-                          reservedSize: 30,
-                          showTitles: true,
-                          getTitlesWidget: sideTitleWidgets,
-                          interval: 10,
-                        ),
-                      ),
-                      rightTitles: const AxisTitles(
-                          sideTitles: SideTitles(showTitles: false)),
-                    ),
-                    gridData: const FlGridData(
-                      show: true,
-                      drawHorizontalLine: true,
-                      drawVerticalLine: true,
-                      horizontalInterval: 10,
-                    ),
-                    borderData: FlBorderData(
-                      show: true,
-                      border: Border(
-                        bottom: BorderSide(
-                          color: chartBorderColor,
-                        ),
-                        left: BorderSide(
-                          color: chartBorderColor,
-                        ),
-                        top: BorderSide(
-                          color: chartBorderColor,
-                        ),
-                        right: BorderSide(
-                          color: chartBorderColor,
-                        ),
-                      ),
-                    ),
-                    minY: -20,
-                    maxY: 20,
-                    maxX: dataLength > 50 ? 50 : dataLength.toDouble(),
-                    minX: 0,
-                    clipData: const FlClipData.all(),
-                    lineBarsData: [
-                      LineChartBarData(
-                        spots: spots,
-                        isCurved: true,
-                        color: widget.color,
-                        barWidth: 2,
-                        isStrokeCapRound: true,
-                        dotData: const FlDotData(show: false),
-                        belowBarData: BarAreaData(show: false),
-                      ),
-                    ],
-                  ),
-                ),
+                ],
               ),
-            ),
-          ],
+            );
+
+            return SingleChildScrollView(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                child: content,
+              ),
+            );
+          },
         ),
       ),
     );

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -90,8 +90,7 @@ class _CommonScaffoldState extends State<CommonScaffold> {
               width: 24,
               height: 24,
             ),
-            tooltip:
-            widget.isRecording ? 'Stop Recording' : 'Start Recording',
+            tooltip: widget.isRecording ? 'Stop Recording' : 'Start Recording',
           ),
         );
       }

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -90,7 +90,9 @@ class _CommonScaffoldState extends State<CommonScaffold> {
               width: 24,
               height: 24,
             ),
-            tooltip: widget.isRecording ? 'Stop Recording' : 'Start Recording',
+            tooltip: widget.isRecording
+                ? appLocalizations.stopRecording
+                : appLocalizations.startRecording,
           ),
         );
       }

--- a/lib/view/widgets/common_scaffold_widget.dart
+++ b/lib/view/widgets/common_scaffold_widget.dart
@@ -36,13 +36,98 @@ class CommonScaffold extends StatefulWidget {
     this.onPlaybackPauseResume,
     this.onPlaybackStop,
   });
+
   @override
   State<StatefulWidget> createState() => _CommonScaffoldState();
 }
 
 class _CommonScaffoldState extends State<CommonScaffold> {
+  List<Widget> _buildResponsiveActions(double width) {
+    final bool isVerySmall = width < 260;
+    final bool isSmall = width < 320;
+
+    final List<Widget> responsiveActions = [];
+
+    if (widget.actions != null) {
+      responsiveActions.addAll(widget.actions!);
+    }
+
+    if (widget.isPlayingBack) {
+      if (!isVerySmall && widget.onPlaybackPauseResume != null) {
+        responsiveActions.add(
+          IconButton(
+            onPressed: widget.onPlaybackPauseResume,
+            icon: Icon(
+              widget.isPlaybackPaused ? Icons.play_arrow : Icons.pause,
+              color: appBarContentColor,
+            ),
+            tooltip: widget.isPlaybackPaused
+                ? appLocalizations.resumePlayback
+                : appLocalizations.pausePlayback,
+          ),
+        );
+      }
+
+      if (!isSmall && widget.onPlaybackStop != null) {
+        responsiveActions.add(
+          IconButton(
+            onPressed: widget.onPlaybackStop,
+            icon: Icon(
+              Icons.stop,
+              color: appBarContentColor,
+            ),
+            tooltip: appLocalizations.stopPlayback,
+          ),
+        );
+      }
+    } else {
+      if (!isVerySmall && widget.onRecordPressed != null) {
+        responsiveActions.add(
+          IconButton(
+            onPressed: widget.onRecordPressed,
+            icon: Image.asset(
+              widget.isRecording ? widget.icStopRecord : widget.icRecord,
+              width: 24,
+              height: 24,
+            ),
+            tooltip:
+            widget.isRecording ? 'Stop Recording' : 'Start Recording',
+          ),
+        );
+      }
+    }
+
+    if (!isSmall && widget.onGuidePressed != null) {
+      responsiveActions.add(
+        IconButton(
+          onPressed: widget.onGuidePressed,
+          icon: Icon(
+            Icons.info,
+            color: appBarContentColor,
+          ),
+        ),
+      );
+    }
+
+    if (widget.onOptionsPressed != null) {
+      responsiveActions.add(
+        IconButton(
+          onPressed: widget.onOptionsPressed,
+          icon: Icon(
+            Icons.more_vert,
+            color: appBarContentColor,
+          ),
+        ),
+      );
+    }
+
+    return responsiveActions;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final double width = MediaQuery.of(context).size.width;
+
     return Scaffold(
       backgroundColor: scaffoldBackgroundColor,
       resizeToAvoidBottomInset: true,
@@ -52,77 +137,31 @@ class _CommonScaffoldState extends State<CommonScaffold> {
           statusBarIconBrightness: Brightness.light,
           statusBarBrightness: Brightness.dark,
         ),
-        leading: Builder(builder: (context) {
-          return IconButton(
-            onPressed: () {
-              Navigator.maybePop(context);
-            },
-            icon: Icon(
-              Icons.arrow_back,
-              color: appBarContentColor,
-            ),
-          );
-        }),
+        leading: Builder(
+          builder: (context) {
+            return IconButton(
+              onPressed: () {
+                Navigator.maybePop(context);
+              },
+              icon: Icon(
+                Icons.arrow_back,
+                color: appBarContentColor,
+              ),
+            );
+          },
+        ),
         backgroundColor: primaryRed,
         title: Text(
-          key: widget.scaffoldKey,
           widget.title,
+          key: widget.scaffoldKey,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
           style: TextStyle(
             color: appBarContentColor,
             fontSize: 15,
           ),
         ),
-        actions: [
-          if (widget.actions != null) ...widget.actions!,
-          if (widget.isPlayingBack) ...[
-            if (widget.onPlaybackPauseResume != null)
-              IconButton(
-                onPressed: widget.onPlaybackPauseResume,
-                icon: Icon(
-                  widget.isPlaybackPaused ? Icons.play_arrow : Icons.pause,
-                  color: appBarContentColor,
-                ),
-                tooltip: widget.isPlaybackPaused
-                    ? appLocalizations.resumePlayback
-                    : appLocalizations.pausePlayback,
-              ),
-            if (widget.onPlaybackStop != null)
-              IconButton(
-                onPressed: widget.onPlaybackStop,
-                icon: Icon(
-                  Icons.stop,
-                  color: appBarContentColor,
-                ),
-                tooltip: appLocalizations.stopPlayback,
-              ),
-          ] else if (widget.onRecordPressed != null)
-            IconButton(
-              onPressed: widget.onRecordPressed,
-              icon: Image.asset(
-                widget.isRecording ? widget.icStopRecord : widget.icRecord,
-                width: 24,
-                height: 24,
-              ),
-              tooltip:
-                  widget.isRecording ? 'Stop Recording' : 'Start Recording',
-            ),
-          if (widget.onGuidePressed != null)
-            IconButton(
-              onPressed: widget.onGuidePressed,
-              icon: Icon(
-                Icons.info,
-                color: appBarContentColor,
-              ),
-            ),
-          if (widget.onOptionsPressed != null)
-            IconButton(
-              onPressed: widget.onOptionsPressed,
-              icon: Icon(
-                Icons.more_vert,
-                color: appBarContentColor,
-              ),
-            ),
-        ],
+        actions: _buildResponsiveActions(width),
       ),
       body: widget.body,
     );


### PR DESCRIPTION
Fixes #3214

Improves the responsiveness of the Accelerometer screen and cards on smaller layouts, refines the Current / Min / Max alignment, and improves chart responsiveness during resize.

## Changes
- Improved Accelerometer card responsiveness
- Refined Current / Min / Max alignment
- Improved chart scaling on smaller widths
- Added screen-level vertical scroll fallback for tight heights

## Testing
Tested on Windows desktop by resizing the app window across multiple widths, and tested on Android phone.

https://github.com/user-attachments/assets/d8b3d0f7-a969-4c3d-99db-04c59f0034f7


https://github.com/user-attachments/assets/a51ac8cb-90db-40c9-a863-602434dc31b5





## Summary by Sourcery

Improve responsiveness and layout of the accelerometer UI and common app scaffold on narrow and desktop window sizes.

Bug Fixes:
- Prevent layout overflow and overlapping in the accelerometer card at small widths.
- Avoid app bar action overflow on very small screens by conditionally rendering playback, recording, guide, and options actions based on available width.

Enhancements:
- Make the accelerometer card adapt between horizontal and vertical layouts based on available width and adjust typography and chart sizing for compact displays.
- Refactor accelerometer card UI into clearer info and chart sections with safer defaults for chart data and axis configuration.
- Make the common scaffold app bar title and actions more robust with truncation and responsive action building logic.