### PR TITLE
fix: wrong base branch in Flutter upgrade check

### DIFF
--- a/.github/workflows/flutter_upgrade.yml
+++ b/.github/workflows/flutter_upgrade.yml
@@ -56,5 +56,5 @@ jobs:
 
           PR_URL=$(gh pr create --title "chore(deps): upgrade Flutter to ${{ env.latest_flutter_version }}" \
                        --body "This PR updates Flutter version in pubspec.yaml to the latest stable release." \
-                       --base flutter \
+                       --base main \
                        --head $BRANCH_NAME)


### PR DESCRIPTION
Fixes #3269

## Changes
- set base branch to `main` instead of `flutter` which was the old name of the branch.

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Fix automated Flutter upgrade PRs using the outdated `flutter` branch by switching the base branch to `main` in the workflow configuration.