### PR TITLE
feat: support printing app version via -v/--version CLI flag

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,15 +38,9 @@ import 'constants.dart';
 void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Handle `-v` / `--version` CLI flags on desktop: print the version and exit
-  // without launching the UI. Mobile platforms don't pass CLI args, so this
-  // branch is effectively desktop-only.
   if (!kIsWeb &&
       (Platform.isWindows || Platform.isLinux || Platform.isMacOS) &&
       args.any((a) => a == '-v' || a == '--version')) {
-    // Flutter on Windows builds a GUI-subsystem binary that has no attached
-    // console, so stdout writes are dropped when launched from a terminal.
-    // Attach to the parent process's console (if any) before printing.
     if (Platform.isWindows) {
       _attachParentConsole();
     }
@@ -181,8 +175,6 @@ class _LocaleAware extends StatelessWidget {
   }
 }
 
-// Attach the current (GUI-subsystem) process to its parent console on Windows
-// so that stdout from CLI flags like `--version` is visible in the terminal.
 void _attachParentConsole() {
   const attachParentProcess = 0xFFFFFFFF;
   final kernel32 = ffi.DynamicLibrary.open('kernel32.dll');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,11 @@
+import 'dart:ffi' as ffi;
+import 'dart:io';
+
 import 'package:pslab/providers/sht21_provider.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/board_state_provider.dart';
@@ -30,9 +35,28 @@ import 'package:pslab/view/wave_generator_screen.dart';
 import 'package:pslab/view/experiments_screen.dart';
 import 'constants.dart';
 
-void main() {
-  setupLocator();
+void main(List<String> args) async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Handle `-v` / `--version` CLI flags on desktop: print the version and exit
+  // without launching the UI. Mobile platforms don't pass CLI args, so this
+  // branch is effectively desktop-only.
+  if (!kIsWeb &&
+      (Platform.isWindows || Platform.isLinux || Platform.isMacOS) &&
+      args.any((a) => a == '-v' || a == '--version')) {
+    // Flutter on Windows builds a GUI-subsystem binary that has no attached
+    // console, so stdout writes are dropped when launched from a terminal.
+    // Attach to the parent process's console (if any) before printing.
+    if (Platform.isWindows) {
+      _attachParentConsole();
+    }
+    final info = await PackageInfo.fromPlatform();
+    stdout.writeln('${info.appName} ${info.version}+${info.buildNumber}');
+    await stdout.flush();
+    exit(0);
+  }
+
+  setupLocator();
   runApp(
     MultiProvider(
       providers: [
@@ -155,6 +179,16 @@ class _LocaleAware extends StatelessWidget {
       ),
     );
   }
+}
+
+// Attach the current (GUI-subsystem) process to its parent console on Windows
+// so that stdout from CLI flags like `--version` is visible in the terminal.
+void _attachParentConsole() {
+  const attachParentProcess = 0xFFFFFFFF;
+  final kernel32 = ffi.DynamicLibrary.open('kernel32.dll');
+  final attachConsole = kernel32.lookupFunction<ffi.Int32 Function(ffi.Uint32),
+      int Function(int)>('AttachConsole');
+  attachConsole(attachParentProcess);
 }
 
 void _preCacheImages(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,7 +266,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: "direct overridden"
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
@@ -1587,5 +1587,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.3 <4.0.0"
-  flutter: ">=3.41.5"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.9"

--- a/test_integration/screenshots.dart
+++ b/test_integration/screenshots.dart
@@ -19,7 +19,7 @@ void main() async {
 
   group('E2E Group', () {
     testWidgets('Take Screenshots', (tester) async {
-      app.main();
+      app.main([]);
       await tester.pumpAndSettle();
 
       final instrumentsScreenTitle =


### PR DESCRIPTION
Fixes #3242
## Changes

- Added support for `-v` and `--version` command line flags.
- Updated `main()` to accept command-line arguments.
- The app now prints the current PSLab version and exits immediately without launching the UI when version flags are used.
- Version information is fetched dynamically using `PackageInfo.fromPlatform()` so it always stays in sync with `pubspec.yaml`.
- Existing startup behavior remains unchanged when no arguments are provided.

## How to Test

### 1. Build the Windows app

```bash
flutter build windows
```
### 2. Test version flags

Go to:
```text
build\windows\x64\runner\Release\
```
Run:
```powershell
.\pslab.exe --version | Out-Host
.\pslab.exe -v        | Out-Host
```
Expected:
- Version is printed in the terminal
- App window does NOT open

> Note: `| Out-Host` is required in PowerShell because Flutter Windows builds are GUI-subsystem binaries (same behavior as VS Code and Electron apps).
### 3. Test normal app launch

Run:

```powershell
.\pslab.exe
```
Expected:
- PSLab launches normally

### 4. Test using Flutter
```bash
flutter run -d windows --dart-entrypoint-args="--version"
flutter run -d windows --dart-entrypoint-args="-v"
```
Expected:
- Version is printed
- App exits immediately without launching the UI

## Screenshots

<img width="944" height="377" alt="photo_2026-05-24_20-50-06" src="https://github.com/user-attachments/assets/0a5080fd-4a28-47c1-b98e-98c99fb75750" />

