### PR TITLE
refactor: deduplicate save filename dialog across instrument screens

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -10,6 +10,8 @@ const multimeterScreenTitleKey = 'multimeter_screen_title';
 const waveGeneratorScreenTitleKey = 'wave_generator_screen_title';
 const oscilloscopeScreenTitleKey = 'oscilloscope_screen_title';
 
+const int kMaxFileNameLength = 200;
+
 AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
 
 List<String> instrumentIcons = [

--- a/lib/view/accelerometer_screen.dart
+++ b/lib/view/accelerometer_screen.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/providers/accelerometer_state_provider.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/accelerometer_card.dart';
@@ -173,38 +173,7 @@ class _AccelerometerScreenState extends State<AccelerometerScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/barometer_screen.dart
+++ b/lib/view/barometer_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'package:intl/intl.dart';
 import 'package:pslab/communication/peripherals/i2c.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:flutter/material.dart';
@@ -12,6 +11,7 @@ import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/barometer_card.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/view/logged_data_screen.dart';
 
@@ -208,38 +208,7 @@ class _BarometerScreenState extends State<BarometerScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(appLocalizations.barometer.toLowerCase(), data);

--- a/lib/view/compass_screen.dart
+++ b/lib/view/compass_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/view/logged_data_screen.dart';
 import 'package:pslab/view/compass_config_screen.dart';
 import '../l10n/app_localizations.dart';
@@ -172,38 +172,7 @@ class _CompassScreenContentState extends State<CompassScreenContent> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/gyroscope_screen.dart
+++ b/lib/view/gyroscope_screen.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/providers/gyroscope_config_provider.dart';
 import 'package:pslab/providers/gyroscope_state_provider.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/gyroscope_card.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/others/csv_service.dart';
@@ -164,38 +164,7 @@ class _GyroscopeScreenState extends State<GyroscopeScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(appLocalizations.gyroscope.toLowerCase(), data);

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/constants.dart';
@@ -14,6 +13,7 @@ import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/logic_analyzer_channel_selection.dart';
 import 'package:pslab/view/widgets/logic_analyzer_graph.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 
@@ -167,38 +167,7 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/luxmeter_screen.dart
+++ b/lib/view/luxmeter_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
@@ -11,6 +10,7 @@ import 'package:pslab/view/logged_data_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/luxmeter_card.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:pslab/view/luxmeter_config_screen.dart';
 import '../providers/experiment_provider.dart';
@@ -149,38 +149,7 @@ class _LuxMeterScreenState extends State<LuxMeterScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(appLocalizations.luxMeter.toLowerCase(), data);

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/l10n/app_localizations.dart';
@@ -13,6 +12,7 @@ import 'package:pslab/view/multimeter_config_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/multimeter_knob.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 
 class MultimeterScreen extends StatefulWidget {
   final String icRecord = 'assets/icons/ic_record_white.png';
@@ -206,38 +206,7 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/constants.dart';
@@ -18,6 +17,7 @@ import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/measurements_list.dart';
 import 'package:pslab/view/widgets/oscilloscope_graph.dart';
 import 'package:pslab/view/widgets/oscilloscope_screen_tabs.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/view/widgets/timebase_trigger_widget.dart';
 import 'package:pslab/view/widgets/xyplot_widget.dart';
 
@@ -266,38 +266,7 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/power_source_screen.dart
+++ b/lib/view/power_source_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
 import 'package:pslab/l10n/app_localizations.dart';
@@ -13,6 +12,7 @@ import 'package:pslab/view/power_source_config_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/power_source_knob.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 
 class PowerSourceScreen extends StatefulWidget {
   final String icRecord = 'assets/icons/ic_record_white.png';
@@ -178,38 +178,7 @@ class _PowerSourceScreenState extends State<PowerSourceScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/soundmeter_screen.dart
+++ b/lib/view/soundmeter_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
@@ -8,6 +7,7 @@ import 'package:pslab/view/soundmeter_config_screen.dart';
 import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
 import 'package:pslab/view/widgets/soundmeter_card.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:pslab/others/csv_service.dart';
 import 'package:pslab/view/logged_data_screen.dart';
@@ -136,38 +136,7 @@ class _SoundMeterScreenState extends State<SoundMeterScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/wave_generator_screen.dart
+++ b/lib/view/wave_generator_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/constants.dart';
@@ -15,6 +14,7 @@ import 'package:pslab/view/widgets/common_scaffold_widget.dart';
 import 'package:pslab/view/widgets/analog_waveform_controls.dart';
 import 'package:pslab/view/widgets/digital_waveform_controls.dart';
 import 'package:pslab/view/widgets/guide_widget.dart';
+import 'package:pslab/view/widgets/save_filename_dialog.dart';
 import 'package:pslab/view/widgets/wave_generator_graph.dart';
 import 'package:pslab/view/widgets/wave_generator_main_controls.dart';
 
@@ -89,38 +89,7 @@ class _WaveGeneratorScreenState extends State<WaveGeneratorScreen> {
   }
 
   Future<void> _showSaveFileDialog(List<List<dynamic>> data) async {
-    final TextEditingController filenameController = TextEditingController();
-    final String defaultFilename =
-        '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv';
-    filenameController.text = defaultFilename;
-
-    final String? fileName = await showDialog<String>(
-      context: context,
-      builder: (context) {
-        return AlertDialog(
-          title: Text(appLocalizations.saveRecording),
-          content: TextField(
-            controller: filenameController,
-            decoration: InputDecoration(
-              hintText: appLocalizations.enterFileName,
-              labelText: appLocalizations.fileName,
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(appLocalizations.cancel.toUpperCase()),
-            ),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pop(context, filenameController.text);
-              },
-              child: Text(appLocalizations.save),
-            ),
-          ],
-        );
-      },
-    );
+    final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
       _csvService.writeMetaData(

--- a/lib/view/widgets/save_filename_dialog.dart
+++ b/lib/view/widgets/save_filename_dialog.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:pslab/constants.dart';
+import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/providers/locator.dart';
+
+Future<String?> showSaveFileNameDialog(BuildContext context) {
+  final AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+  final TextEditingController filenameController = TextEditingController(
+    text: '${DateFormat('yyyy-MM-dd_HH-mm-ss').format(DateTime.now())}.csv',
+  );
+
+  return showDialog<String>(
+    context: context,
+    builder: (context) {
+      return AlertDialog(
+        title: Text(appLocalizations.saveRecording),
+        content: TextField(
+          controller: filenameController,
+          maxLength: kMaxFileNameLength,
+          decoration: InputDecoration(
+            hintText: appLocalizations.enterFileName,
+            labelText: appLocalizations.fileName,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(appLocalizations.cancel.toUpperCase()),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pop(context, filenameController.text.trim());
+            },
+            child: Text(appLocalizations.save),
+          ),
+        ],
+      );
+    },
+  );
+}


### PR DESCRIPTION
## Description 

This PR improves the way the "Save Recording" dialog works across different instrument screens.

Earlier, each screen had its own copy of the same dialog code, which made it repetitive and hard to maintain. This PR fixes that by moving the dialog into a single reusable helper so all screens use the same implementation.

It also introduces a shared constant for the filename length limit to ensure consistent behavior everywhere.

## Changes
- Added a reusable dialog:
  `lib/view/widgets/save_filename_dialog.dart`  
  → Handles filename input, trimming, and Save/Cancel actions

- Added a shared constant:
  `kMaxFileNameLength = 200` in `lib/constants.dart`

- Updated all instrument screens to use the shared dialog:
  - accelerometer
  - gyroscope
  - luxmeter
  - soundmeter
  - oscilloscope
  - barometer
  - compass
  - logic analyzer
  - multimeter
  - power source
  - wave generator

- Removed duplicated inline dialog implementations

## Screenshots / Recordings

> N/A (no UI change, behavior remains the same)

## Checklist

- [x] **No hard coding**: Used `kMaxFileNameLength` from constants
- [x] **No end of file edits**
- [x] **Code reformatting**: `dart format` applied
- [x] **Code analysis**: `flutter analyze` passes