### PR TITLE
fix: screen to choice the hardware

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -666,5 +666,11 @@
     "pin_res_desc": "Resistance Measurement Pin",
     "stopSound" : "Stop Sound",
     "saw" : "Saw",
-    "comingSoon": "Coming Soon"
+    "comingSoon": "Coming Soon",
+    "changeHardware": "Change Hardware",
+    "psLab": "PSLab",
+    "psLabBoard": "PSLab Board",
+    "internalSensors": "Internal sensors",
+    "selectHardware": "Select Hardware",
+    "selectHardwareQuestion": "What hardware do you want to use?"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -667,6 +667,8 @@
     "stopSound" : "Stop Sound",
     "saw" : "Saw",
     "comingSoon": "Coming Soon",
+    "startRecording": "Start Recording",
+    "stopRecording": "Stop Recording",
     "changeHardware": "Change Hardware",
     "psLab": "PSLab",
     "psLabBoard": "PSLab Board",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:pslab/view/multimeter_screen.dart';
 import 'package:pslab/view/oscilloscope_screen.dart';
 import 'package:pslab/view/power_source_screen.dart';
 import 'package:pslab/view/robotic_arm_screen.dart';
+import 'package:pslab/view/select_hardware.dart';
 import 'package:pslab/view/sensors_screen.dart';
 import 'package:pslab/view/settings_screen.dart';
 import 'package:pslab/view/about_us_screen.dart';
@@ -30,9 +31,16 @@ import 'package:pslab/view/wave_generator_screen.dart';
 import 'package:pslab/view/experiments_screen.dart';
 import 'constants.dart';
 
-void main() {
+void main() async {
   setupLocator();
   WidgetsFlutterBinding.ensureInitialized();
+  final boardProvider = getIt<BoardStateProvider>();
+  await boardProvider.loadSavedHardware();
+  String initialRoute = '/selectHardware';
+  if (boardProvider.selectedHardware.isNotEmpty) {
+    initialRoute = '/';
+  }
+
   runApp(
     MultiProvider(
       providers: [
@@ -46,13 +54,14 @@ void main() {
           create: (context) => getIt<SHT21Provider>(),
         ),
       ],
-      child: const MyApp(),
+      child: MyApp(initialRoute: initialRoute),
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({super.key, required this.initialRoute});
+  final String initialRoute;
 
   @override
   Widget build(BuildContext context) {
@@ -77,8 +86,9 @@ class MyApp extends StatelessWidget {
               ),
               localizationsDelegates: AppLocalizations.localizationsDelegates,
               supportedLocales: AppLocalizations.supportedLocales,
-              initialRoute: '/',
+              initialRoute: initialRoute,
               routes: {
+                '/selectHardware': (context) => const HardwareSelectionScreen(),
                 '/': (context) => const InstrumentsScreen(),
                 '/oscilloscope': (context) => const OscilloscopeScreen(),
                 '/multimeter': (context) => const MultimeterScreen(),

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -7,12 +7,13 @@ import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/settings_config_provider.dart';
 import 'package:usb_serial/usb_serial.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:pslab/others/science_lab_common.dart';
 
 class BoardStateProvider extends ChangeNotifier {
   late SettingsConfigProvider configProvider;
-  AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
   bool initialisationStatus = false;
   bool pslabIsConnected = false;
   bool hasPermission = false;
@@ -23,6 +24,8 @@ class BoardStateProvider extends ChangeNotifier {
   int pslabVersion = 0;
   int pslabFirmwareVersion = 0;
   bool _isProcessing = false;
+  String _selectedHardware = "";
+  String get selectedHardware => _selectedHardware;
 
   final ValueNotifier<String?> legacyFirmwareNotifier = ValueNotifier(null);
 
@@ -119,5 +122,18 @@ class BoardStateProvider extends ChangeNotifier {
       }
     }
     return false;
+  }
+
+  Future<void> loadSavedHardware() async {
+    final prefs = await SharedPreferences.getInstance();
+    _selectedHardware = prefs.getString('selected_hardware') ?? "";
+    notifyListeners();
+  }
+
+  Future<void> setHardware(String name) async {
+    _selectedHardware = name;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('selected_hardware', name);
+    notifyListeners();
   }
 }

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -17,14 +17,16 @@ class _InstrumentData {
   final String heading;
   final String description;
   final String name;
+  final List<String> supportedHardware;
 
-  _InstrumentData(this.heading, this.description, this.name);
+  _InstrumentData(
+      this.heading, this.description, this.name, this.supportedHardware);
 }
 
 class _InstrumentsScreenState extends State<InstrumentsScreen> {
   List<int> _filteredIndices = <int>[];
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
-  late List<_InstrumentData> _instrumentDatas;
+  List<_InstrumentData> _instrumentDatas = [];
 
   void _onItemTapped(int index) {
     _InstrumentData instrument = _instrumentDatas[index];
@@ -54,6 +56,18 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
                 .contains(query.toLowerCase()))
             .toList();
       }
+    });
+  }
+
+  void _updateVisibleInstruments() {
+    final currentHardware = getIt.get<BoardStateProvider>().selectedHardware;
+
+    setState(() {
+      _filteredIndices =
+          List.generate(_instrumentDatas.length, (i) => i).where((i) {
+        final instrument = _instrumentDatas[i];
+        return instrument.supportedHardware.contains(currentHardware);
+      }).toList();
     });
   }
 
@@ -88,36 +102,66 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
 
     _instrumentDatas = [
       _InstrumentData(appLocalizations.oscilloscope,
-          appLocalizations.oscilloscopeDesc, '/oscilloscope'),
-      _InstrumentData(appLocalizations.multimeter,
-          appLocalizations.multimeterDesc, '/multimeter'),
-      _InstrumentData(appLocalizations.logicAnalyzer,
-          appLocalizations.logicAnalyzerDesc, '/logicAnalyzer'),
+          appLocalizations.oscilloscopeDesc, '/oscilloscope', ['pslab_board', 'internal_sensors']),
       _InstrumentData(
-          appLocalizations.sensors, appLocalizations.sensorsDesc, '/sensors'),
-      _InstrumentData(appLocalizations.waveGenerator,
-          appLocalizations.waveGeneratorDesc, '/waveGenerator'),
-      _InstrumentData(appLocalizations.powerSource,
-          appLocalizations.powerSourceDesc, '/powerSource'),
+          appLocalizations.multimeter,
+          appLocalizations.multimeterDesc,
+          '/multimeter',
+          ['pslab_board']),
+      _InstrumentData(
+          appLocalizations.logicAnalyzer,
+          appLocalizations.logicAnalyzerDesc,
+          '/logicAnalyzer',
+          ['pslab_board']),
+      _InstrumentData(appLocalizations.sensors, appLocalizations.sensorsDesc,
+          '/sensors', ['pslab_board']),
+      _InstrumentData(
+          appLocalizations.waveGenerator,
+          appLocalizations.waveGeneratorDesc,
+          '/waveGenerator',
+          ['pslab_board', 'internal_sensors']),
+      _InstrumentData(
+          appLocalizations.powerSource,
+          appLocalizations.powerSourceDesc,
+          '/powerSource',
+          ['pslab_board']),
       _InstrumentData(appLocalizations.luxMeter, appLocalizations.luxMeterDesc,
-          '/luxmeter'),
-      _InstrumentData(appLocalizations.accelerometer,
-          appLocalizations.accelerometerDesc, '/accelerometer'),
-      _InstrumentData(appLocalizations.barometer,
-          appLocalizations.barometerDesc, '/barometer'),
+          '/luxmeter', ['pslab_board', 'internal_sensors']),
       _InstrumentData(
-          appLocalizations.compass, appLocalizations.compassDesc, '/compass'),
-      _InstrumentData(appLocalizations.gyroscope,
-          appLocalizations.gyroscopeDesc, '/gyroscope'),
-      _InstrumentData(appLocalizations.thermometer,
-          appLocalizations.thermometerDesc, '/thermometer'),
-      _InstrumentData(appLocalizations.roboticArm,
-          appLocalizations.roboticArmDesc, '/roboticArm'),
+          appLocalizations.accelerometer,
+          appLocalizations.accelerometerDesc,
+          '/accelerometer',
+          ['pslab_board', 'internal_sensors']),
+      _InstrumentData(
+          appLocalizations.barometer,
+          appLocalizations.barometerDesc,
+          '/barometer',
+          ['pslab_board', 'internal_sensors']),
+      _InstrumentData(appLocalizations.compass, appLocalizations.compassDesc,
+          '/compass', ['pslab_board', 'internal_sensors']),
+      _InstrumentData(
+          appLocalizations.gyroscope,
+          appLocalizations.gyroscopeDesc,
+          '/gyroscope',
+          ['pslab_board', 'internal_sensors']),
+      _InstrumentData(
+          appLocalizations.thermometer,
+          appLocalizations.thermometerDesc,
+          '/thermometer',
+          ['pslab_board', 'internal_sensors']),
+      _InstrumentData(
+          appLocalizations.roboticArm,
+          appLocalizations.roboticArmDesc,
+          '/roboticArm',
+          ['pslab_board']),
       // Instruments below are not yet implemented.
       //_InstrumentData(appLocalizations.gasSensor, appLocalizations.gasSensorDesc, '/gassensor'),
       //_InstrumentData(appLocalizations.dustSensor, appLocalizations.dustSensorDesc, '/dustsensor'),
-      _InstrumentData(appLocalizations.soundMeter,
-          appLocalizations.soundMeterDesc, '/soundmeter'),
+      _InstrumentData(
+          appLocalizations.soundMeter,
+          appLocalizations.soundMeterDesc,
+          '/soundmeter',
+          ['pslab_board', 'internal_sensors']),
     ];
 
     _filteredIndices =
@@ -126,6 +170,8 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
       _setPortraitOrientation();
       SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
     });
+
+    _updateVisibleInstruments();
   }
 
   void _setPortraitOrientation() {

--- a/lib/view/instruments_screen.dart
+++ b/lib/view/instruments_screen.dart
@@ -101,13 +101,13 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
     });
 
     _instrumentDatas = [
-      _InstrumentData(appLocalizations.oscilloscope,
-          appLocalizations.oscilloscopeDesc, '/oscilloscope', ['pslab_board', 'internal_sensors']),
       _InstrumentData(
-          appLocalizations.multimeter,
-          appLocalizations.multimeterDesc,
-          '/multimeter',
-          ['pslab_board']),
+          appLocalizations.oscilloscope,
+          appLocalizations.oscilloscopeDesc,
+          '/oscilloscope',
+          ['pslab_board', 'internal_sensors']),
+      _InstrumentData(appLocalizations.multimeter,
+          appLocalizations.multimeterDesc, '/multimeter', ['pslab_board']),
       _InstrumentData(
           appLocalizations.logicAnalyzer,
           appLocalizations.logicAnalyzerDesc,
@@ -120,11 +120,8 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
           appLocalizations.waveGeneratorDesc,
           '/waveGenerator',
           ['pslab_board', 'internal_sensors']),
-      _InstrumentData(
-          appLocalizations.powerSource,
-          appLocalizations.powerSourceDesc,
-          '/powerSource',
-          ['pslab_board']),
+      _InstrumentData(appLocalizations.powerSource,
+          appLocalizations.powerSourceDesc, '/powerSource', ['pslab_board']),
       _InstrumentData(appLocalizations.luxMeter, appLocalizations.luxMeterDesc,
           '/luxmeter', ['pslab_board', 'internal_sensors']),
       _InstrumentData(
@@ -149,11 +146,8 @@ class _InstrumentsScreenState extends State<InstrumentsScreen> {
           appLocalizations.thermometerDesc,
           '/thermometer',
           ['pslab_board', 'internal_sensors']),
-      _InstrumentData(
-          appLocalizations.roboticArm,
-          appLocalizations.roboticArmDesc,
-          '/roboticArm',
-          ['pslab_board']),
+      _InstrumentData(appLocalizations.roboticArm,
+          appLocalizations.roboticArmDesc, '/roboticArm', ['pslab_board']),
       // Instruments below are not yet implemented.
       //_InstrumentData(appLocalizations.gasSensor, appLocalizations.gasSensorDesc, '/gassensor'),
       //_InstrumentData(appLocalizations.dustSensor, appLocalizations.dustSensorDesc, '/dustsensor'),

--- a/lib/view/select_hardware.dart
+++ b/lib/view/select_hardware.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/locator.dart';
+import 'package:pslab/providers/board_state_provider.dart';
+import 'package:pslab/view/widgets/main_scaffold_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../theme/colors.dart';
+
+class HardwareSelectionScreen extends StatefulWidget {
+  const HardwareSelectionScreen({super.key});
+
+  @override
+  State<HardwareSelectionScreen> createState() =>
+      _HardwareSelectionScreenState();
+}
+
+class _HardwareOption {
+  final String label;
+  final IconData icon;
+  final String value;
+
+  _HardwareOption(this.label, this.icon, this.value);
+}
+
+class _HardwareSelectionScreenState extends State<HardwareSelectionScreen> {
+  final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  late List<_HardwareOption> _options;
+
+  @override
+  void initState() {
+    super.initState();
+    _options = [
+      _HardwareOption(appLocalizations.psLabBoard, Icons.usb, "pslab_board"),
+      _HardwareOption(
+          appLocalizations.internalSensors, Icons.developer_board, "internal_sensors"),
+    ];
+  }
+
+  Future<void> _selectHardware(String hardwareValue) async {
+    final boardProvider = getIt.get<BoardStateProvider>();
+    boardProvider.setHardware(hardwareValue);
+
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('selected_hardware', hardwareValue);
+
+    if (mounted) {
+      Navigator.pushReplacementNamed(context, '/');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MainScaffold(
+      index: 1,
+      title: appLocalizations.selectHardware,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Center(
+                child: Image.asset(
+                  'assets/icons/icon.png',
+                  height: 100,
+                  fit: BoxFit.contain,
+                ),
+              ),
+              const SizedBox(height: 40),
+              Text(
+                appLocalizations.selectHardwareQuestion,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+              const SizedBox(height: 32),
+              ..._options.map((option) => Padding(
+                    padding: const EdgeInsets.only(bottom: 16.0),
+                    child: ElevatedButton.icon(
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 20),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12)),
+                        backgroundColor: primaryRed,
+                      ),
+                      onPressed: () => _selectHardware(
+                          option.value),
+                      icon: Icon(option.icon, size: 28, color: chartTextColor,),
+                      label: Text(option.label,
+                          style: TextStyle(fontSize: 18, color: chartTextColor)),
+                    ),
+                  )),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/select_hardware.dart
+++ b/lib/view/select_hardware.dart
@@ -32,8 +32,8 @@ class _HardwareSelectionScreenState extends State<HardwareSelectionScreen> {
     super.initState();
     _options = [
       _HardwareOption(appLocalizations.psLabBoard, Icons.usb, "pslab_board"),
-      _HardwareOption(
-          appLocalizations.internalSensors, Icons.developer_board, "internal_sensors"),
+      _HardwareOption(appLocalizations.internalSensors, Icons.developer_board,
+          "internal_sensors"),
     ];
   }
 
@@ -86,11 +86,15 @@ class _HardwareSelectionScreenState extends State<HardwareSelectionScreen> {
                             borderRadius: BorderRadius.circular(12)),
                         backgroundColor: primaryRed,
                       ),
-                      onPressed: () => _selectHardware(
-                          option.value),
-                      icon: Icon(option.icon, size: 28, color: chartTextColor,),
+                      onPressed: () => _selectHardware(option.value),
+                      icon: Icon(
+                        option.icon,
+                        size: 28,
+                        color: chartTextColor,
+                      ),
                       label: Text(option.label,
-                          style: TextStyle(fontSize: 18, color: chartTextColor)),
+                          style:
+                              TextStyle(fontSize: 18, color: chartTextColor)),
                     ),
                   )),
             ],

--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/providers/board_state_provider.dart';
-
+import 'package:pslab/l10n/app_localizations.dart';
+import '../../providers/locator.dart';
 import '../../theme/colors.dart';
 import '../pin_layout_screen.dart';
 import 'navigation_drawer.dart';
@@ -41,6 +42,7 @@ class _MainScaffoldState extends State<MainScaffold>
   bool _isSearching = false;
   final TextEditingController _searchController = TextEditingController();
   late AnimationController _animationController;
+  AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
 
   @override
   void initState() {
@@ -196,6 +198,63 @@ class _MainScaffoldState extends State<MainScaffold>
                           );
                         }
                       },
+                    );
+                  },
+                ),
+                Consumer<BoardStateProvider>(
+                  builder: (context, provider, _) {
+                    return PopupMenuButton<String>(
+                      tooltip: appLocalizations.changeHardware,
+                      onSelected: (String value) {
+                        if (value == 'change') {
+                          Navigator.pushNamed(context, '/selectHardware');
+                        }
+                      },
+                      child: Container(
+                        alignment: Alignment.center,
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: Row(
+                          children: [
+                            Text(
+                              provider.selectedHardware == "pslab_board"
+                                  ? appLocalizations.psLab
+                                  : appLocalizations.internalSensors,
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 14,
+                              ),
+                            ),
+                            const Icon(Icons.arrow_drop_down,
+                                color: Colors.white),
+                          ],
+                        ),
+                      ),
+                      itemBuilder: (BuildContext context) =>
+                          <PopupMenuEntry<String>>[
+                        PopupMenuItem<String>(
+                          value: 'status',
+                          enabled: false,
+                          child: Text(
+                            provider.selectedHardware == "pslab_board"
+                                ? appLocalizations.psLab
+                                : appLocalizations.internalSensors,
+                            style: const TextStyle(
+                                fontSize: 12, color: Colors.grey),
+                          ),
+                        ),
+                        const PopupMenuDivider(),
+                        PopupMenuItem<String>(
+                          value: 'change',
+                          child: Row(
+                            children: [
+                              Icon(Icons.sync, color: Colors.black54),
+                              SizedBox(width: 8),
+                              Text(appLocalizations.changeHardware),
+                            ],
+                          ),
+                        ),
+                      ],
                     );
                   },
                 ),

--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -203,7 +203,8 @@ class _MainScaffoldState extends State<MainScaffold>
                 ),
                 Consumer<BoardStateProvider>(
                   builder: (context, provider, _) {
-                    return PopupMenuButton<String>(
+                    if(provider.selectedHardware != "") {
+                      return PopupMenuButton<String>(
                       tooltip: appLocalizations.changeHardware,
                       onSelected: (String value) {
                         if (value == 'change') {
@@ -256,6 +257,9 @@ class _MainScaffoldState extends State<MainScaffold>
                         ),
                       ],
                     );
+                    }else{
+                      return SizedBox.shrink();
+                    }
                   },
                 ),
                 PopupMenuButton<bool>(

--- a/lib/view/widgets/main_scaffold_widget.dart
+++ b/lib/view/widgets/main_scaffold_widget.dart
@@ -203,61 +203,61 @@ class _MainScaffoldState extends State<MainScaffold>
                 ),
                 Consumer<BoardStateProvider>(
                   builder: (context, provider, _) {
-                    if(provider.selectedHardware != "") {
+                    if (provider.selectedHardware != "") {
                       return PopupMenuButton<String>(
-                      tooltip: appLocalizations.changeHardware,
-                      onSelected: (String value) {
-                        if (value == 'change') {
-                          Navigator.pushNamed(context, '/selectHardware');
-                        }
-                      },
-                      child: Container(
-                        alignment: Alignment.center,
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        child: Row(
-                          children: [
-                            Text(
+                        tooltip: appLocalizations.changeHardware,
+                        onSelected: (String value) {
+                          if (value == 'change') {
+                            Navigator.pushNamed(context, '/selectHardware');
+                          }
+                        },
+                        child: Container(
+                          alignment: Alignment.center,
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          child: Row(
+                            children: [
+                              Text(
+                                provider.selectedHardware == "pslab_board"
+                                    ? appLocalizations.psLab
+                                    : appLocalizations.internalSensors,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 14,
+                                ),
+                              ),
+                              const Icon(Icons.arrow_drop_down,
+                                  color: Colors.white),
+                            ],
+                          ),
+                        ),
+                        itemBuilder: (BuildContext context) =>
+                            <PopupMenuEntry<String>>[
+                          PopupMenuItem<String>(
+                            value: 'status',
+                            enabled: false,
+                            child: Text(
                               provider.selectedHardware == "pslab_board"
                                   ? appLocalizations.psLab
                                   : appLocalizations.internalSensors,
                               style: const TextStyle(
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
-                                fontSize: 14,
-                              ),
+                                  fontSize: 12, color: Colors.grey),
                             ),
-                            const Icon(Icons.arrow_drop_down,
-                                color: Colors.white),
-                          ],
-                        ),
-                      ),
-                      itemBuilder: (BuildContext context) =>
-                          <PopupMenuEntry<String>>[
-                        PopupMenuItem<String>(
-                          value: 'status',
-                          enabled: false,
-                          child: Text(
-                            provider.selectedHardware == "pslab_board"
-                                ? appLocalizations.psLab
-                                : appLocalizations.internalSensors,
-                            style: const TextStyle(
-                                fontSize: 12, color: Colors.grey),
                           ),
-                        ),
-                        const PopupMenuDivider(),
-                        PopupMenuItem<String>(
-                          value: 'change',
-                          child: Row(
-                            children: [
-                              Icon(Icons.sync, color: Colors.black54),
-                              SizedBox(width: 8),
-                              Text(appLocalizations.changeHardware),
-                            ],
+                          const PopupMenuDivider(),
+                          PopupMenuItem<String>(
+                            value: 'change',
+                            child: Row(
+                              children: [
+                                Icon(Icons.sync, color: Colors.black54),
+                                SizedBox(width: 8),
+                                Text(appLocalizations.changeHardware),
+                              ],
+                            ),
                           ),
-                        ),
-                      ],
-                    );
-                    }else{
+                        ],
+                      );
+                    } else {
                       return SizedBox.shrink();
                     }
                   },


### PR DESCRIPTION
Fixes #3229

## Changes
- Added a new screen to choice the hardware
- Edit AppBar to change hardware in instruments screen
- Edit main to go in hardware choice screen if it was not already selected, in instruments otherwise
- Added strings variables in English only
- If we want to add or change which intruments we want to show we just need to edit instruments_screen.dart file

## Screenshots / Recordings
[Screencast From 2026-05-12 16-38-04.webm](https://github.com/user-attachments/assets/5fa9af3d-cc4b-4344-9fe5-3d59f750f0c1)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [ ] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [ ] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.