### PR TITLE
feat(oscilloscope): add arrow navigation and Enter key play/pause support

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -271,6 +271,8 @@
     "dataAnalysis": "Data Analysis",
     "fourierAnalysis": "Fourier Analysis",
     "channels": "Channels",
+    "previousTab": "Previous tab",
+    "nextTab": "Next tab",
     "pslabMic": "PSLab MIC",
     "inBuiltMic": "In-Built MIC",
     "ch3Range": "CH3 (+/- 3.3V)",

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -48,6 +48,11 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void toggleRunning() {
+    isRunning = !isRunning;
+    notifyListeners();
+  }
+
   late int samples;
   late double timeGap;
   late double timebase;

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -309,178 +309,190 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
       ],
       child: Consumer<OscilloscopeStateProvider>(
         builder: (context, provider, _) {
-          return Stack(
-            children: [
-              CommonScaffold(
-                title: appLocalizations.oscilloscope,
-                key: const Key(oscilloscopeScreenTitleKey),
-                onOptionsPressed:
-                    provider.isPlayingBack ? null : _showOptionsMenu,
-                onGuidePressed: _showInstrumentGuide,
-                onRecordPressed:
-                    provider.isPlayingBack ? null : _toggleRecording,
-                isRecording: provider.isRecording,
-                isPlayingBack: provider.isPlayingBack,
-                isPlaybackPaused: provider.isPlaybackPaused,
-                onPlaybackPauseResume: provider.isPlayingBack
-                    ? (provider.isPlaybackPaused
-                        ? _provider.resumePlayback
-                        : _provider.pausePlayback)
-                    : null,
-                onPlaybackStop: provider.isPlayingBack
-                    ? () async {
-                        await _provider.stopPlayback();
-                      }
-                    : null,
-                body: SafeArea(
-                  minimum: const EdgeInsets.only(right: 0, bottom: 0),
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      return Container(
-                        margin: const EdgeInsets.only(left: 5, top: 5),
-                        child: widget.playbackData != null
-                            ? Container(
-                                margin:
-                                    const EdgeInsets.only(right: 5, bottom: 5),
-                                padding: const EdgeInsets.only(bottom: 20),
-                                color: Colors.black,
-                                child: OscilloscopeGraph(),
-                              )
-                            : Row(
-                                children: [
-                                  Expanded(
-                                    flex: 89,
-                                    child: Container(
-                                      margin: const EdgeInsets.only(right: 5),
-                                      child: Stack(
-                                        children: [
-                                          Column(
-                                            children: [
-                                              Expanded(
-                                                flex:
-                                                    constraints.maxHeight < 600
-                                                        ? 68
-                                                        : 80,
-                                                child: Container(
-                                                  padding:
-                                                      const EdgeInsets.only(
-                                                          bottom: 20),
-                                                  color: Colors.black,
-                                                  child:
-                                                      const OscilloscopeGraph(),
+          return Shortcuts(
+            shortcuts: const <ShortcutActivator, Intent>{
+              SingleActivator(LogicalKeyboardKey.enter):
+                  DoNothingAndStopPropagationIntent(),
+              SingleActivator(LogicalKeyboardKey.numpadEnter):
+                  DoNothingAndStopPropagationIntent(),
+              SingleActivator(LogicalKeyboardKey.arrowUp):
+                  DoNothingAndStopPropagationIntent(),
+              SingleActivator(LogicalKeyboardKey.arrowDown):
+                  DoNothingAndStopPropagationIntent(),
+            },
+            child: Stack(
+              children: [
+                CommonScaffold(
+                  title: appLocalizations.oscilloscope,
+                  key: const Key(oscilloscopeScreenTitleKey),
+                  onOptionsPressed:
+                      provider.isPlayingBack ? null : _showOptionsMenu,
+                  onGuidePressed: _showInstrumentGuide,
+                  onRecordPressed:
+                      provider.isPlayingBack ? null : _toggleRecording,
+                  isRecording: provider.isRecording,
+                  isPlayingBack: provider.isPlayingBack,
+                  isPlaybackPaused: provider.isPlaybackPaused,
+                  onPlaybackPauseResume: provider.isPlayingBack
+                      ? (provider.isPlaybackPaused
+                          ? _provider.resumePlayback
+                          : _provider.pausePlayback)
+                      : null,
+                  onPlaybackStop: provider.isPlayingBack
+                      ? () async {
+                          await _provider.stopPlayback();
+                        }
+                      : null,
+                  body: SafeArea(
+                    minimum: const EdgeInsets.only(right: 0, bottom: 0),
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        return Container(
+                          margin: const EdgeInsets.only(left: 5, top: 5),
+                          child: widget.playbackData != null
+                              ? Container(
+                                  margin: const EdgeInsets.only(
+                                      right: 5, bottom: 5),
+                                  padding: const EdgeInsets.only(bottom: 20),
+                                  color: Colors.black,
+                                  child: OscilloscopeGraph(),
+                                )
+                              : Row(
+                                  children: [
+                                    Expanded(
+                                      flex: 89,
+                                      child: Container(
+                                        margin: const EdgeInsets.only(right: 5),
+                                        child: Stack(
+                                          children: [
+                                            Column(
+                                              children: [
+                                                Expanded(
+                                                  flex: constraints.maxHeight <
+                                                          600
+                                                      ? 68
+                                                      : 80,
+                                                  child: Container(
+                                                    padding:
+                                                        const EdgeInsets.only(
+                                                            bottom: 20),
+                                                    color: Colors.black,
+                                                    child:
+                                                        const OscilloscopeGraph(),
+                                                  ),
                                                 ),
-                                              ),
-                                              Expanded(
-                                                flex:
-                                                    constraints.maxHeight < 600
-                                                        ? 32
-                                                        : 20,
-                                                child: Selector<
-                                                    OscilloscopeStateProvider,
-                                                    int>(
-                                                  selector: (context,
-                                                          provider) =>
-                                                      provider.selectedIndex,
-                                                  builder: (context,
-                                                      selectedIndex, _) {
-                                                    switch (selectedIndex) {
-                                                      case 0:
-                                                        return const ChannelParametersWidget();
-                                                      case 1:
-                                                        return const TimebaseTriggerWidget();
-                                                      case 2:
-                                                        return const DataAnalysisWidget();
-                                                      case 3:
-                                                        return const XYPlotWidget();
-                                                      default:
-                                                        return const ChannelParametersWidget();
-                                                    }
-                                                  },
+                                                Expanded(
+                                                  flex: constraints.maxHeight <
+                                                          600
+                                                      ? 32
+                                                      : 20,
+                                                  child: Selector<
+                                                      OscilloscopeStateProvider,
+                                                      int>(
+                                                    selector: (context,
+                                                            provider) =>
+                                                        provider.selectedIndex,
+                                                    builder: (context,
+                                                        selectedIndex, _) {
+                                                      switch (selectedIndex) {
+                                                        case 0:
+                                                          return const ChannelParametersWidget();
+                                                        case 1:
+                                                          return const TimebaseTriggerWidget();
+                                                        case 2:
+                                                          return const DataAnalysisWidget();
+                                                        case 3:
+                                                          return const XYPlotWidget();
+                                                        default:
+                                                          return const ChannelParametersWidget();
+                                                      }
+                                                    },
+                                                  ),
                                                 ),
-                                              ),
-                                            ],
-                                          ),
-                                          provider.isMeasurementsChecked
-                                              ? Positioned(
-                                                  right: 0,
-                                                  top: 0,
-                                                  child: SizedBox(
-                                                      width: 135,
-                                                      child: MeasurementsList(
-                                                          dataParamsChannels:
-                                                              provider
-                                                                  .dataParamsChannels)),
-                                                )
-                                              : const SizedBox.shrink(),
-                                        ],
+                                              ],
+                                            ),
+                                            provider.isMeasurementsChecked
+                                                ? Positioned(
+                                                    right: 0,
+                                                    top: 0,
+                                                    child: SizedBox(
+                                                        width: 135,
+                                                        child: MeasurementsList(
+                                                            dataParamsChannels:
+                                                                provider
+                                                                    .dataParamsChannels)),
+                                                  )
+                                                : const SizedBox.shrink(),
+                                          ],
+                                        ),
                                       ),
                                     ),
-                                  ),
-                                  const Expanded(
-                                    flex: 11,
-                                    child: OscilloscopeScreenTabs(),
-                                  )
-                                ],
-                              ),
-                      );
-                    },
-                  ),
-                ),
-                actions: [
-                  TextButton(
-                    onPressed: () {
-                      if ((((provider.isCH1Selected ||
-                                      provider.isCH2Selected ||
-                                      provider.isCH3Selected ||
-                                      provider.isMICSelected) &&
-                                  getIt<ScienceLab>().isConnected()) ||
-                              provider.isInBuiltMICSelected) &&
-                          !provider.autoScale()) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(appLocalizations.noSignal),
-                          ),
-                        );
-                      }
-                    },
-                    child: Text(appLocalizations.autoScale,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                        )),
-                  ),
-                  widget.playbackData == null
-                      ? IconButton(
-                          icon: provider.isRunning
-                              ? const Icon(
-                                  Icons.pause,
-                                  color: Colors.white,
-                                )
-                              : const Icon(
-                                  Icons.play_arrow,
-                                  color: Colors.white,
+                                    const Expanded(
+                                      flex: 11,
+                                      child: OscilloscopeScreenTabs(),
+                                    )
+                                  ],
                                 ),
-                          onPressed: () {
-                            if (provider.isRunning) {
-                              provider.isRunning = false;
-                            } else {
-                              provider.isRunning = true;
-                            }
-                            setState(
-                              () {},
-                            );
-                          },
-                        )
-                      : const SizedBox.shrink(),
-                ],
-              ),
-              if (_showGuide)
-                InstrumentOverviewDrawer(
-                  instrumentName: appLocalizations.oscilloscope,
-                  content: _getOscilloscopeContent(),
-                  onHide: _hideInstrumentGuide,
+                        );
+                      },
+                    ),
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () {
+                        if ((((provider.isCH1Selected ||
+                                        provider.isCH2Selected ||
+                                        provider.isCH3Selected ||
+                                        provider.isMICSelected) &&
+                                    getIt<ScienceLab>().isConnected()) ||
+                                provider.isInBuiltMICSelected) &&
+                            !provider.autoScale()) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text(appLocalizations.noSignal),
+                            ),
+                          );
+                        }
+                      },
+                      child: Text(appLocalizations.autoScale,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                          )),
+                    ),
+                    widget.playbackData == null
+                        ? IconButton(
+                            icon: provider.isRunning
+                                ? const Icon(
+                                    Icons.pause,
+                                    color: Colors.white,
+                                  )
+                                : const Icon(
+                                    Icons.play_arrow,
+                                    color: Colors.white,
+                                  ),
+                            onPressed: () {
+                              if (provider.isRunning) {
+                                provider.isRunning = false;
+                              } else {
+                                provider.isRunning = true;
+                              }
+                              setState(
+                                () {},
+                              );
+                            },
+                          )
+                        : const SizedBox.shrink(),
+                  ],
                 ),
-            ],
+                if (_showGuide)
+                  InstrumentOverviewDrawer(
+                    instrumentName: appLocalizations.oscilloscope,
+                    content: _getOscilloscopeContent(),
+                    onHide: _hideInstrumentGuide,
+                  ),
+              ],
+            ),
           );
         },
       ),

--- a/lib/view/widgets/oscilloscope_screen_tabs.dart
+++ b/lib/view/widgets/oscilloscope_screen_tabs.dart
@@ -36,6 +36,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
   }
 
   bool _handleKey(KeyEvent event) {
+    if (!mounted) return false;
     final BuildContext? focusContext =
         FocusManager.instance.primaryFocus?.context;
     if (focusContext != null && focusContext.widget is EditableText) {
@@ -80,15 +81,11 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
 
   void _cycleTab(OscilloscopeStateProvider provider, int delta) {
     final int next = (provider.selectedIndex + delta + _tabCount) % _tabCount;
-    setState(() {
-      provider.updateSelectedIndex(next);
-    });
+    provider.updateSelectedIndex(next);
   }
 
   void _selectTab(OscilloscopeStateProvider provider, int index) {
-    setState(() {
-      provider.updateSelectedIndex(index);
-    });
+    provider.updateSelectedIndex(index);
   }
 
   Border _tabBorder(OscilloscopeStateProvider provider, int index) {
@@ -135,7 +132,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
         children: [
           _arrowButton(
             icon: Icons.keyboard_arrow_up,
-            tooltip: 'Previous tab',
+            tooltip: appLocalizations.previousTab,
             onPressed: () => _cycleTab(oscilloscopeStateProvider, -1),
           ),
           Expanded(
@@ -334,7 +331,7 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
           ),
           _arrowButton(
             icon: Icons.keyboard_arrow_down,
-            tooltip: 'Next tab',
+            tooltip: appLocalizations.nextTab,
             onPressed: () => _cycleTab(oscilloscopeStateProvider, 1),
           ),
         ],

--- a/lib/view/widgets/oscilloscope_screen_tabs.dart
+++ b/lib/view/widgets/oscilloscope_screen_tabs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
@@ -19,6 +20,104 @@ class OscilloscopeScreenTabs extends StatefulWidget {
 
 class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
   AppLocalizations appLocalizations = getIt.get<AppLocalizations>();
+
+  static const int _tabCount = 4;
+
+  @override
+  void initState() {
+    super.initState();
+    HardwareKeyboard.instance.addHandler(_handleKey);
+  }
+
+  @override
+  void dispose() {
+    HardwareKeyboard.instance.removeHandler(_handleKey);
+    super.dispose();
+  }
+
+  bool _handleKey(KeyEvent event) {
+    final BuildContext? focusContext =
+        FocusManager.instance.primaryFocus?.context;
+    if (focusContext != null && focusContext.widget is EditableText) {
+      return false;
+    }
+    final bool isEnter = event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter;
+    final bool isArrow = event.logicalKey == LogicalKeyboardKey.arrowUp ||
+        event.logicalKey == LogicalKeyboardKey.arrowDown;
+    if (!isEnter && !isArrow) return false;
+
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return true;
+    }
+
+    final OscilloscopeStateProvider provider =
+        context.read<OscilloscopeStateProvider>();
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      _cycleTab(provider, -1);
+      return true;
+    }
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      _cycleTab(provider, 1);
+      return true;
+    }
+    if (isEnter) {
+      if (event is KeyRepeatEvent) return true;
+      FocusManager.instance.primaryFocus?.unfocus();
+      if (provider.isPlayingBack) {
+        if (provider.isPlaybackPaused) {
+          provider.resumePlayback();
+        } else {
+          provider.pausePlayback();
+        }
+      } else {
+        provider.toggleRunning();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  void _cycleTab(OscilloscopeStateProvider provider, int delta) {
+    final int next = (provider.selectedIndex + delta + _tabCount) % _tabCount;
+    setState(() {
+      provider.updateSelectedIndex(next);
+    });
+  }
+
+  void _selectTab(OscilloscopeStateProvider provider, int index) {
+    setState(() {
+      provider.updateSelectedIndex(index);
+    });
+  }
+
+  Border _tabBorder(OscilloscopeStateProvider provider, int index) {
+    return Border.all(
+      width: 1,
+      color: provider.selectedIndex == index
+          ? oscilloscopeOptionTitleColor
+          : Colors.transparent,
+    );
+  }
+
+  Widget _arrowButton({
+    required IconData icon,
+    required String tooltip,
+    required VoidCallback onPressed,
+  }) {
+    return SizedBox(
+      height: 24,
+      child: IconButton(
+        padding: EdgeInsets.zero,
+        iconSize: 18,
+        visualDensity: VisualDensity.compact,
+        tooltip: tooltip,
+        icon: Icon(icon, color: oscilloscopeOptionLabelColor),
+        onPressed: onPressed,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     OscilloscopeStateProvider oscilloscopeStateProvider =
@@ -34,92 +133,42 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
-          Expanded(
-            child: GestureDetector(
-              onTap: () {
-                setState(
-                  () {
-                    oscilloscopeStateProvider.updateSelectedIndex(0);
-                  },
-                );
-              },
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 4, horizontal: 8),
-                      decoration: BoxDecoration(
-                        color: oscilloscopeTabInnerBoxColor,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                      margin: const EdgeInsets.all(4),
-                      child: Image.asset(
-                        widget.channelParametersImage,
-                      ),
-                    ),
-                  ),
-                  Container(
-                    margin:
-                        const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
-                    color: oscilloscopeStateProvider.selectedIndex == 0
-                        ? oscilloscopeOptionTitleColor
-                        : Colors.transparent,
-                    child: Text(
-                      appLocalizations.channels,
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontSize: 9.5,
-                        fontStyle: FontStyle.normal,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                  Divider(
-                    color: oscilloscopeTabBorderColor,
-                    height: 2,
-                  )
-                ],
-              ),
-            ),
+          _arrowButton(
+            icon: Icons.keyboard_arrow_up,
+            tooltip: 'Previous tab',
+            onPressed: () => _cycleTab(oscilloscopeStateProvider, -1),
           ),
           Expanded(
-            child: GestureDetector(
-              onTap: () {
-                setState(
-                  () {
-                    oscilloscopeStateProvider.updateSelectedIndex(1);
-                  },
-                );
-              },
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 4, horizontal: 8),
-                      decoration: BoxDecoration(
-                        color: oscilloscopeTabInnerBoxColor,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                      margin: const EdgeInsets.all(4),
-                      child: Image.asset(
-                        widget.timebaseTriggerImage,
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => _selectTab(oscilloscopeStateProvider, 0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 8),
+                        decoration: BoxDecoration(
+                          color: oscilloscopeTabInnerBoxColor,
+                          borderRadius: BorderRadius.circular(2),
+                          border: _tabBorder(oscilloscopeStateProvider, 0),
+                        ),
+                        margin: const EdgeInsets.all(4),
+                        child: Image.asset(
+                          widget.channelParametersImage,
+                        ),
                       ),
                     ),
-                  ),
-                  Container(
+                    Container(
                       margin: const EdgeInsets.symmetric(
                           vertical: 4, horizontal: 2),
-                      color: oscilloscopeStateProvider.selectedIndex == 1
+                      color: oscilloscopeStateProvider.selectedIndex == 0
                           ? oscilloscopeOptionTitleColor
                           : Colors.transparent,
                       child: Text(
-                        appLocalizations.timeBase,
+                        appLocalizations.channels,
                         textAlign: TextAlign.center,
                         maxLines: 1,
                         style: TextStyle(
@@ -128,49 +177,146 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                           fontStyle: FontStyle.normal,
                           fontWeight: FontWeight.bold,
                         ),
-                      )),
-                  Divider(
-                    color: oscilloscopeTabBorderColor,
-                    height: 2,
-                  )
-                ],
+                      ),
+                    ),
+                    Divider(
+                      color: oscilloscopeTabBorderColor,
+                      height: 2,
+                    )
+                  ],
+                ),
               ),
             ),
           ),
           Expanded(
-            child: GestureDetector(
-              onTap: () {
-                setState(
-                  () {
-                    oscilloscopeStateProvider.updateSelectedIndex(2);
-                  },
-                );
-              },
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 4, horizontal: 8),
-                      decoration: BoxDecoration(
-                        color: oscilloscopeTabInnerBoxColor,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                      margin: const EdgeInsets.all(4),
-                      child: Image.asset(
-                        widget.dataAnalysisImage,
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => _selectTab(oscilloscopeStateProvider, 1),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 8),
+                        decoration: BoxDecoration(
+                          color: oscilloscopeTabInnerBoxColor,
+                          borderRadius: BorderRadius.circular(2),
+                          border: _tabBorder(oscilloscopeStateProvider, 1),
+                        ),
+                        margin: const EdgeInsets.all(4),
+                        child: Image.asset(
+                          widget.timebaseTriggerImage,
+                        ),
                       ),
                     ),
-                  ),
-                  Container(
+                    Container(
+                        margin: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 2),
+                        color: oscilloscopeStateProvider.selectedIndex == 1
+                            ? oscilloscopeOptionTitleColor
+                            : Colors.transparent,
+                        child: Text(
+                          appLocalizations.timeBase,
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                          style: TextStyle(
+                            color: oscilloscopeOptionLabelColor,
+                            fontSize: 9.5,
+                            fontStyle: FontStyle.normal,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        )),
+                    Divider(
+                      color: oscilloscopeTabBorderColor,
+                      height: 2,
+                    )
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => _selectTab(oscilloscopeStateProvider, 2),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 8),
+                        decoration: BoxDecoration(
+                          color: oscilloscopeTabInnerBoxColor,
+                          borderRadius: BorderRadius.circular(2),
+                          border: _tabBorder(oscilloscopeStateProvider, 2),
+                        ),
+                        margin: const EdgeInsets.all(4),
+                        child: Image.asset(
+                          widget.dataAnalysisImage,
+                        ),
+                      ),
+                    ),
+                    Container(
+                        margin: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 2),
+                        color: oscilloscopeStateProvider.selectedIndex == 2
+                            ? oscilloscopeOptionTitleColor
+                            : Colors.transparent,
+                        child: Text(
+                          appLocalizations.dataAnalysis,
+                          textAlign: TextAlign.center,
+                          maxLines: 1,
+                          style: TextStyle(
+                            color: oscilloscopeOptionLabelColor,
+                            fontSize: 9.5,
+                            fontStyle: FontStyle.normal,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        )),
+                    Divider(
+                      color: oscilloscopeTabBorderColor,
+                      height: 2,
+                    )
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Expanded(
+            child: MouseRegion(
+              cursor: SystemMouseCursors.click,
+              child: GestureDetector(
+                onTap: () => _selectTab(oscilloscopeStateProvider, 3),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Expanded(
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 8),
+                        decoration: BoxDecoration(
+                          color: oscilloscopeTabInnerBoxColor,
+                          borderRadius: BorderRadius.circular(2),
+                          border: _tabBorder(oscilloscopeStateProvider, 3),
+                        ),
+                        margin: const EdgeInsets.all(4),
+                        child: Image.asset(
+                          widget.xyPlotImage,
+                        ),
+                      ),
+                    ),
+                    Container(
                       margin: const EdgeInsets.symmetric(
                           vertical: 4, horizontal: 2),
-                      color: oscilloscopeStateProvider.selectedIndex == 2
+                      color: oscilloscopeStateProvider.selectedIndex == 3
                           ? oscilloscopeOptionTitleColor
                           : Colors.transparent,
                       child: Text(
-                        appLocalizations.dataAnalysis,
+                        appLocalizations.xyPlot,
                         textAlign: TextAlign.center,
                         maxLines: 1,
                         style: TextStyle(
@@ -179,62 +325,17 @@ class _OscilloscopeTabsState extends State<OscilloscopeScreenTabs> {
                           fontStyle: FontStyle.normal,
                           fontWeight: FontWeight.bold,
                         ),
-                      )),
-                  Divider(
-                    color: oscilloscopeTabBorderColor,
-                    height: 2,
-                  )
-                ],
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
-          Expanded(
-            child: GestureDetector(
-              onTap: () {
-                setState(
-                  () {
-                    oscilloscopeStateProvider.updateSelectedIndex(3);
-                  },
-                );
-              },
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Expanded(
-                    child: Container(
-                      padding: const EdgeInsets.symmetric(
-                          vertical: 4, horizontal: 8),
-                      decoration: BoxDecoration(
-                        color: oscilloscopeTabInnerBoxColor,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                      margin: const EdgeInsets.all(4),
-                      child: Image.asset(
-                        widget.xyPlotImage,
-                      ),
-                    ),
-                  ),
-                  Container(
-                    margin:
-                        const EdgeInsets.symmetric(vertical: 4, horizontal: 2),
-                    color: oscilloscopeStateProvider.selectedIndex == 3
-                        ? oscilloscopeOptionTitleColor
-                        : Colors.transparent,
-                    child: Text(
-                      appLocalizations.xyPlot,
-                      textAlign: TextAlign.center,
-                      maxLines: 1,
-                      style: TextStyle(
-                        color: oscilloscopeOptionLabelColor,
-                        fontSize: 9.5,
-                        fontStyle: FontStyle.normal,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
+          _arrowButton(
+            icon: Icons.keyboard_arrow_down,
+            tooltip: 'Next tab',
+            onPressed: () => _cycleTab(oscilloscopeStateProvider, 1),
           ),
         ],
       ),


### PR DESCRIPTION
Fixes #3253

## Changes
- Added Up and Down arrow buttons to move between the different Oscilloscope tabs.
- Users can now press the Up and Down arrow keys on the keyboard to switch tabs.
- The currently selected tab is highlighted with a thin red border so it is easier to identify.
- The mouse cursor changes to a pointer when hovering over tabs on desktop and web.
- Pressing Enter now starts or pauses data capture, and also pauses or resumes playback.
- Prevented Enter from accidentally triggering the back button in the app bar.
- Keyboard shortcuts are turned off while typing in text fields, so they do not interfere with text input.

## Screenshots / Recordings

https://github.com/user-attachments/assets/c38189b1-26bf-4410-9d41-ec887fe4f75a

**Checklist**:
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Enhance the Oscilloscope screen with keyboard- and button-based tab navigation and Enter key capture/playback control while preventing unintended keyboard interactions.

New Features:
- Add global keyboard handling on the Oscilloscope screen to switch tabs with Up/Down arrow keys and control capture/playback with the Enter key.
- Add on-screen Up/Down arrow buttons to move between Oscilloscope tabs.
- Highlight the selected Oscilloscope tab with a visible border and show a pointer cursor when hovering over tabs on desktop/web.
- Introduce a toggleRunning helper on OscilloscopeStateProvider to flip the running state and notify listeners.

Enhancements:
- Wrap the Oscilloscope screen content in a Shortcuts widget to stop Enter and arrow key events from propagating to the app bar and other ancestors.