### PR TITLE
fix: broken web build

### DIFF
--- a/lib/console_helper.dart
+++ b/lib/console_helper.dart
@@ -1,0 +1,9 @@
+import 'dart:ffi' as ffi;
+
+void attachParentConsole() {
+  const attachParentProcess = 0xFFFFFFFF;
+  final kernel32 = ffi.DynamicLibrary.open('kernel32.dll');
+  final attachConsole = kernel32.lookupFunction<ffi.Int32 Function(ffi.Uint32),
+      int Function(int)>('AttachConsole');
+  attachConsole(attachParentProcess);
+}

--- a/lib/console_helper_dummy.dart
+++ b/lib/console_helper_dummy.dart
@@ -1,0 +1,3 @@
+void attachParentConsole() {
+  throw Exception("Dummy method. This method should never be called.");
+}

--- a/lib/console_helper_dummy.dart
+++ b/lib/console_helper_dummy.dart
@@ -1,3 +1,4 @@
 void attachParentConsole() {
-  throw Exception("Dummy method. This method should never be called.");
+  throw UnsupportedError(
+      'attachParentConsole is not supported on this platform');
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:pslab/console_helper_dummy.dart'
-    if (dart.library.html) 'package:pslab/console_helper_dummy.dart'
     if (dart.library.io) 'package:pslab/console_helper.dart' as console_helper;
 
 import 'package:pslab/providers/sht21_provider.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,8 @@
-import 'dart:ffi' as ffi;
 import 'dart:io';
+
+import 'package:pslab/console_helper.dart'
+    if (dart.library.html) 'package:pslab/console_helper_dummy.dart'
+    if (dart.library.io) 'package:pslab/console_helper.dart' as console_helper;
 
 import 'package:pslab/providers/sht21_provider.dart';
 import 'package:flutter/foundation.dart';
@@ -42,7 +45,7 @@ void main(List<String> args) async {
       (Platform.isWindows || Platform.isLinux || Platform.isMacOS) &&
       args.any((a) => a == '-v' || a == '--version')) {
     if (Platform.isWindows) {
-      _attachParentConsole();
+      console_helper.attachParentConsole();
     }
     final info = await PackageInfo.fromPlatform();
     stdout.writeln('${info.appName} ${info.version}+${info.buildNumber}');
@@ -173,14 +176,6 @@ class _LocaleAware extends StatelessWidget {
       ),
     );
   }
-}
-
-void _attachParentConsole() {
-  const attachParentProcess = 0xFFFFFFFF;
-  final kernel32 = ffi.DynamicLibrary.open('kernel32.dll');
-  final attachConsole = kernel32.lookupFunction<ffi.Int32 Function(ffi.Uint32),
-      int Function(int)>('AttachConsole');
-  attachConsole(attachParentProcess);
 }
 
 void _preCacheImages(BuildContext context) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:pslab/console_helper.dart'
+import 'package:pslab/console_helper_dummy.dart'
     if (dart.library.html) 'package:pslab/console_helper_dummy.dart'
     if (dart.library.io) 'package:pslab/console_helper.dart' as console_helper;
 


### PR DESCRIPTION
Fixes #3259

## Changes
- moved Windows specific method which uses library which is not available in web version to extra file
- added dummy class which only exists to satisfy dependency in web version but should never be called
- replaced import of ffi with conditional import

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Fix the web build by isolating Windows-specific console attachment logic behind a platform-appropriate import.

Bug Fixes:
- Prevent web build failures by removing direct dart:ffi usage from the main entrypoint and using conditional imports instead.

Enhancements:
- Extract Windows console attachment into a dedicated helper module and introduce a dummy implementation for non-IO platforms to satisfy dependencies without runtime use.