### PR TITLE
chore: enforce common build dependency for screenshot jobs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -101,7 +101,7 @@ jobs:
 
   screenshots-android:
     name: Screenshots (Android)
-    needs: changes
+    needs: [changes, common]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -121,7 +121,7 @@ jobs:
 
   screenshots-iphone:
     name: Screenshots (iPhone)
-    needs: changes
+    needs: [changes, common]
     runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -146,7 +146,7 @@ jobs:
 
   screenshots-ipad:
     name: Screenshots (iPad)
-    needs: changes
+    needs: [changes, common]
     runs-on: ${{ needs.changes.outputs.is_code == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Fixes #3222 

## Changes
This PR ensures that the screenshot jobs (Android, iPhone, and iPad) correctly depend on the success of the common build.

Previously, these jobs only waited for the change detection job to complete, causing them to run even if the initial common setup failed.

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

CI:
- Update screenshot (Android, iPhone, iPad) workflow jobs to require both change detection and common build completion before running