### PR TITLE
chore: add web build

### DIFF
--- a/.github/actions/web/action.yml
+++ b/.github/actions/web/action.yml
@@ -1,0 +1,38 @@
+name: "Web App Workflow"
+
+inputs:
+  VERSION_NAME:
+    description: 'Version Name to be used for build'
+    required: false
+    default: '1.0.0'
+  VERSION_CODE:
+    description: 'Version Code to be used for build'
+    required: true
+    default: '1'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        cache: true
+        flutter-version-file: pubspec.yaml
+    
+    - name: Build Web App
+      shell: bash
+      run: |
+        flutter config --enable-web
+        flutter build web --build-name ${{ inputs.VERSION_NAME }} --build-number ${{ inputs.VERSION_CODE }}
+    
+    - name: Create Web Archive
+      shell: bash
+      run: |
+        cd build/web
+        zip -r ../pslab-web-app-${{ inputs.VERSION_NAME }}.zip .
+
+    - name: Store Archive
+      uses: actions/upload-artifact@v7
+      with:
+        name: pslab-web-app-${{ inputs.VERSION_NAME }}
+        path: build/pslab-web-app-${{ inputs.VERSION_NAME }}.zip

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - "/.github/actions/screenshot-android"
       - "/.github/actions/screenshot-ipad"
       - "/.github/actions/screenshot-iphone"
+      - "/.github/actions/web"
       - "/.github/actions/windows"
       - "/.github/workflows"
     schedule:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -169,6 +169,22 @@ jobs:
         if: needs.changes.outputs.is_code != 'true'
         run: echo "Non-code change detected."
 
+  web:
+    name: Web App Flutter Build
+    needs: [ changes, common ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.is_code == 'true'
+
+      - name: Web App Workflow
+        if: needs.changes.outputs.is_code == 'true'
+        uses: ./.github/actions/web
+
+      - name: Non-Code Change
+        if: needs.changes.outputs.is_code != 'true'
+        run: echo "Non-code change detected."
+
   windows:
     name: Windows Flutter Build
     needs: [ changes, common ]

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -165,6 +165,25 @@ jobs:
               exit 1
           fi
 
+  web:
+    name: Web App Flutter Build
+    needs: common
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Web App Workflow
+        uses: ./.github/actions/web
+        with:
+          VERSION_NAME: ${{needs.common.outputs.VERSION_NAME}}
+          VERSION_CODE: ${{needs.common.outputs.VERSION_CODE}}
+
+      - name: Upload Web App Archive
+        uses: actions/upload-artifact@v7
+        with:
+          name: Web App Archive
+          path: build/pslab-web-app-${{needs.common.outputs.VERSION_NAME }}.zip
+
   windows:
     name: Windows Flutter Build
     needs: common
@@ -247,7 +266,7 @@ jobs:
 
   publish-app-branch:
     name: Publish artifacts to app branch
-    needs: [android, windows, linux, linux-arm64, macos]
+    needs: [android, windows, linux, linux-arm64, macos, web]
     if: ${{ github.repository == 'fossasia/pslab-app' }}
     runs-on: ubuntu-latest
 
@@ -278,7 +297,7 @@ jobs:
 
           echo "Removing old artifacts"
 
-          find . -maxdepth 1 -type f \( -name '*.apk' -o -name '*.aab' -o -name '*.exe' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' \) -delete
+          find . -maxdepth 1 -type f \( -name '*.apk' -o -name '*.aab' -o -name '*.exe' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.zip' \) -delete
 
           echo "Copying new artifacts"
 
@@ -288,7 +307,8 @@ jobs:
             -name '*.exe' -o \
             -name '*.deb' -o \
             -name '*.rpm' -o \
-            -name '*.dmg' \
+            -name '*.dmg' -o \
+            -name '*.zip' \
           \) -exec cp -v {} . \;
 
           echo "Renaming Android artifacts"


### PR DESCRIPTION
Fixes #3105

## Changes
- add web build
- commit web app archive to app branch on merge

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add automated Flutter web app build and artifact publishing to CI workflows.

Build:
- Introduce a reusable composite GitHub Action for building and packaging the Flutter web app.
- Extend push and pull request workflows to run a Flutter web build job.
- Include generated web app ZIP archives alongside other platform artifacts when preparing release outputs.

CI:
- Gate the web build in the pull request workflow on code changes, mirroring existing platform build conditions.