### PR TITLE
feat(multimeter): add interactive desktop knob controls 

### DIFF
--- a/lib/providers/multimeter_state_provider.dart
+++ b/lib/providers/multimeter_state_provider.dart
@@ -116,6 +116,11 @@ class MultimeterStateProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void stepMode(int direction) {
+    final count = knobMarker.length;
+    setSelectedIndex((_selectedIndex + direction + count) % count);
+  }
+
   void setSwitch(bool checked) {
     isSwitchChecked = checked;
     if (isSwitchChecked) {

--- a/lib/view/multimeter_screen.dart
+++ b/lib/view/multimeter_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/constants.dart';
@@ -30,6 +31,21 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
   late MultimeterConfigProvider? _configProvider;
   final CsvService _csvService = CsvService();
   bool _showGuide = false;
+
+  double _scrollAccumulator = 0.0;
+  static const double _scrollThreshold = 50.0;
+
+  void _handleInstrumentScroll(
+    PointerSignalEvent event,
+    MultimeterStateProvider provider,
+  ) {
+    if (event is! PointerScrollEvent) return;
+    _scrollAccumulator += event.scrollDelta.dy;
+    if (_scrollAccumulator.abs() < _scrollThreshold) return;
+    final direction = _scrollAccumulator < 0 ? 1 : -1;
+    _scrollAccumulator = 0.0;
+    provider.stepMode(direction);
+  }
 
   void _hideInstrumentGuide() {
     setState(() {
@@ -275,225 +291,235 @@ class _MultimeterScreenState extends State<MultimeterScreen> {
                       }
                     : null,
                 body: SafeArea(
-                  child: LayoutBuilder(
-                    builder: (context, constraints) {
-                      return Column(
-                        children: [
-                          Expanded(
-                            flex: 23,
-                            child: Container(
-                              margin: const EdgeInsets.all(10),
-                              width: double.infinity,
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(4),
-                                border: Border.all(
-                                    width: 1, color: multimeterBorderLightRed),
-                              ),
-                              child: Column(
-                                children: [
-                                  Expanded(
-                                    flex: 75,
-                                    child: Container(
-                                      padding: const EdgeInsets.only(
-                                          right: 10, bottom: 10, left: 10),
-                                      alignment: Alignment.centerRight,
-                                      child: FittedBox(
-                                        fit: BoxFit.scaleDown,
+                  child: Listener(
+                    onPointerSignal: (event) =>
+                        _handleInstrumentScroll(event, provider),
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        return Column(
+                          children: [
+                            Expanded(
+                              flex: 23,
+                              child: Container(
+                                margin: const EdgeInsets.all(10),
+                                width: double.infinity,
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(4),
+                                  border: Border.all(
+                                      width: 1,
+                                      color: multimeterBorderLightRed),
+                                ),
+                                child: Column(
+                                  children: [
+                                    Expanded(
+                                      flex: 75,
+                                      child: Container(
+                                        padding: const EdgeInsets.only(
+                                            right: 10, bottom: 10, left: 10),
                                         alignment: Alignment.centerRight,
-                                        child: Text(
-                                          provider.value,
-                                          style: TextStyle(
-                                            fontSize: 50,
-                                            fontStyle: FontStyle.italic,
-                                            fontFamily: 'Digital-7',
-                                            color: multimeterBorderBlack,
+                                        child: FittedBox(
+                                          fit: BoxFit.scaleDown,
+                                          alignment: Alignment.centerRight,
+                                          child: Text(
+                                            provider.value,
+                                            style: TextStyle(
+                                              fontSize: 50,
+                                              fontStyle: FontStyle.italic,
+                                              fontFamily: 'Digital-7',
+                                              color: multimeterBorderBlack,
+                                            ),
                                           ),
                                         ),
                                       ),
                                     ),
-                                  ),
-                                  Divider(
-                                    height: 1,
-                                    color: multimeterDividerColor,
-                                  ),
-                                  Expanded(
-                                    flex: 25,
-                                    child: Container(
-                                      alignment: Alignment.center,
-                                      child: Text(
-                                        provider.unit,
-                                        style: TextStyle(
-                                          fontSize: 20,
+                                    Divider(
+                                      height: 1,
+                                      color: multimeterDividerColor,
+                                    ),
+                                    Expanded(
+                                      flex: 25,
+                                      child: Container(
+                                        alignment: Alignment.center,
+                                        child: Text(
+                                          provider.unit,
+                                          style: TextStyle(
+                                            fontSize: 20,
+                                          ),
                                         ),
                                       ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                            Expanded(
+                              flex: 77,
+                              child: Stack(
+                                children: [
+                                  Column(
+                                    children: [
+                                      Expanded(
+                                        flex: 47,
+                                        child: Container(
+                                          width: double.infinity,
+                                          margin: const EdgeInsets.symmetric(
+                                              horizontal: 10),
+                                          decoration: BoxDecoration(
+                                            borderRadius:
+                                                BorderRadius.circular(10.0),
+                                            border: Border.all(
+                                                width: 3,
+                                                color: multimeterBorderRed),
+                                          ),
+                                          child: Text(appLocalizations.voltage,
+                                              style: TextStyle(
+                                                  fontSize: 15,
+                                                  color: multimeterBorderRed,
+                                                  fontWeight: FontWeight.bold),
+                                              textAlign: TextAlign.center),
+                                        ),
+                                      ),
+                                      Expanded(
+                                        flex: 53,
+                                        child: Row(
+                                          children: [
+                                            Expanded(
+                                              flex: constraints.maxWidth < 600
+                                                  ? 67
+                                                  : (constraints.maxWidth >
+                                                          constraints.maxHeight
+                                                      ? 56
+                                                      : 63),
+                                              child: Container(
+                                                height: double.infinity,
+                                                margin: const EdgeInsets.only(
+                                                    top: 5,
+                                                    left: 10,
+                                                    right: 2,
+                                                    bottom: 10),
+                                                decoration: BoxDecoration(
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          10.0),
+                                                  border: Border.all(
+                                                      width: 3,
+                                                      color: Colors.black),
+                                                ),
+                                                child: Align(
+                                                  alignment:
+                                                      Alignment.bottomCenter,
+                                                  child: Row(
+                                                    mainAxisSize:
+                                                        MainAxisSize.max,
+                                                    mainAxisAlignment:
+                                                        MainAxisAlignment
+                                                            .center,
+                                                    children: [
+                                                      Text(
+                                                        appLocalizations.unitHz,
+                                                        style: TextStyle(
+                                                            fontSize: 15,
+                                                            color:
+                                                                multimeterBorderBlack,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                        textAlign:
+                                                            TextAlign.center,
+                                                      ),
+                                                      Transform.scale(
+                                                        scale: 0.75,
+                                                        child: Switch(
+                                                          activeThumbColor:
+                                                              multimeterBorderBlack,
+                                                          value: provider
+                                                              .isSwitchChecked,
+                                                          onChanged:
+                                                              (bool value) {
+                                                            provider.setSwitch(
+                                                                value);
+                                                          },
+                                                        ),
+                                                      ),
+                                                      Text(
+                                                        appLocalizations
+                                                            .countPulse,
+                                                        style: TextStyle(
+                                                            fontSize: 15,
+                                                            color:
+                                                                multimeterBorderBlack,
+                                                            fontWeight:
+                                                                FontWeight
+                                                                    .bold),
+                                                        textAlign:
+                                                            TextAlign.center,
+                                                      ),
+                                                    ],
+                                                  ),
+                                                ),
+                                              ),
+                                            ),
+                                            Expanded(
+                                              flex: constraints.maxWidth < 600
+                                                  ? 33
+                                                  : (constraints.maxWidth >
+                                                          constraints.maxHeight
+                                                      ? 44
+                                                      : 37),
+                                              child: Container(
+                                                height: double.infinity,
+                                                margin: const EdgeInsets.only(
+                                                    top: 5,
+                                                    left: 2,
+                                                    right: 10,
+                                                    bottom: 10),
+                                                decoration: BoxDecoration(
+                                                  borderRadius:
+                                                      BorderRadius.circular(
+                                                          10.0),
+                                                  border: Border.all(
+                                                      width: 3,
+                                                      color:
+                                                          multimeterBorderBlack),
+                                                ),
+                                                child: Align(
+                                                  alignment:
+                                                      Alignment.bottomCenter,
+                                                  child: Text(
+                                                      appLocalizations.measure,
+                                                      style: TextStyle(
+                                                          fontSize: 15,
+                                                          color:
+                                                              multimeterBorderBlack,
+                                                          fontWeight:
+                                                              FontWeight.bold),
+                                                      textAlign:
+                                                          TextAlign.center),
+                                                ),
+                                              ),
+                                            )
+                                          ],
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                  Positioned(
+                                    left: 0,
+                                    top: 0,
+                                    right: 0,
+                                    bottom: 0,
+                                    child: Align(
+                                      alignment: Alignment.center,
+                                      child: MultimeterKnob(),
                                     ),
                                   ),
                                 ],
                               ),
                             ),
-                          ),
-                          Expanded(
-                            flex: 77,
-                            child: Stack(
-                              children: [
-                                Column(
-                                  children: [
-                                    Expanded(
-                                      flex: 47,
-                                      child: Container(
-                                        width: double.infinity,
-                                        margin: const EdgeInsets.symmetric(
-                                            horizontal: 10),
-                                        decoration: BoxDecoration(
-                                          borderRadius:
-                                              BorderRadius.circular(10.0),
-                                          border: Border.all(
-                                              width: 3,
-                                              color: multimeterBorderRed),
-                                        ),
-                                        child: Text(appLocalizations.voltage,
-                                            style: TextStyle(
-                                                fontSize: 15,
-                                                color: multimeterBorderRed,
-                                                fontWeight: FontWeight.bold),
-                                            textAlign: TextAlign.center),
-                                      ),
-                                    ),
-                                    Expanded(
-                                      flex: 53,
-                                      child: Row(
-                                        children: [
-                                          Expanded(
-                                            flex: constraints.maxWidth < 600
-                                                ? 67
-                                                : (constraints.maxWidth >
-                                                        constraints.maxHeight
-                                                    ? 56
-                                                    : 63),
-                                            child: Container(
-                                              height: double.infinity,
-                                              margin: const EdgeInsets.only(
-                                                  top: 5,
-                                                  left: 10,
-                                                  right: 2,
-                                                  bottom: 10),
-                                              decoration: BoxDecoration(
-                                                borderRadius:
-                                                    BorderRadius.circular(10.0),
-                                                border: Border.all(
-                                                    width: 3,
-                                                    color: Colors.black),
-                                              ),
-                                              child: Align(
-                                                alignment:
-                                                    Alignment.bottomCenter,
-                                                child: Row(
-                                                  mainAxisSize:
-                                                      MainAxisSize.max,
-                                                  mainAxisAlignment:
-                                                      MainAxisAlignment.center,
-                                                  children: [
-                                                    Text(
-                                                      appLocalizations.unitHz,
-                                                      style: TextStyle(
-                                                          fontSize: 15,
-                                                          color:
-                                                              multimeterBorderBlack,
-                                                          fontWeight:
-                                                              FontWeight.bold),
-                                                      textAlign:
-                                                          TextAlign.center,
-                                                    ),
-                                                    Transform.scale(
-                                                      scale: 0.75,
-                                                      child: Switch(
-                                                        activeThumbColor:
-                                                            multimeterBorderBlack,
-                                                        value: provider
-                                                            .isSwitchChecked,
-                                                        onChanged:
-                                                            (bool value) {
-                                                          provider
-                                                              .setSwitch(value);
-                                                        },
-                                                      ),
-                                                    ),
-                                                    Text(
-                                                      appLocalizations
-                                                          .countPulse,
-                                                      style: TextStyle(
-                                                          fontSize: 15,
-                                                          color:
-                                                              multimeterBorderBlack,
-                                                          fontWeight:
-                                                              FontWeight.bold),
-                                                      textAlign:
-                                                          TextAlign.center,
-                                                    ),
-                                                  ],
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                          Expanded(
-                                            flex: constraints.maxWidth < 600
-                                                ? 33
-                                                : (constraints.maxWidth >
-                                                        constraints.maxHeight
-                                                    ? 44
-                                                    : 37),
-                                            child: Container(
-                                              height: double.infinity,
-                                              margin: const EdgeInsets.only(
-                                                  top: 5,
-                                                  left: 2,
-                                                  right: 10,
-                                                  bottom: 10),
-                                              decoration: BoxDecoration(
-                                                borderRadius:
-                                                    BorderRadius.circular(10.0),
-                                                border: Border.all(
-                                                    width: 3,
-                                                    color:
-                                                        multimeterBorderBlack),
-                                              ),
-                                              child: Align(
-                                                alignment:
-                                                    Alignment.bottomCenter,
-                                                child: Text(
-                                                    appLocalizations.measure,
-                                                    style: TextStyle(
-                                                        fontSize: 15,
-                                                        color:
-                                                            multimeterBorderBlack,
-                                                        fontWeight:
-                                                            FontWeight.bold),
-                                                    textAlign:
-                                                        TextAlign.center),
-                                              ),
-                                            ),
-                                          )
-                                        ],
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                Positioned(
-                                  left: 0,
-                                  top: 0,
-                                  right: 0,
-                                  bottom: 0,
-                                  child: Align(
-                                    alignment: Alignment.center,
-                                    child: MultimeterKnob(),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      );
-                    },
+                          ],
+                        );
+                      },
+                    ),
                   ),
                 ),
               ),

--- a/lib/view/widgets/multimeter_knob.dart
+++ b/lib/view/widgets/multimeter_knob.dart
@@ -1,6 +1,8 @@
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
@@ -23,9 +25,7 @@ class InnerDialPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    return false;
-  }
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }
 
 class InnerDialFillPainter extends CustomPainter {
@@ -103,6 +103,7 @@ class RadialLabelPainter extends CustomPainter {
   final List<String> labels;
   final List<Color> labelColors;
   final double radius;
+  final int selectedIndex;
   final TextStyle baseTextStyle;
   final double arcRadiusOffset;
   final double arcLength;
@@ -112,6 +113,7 @@ class RadialLabelPainter extends CustomPainter {
     required this.labels,
     required this.labelColors,
     required this.radius,
+    this.selectedIndex = -1,
     this.baseTextStyle = const TextStyle(
       fontWeight: FontWeight.bold,
       fontSize: 16,
@@ -125,6 +127,7 @@ class RadialLabelPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final center = Offset(size.width / 2, size.height / 2);
     final angleIncrement = 2 * pi / labels.length;
+    final baseFontSize = baseTextStyle.fontSize ?? 16;
 
     final textPainter = TextPainter(
       textAlign: TextAlign.center,
@@ -134,6 +137,7 @@ class RadialLabelPainter extends CustomPainter {
     for (int i = 0; i < labels.length; i++) {
       final angle = i * angleIncrement - pi / 2;
       final color = labelColors[i];
+      final isSelected = i == selectedIndex;
 
       final textOffset = Offset(
         center.dx + (radius + 20) * cos(angle),
@@ -142,7 +146,10 @@ class RadialLabelPainter extends CustomPainter {
 
       textPainter.text = TextSpan(
         text: labels[i],
-        style: baseTextStyle.copyWith(color: color),
+        style: baseTextStyle.copyWith(
+          color: color,
+          fontSize: isSelected ? baseFontSize * 1.1 : baseFontSize,
+        ),
       );
       textPainter.layout();
 
@@ -154,19 +161,27 @@ class RadialLabelPainter extends CustomPainter {
 
       final arcPaint = Paint()
         ..color = color
-        ..strokeWidth = arcStrokeWidth
+        ..strokeWidth = isSelected ? arcStrokeWidth * 1.4 : arcStrokeWidth
         ..style = PaintingStyle.stroke
         ..strokeCap = StrokeCap.round;
 
+      final arcSpan = isSelected ? arcLength * 1.5 : arcLength;
       final arcRadius = radius + arcRadiusOffset;
-      final arcStartAngle = angle - arcLength / 2;
+      final arcStartAngle = angle - arcSpan / 2;
       final arcRect = Rect.fromCircle(center: center, radius: arcRadius);
-      canvas.drawArc(arcRect, arcStartAngle, arcLength, false, arcPaint);
+      canvas.drawArc(arcRect, arcStartAngle, arcSpan, false, arcPaint);
     }
   }
 
   @override
-  bool shouldRepaint(CustomPainter oldDelegate) => false;
+  bool shouldRepaint(covariant RadialLabelPainter oldDelegate) =>
+      oldDelegate.selectedIndex != selectedIndex;
+}
+
+class _AdjustModeIntent extends Intent {
+  const _AdjustModeIntent(this.direction);
+
+  final int direction;
 }
 
 class MultimeterKnob extends StatefulWidget {
@@ -178,10 +193,24 @@ class MultimeterKnob extends StatefulWidget {
 }
 
 class _MultimeterKnobState extends State<MultimeterKnob> {
-  final double maxValue = 11.0;
-  bool isDragging = true;
+  static const int modeCount = 11;
+  final double maxValue = modeCount.toDouble();
+
+  static const double _plateDiameter = 300.0;
+
   AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
   late List<String> knobMarker;
+
+  final FocusNode _knobFocusNode = FocusNode();
+  bool _isDragging = false;
+  double _pointerTarget = 0.0;
+
+  bool get _isDesktopOrWeb =>
+      kIsWeb ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.linux ||
+      defaultTargetPlatform == TargetPlatform.macOS;
+
   @override
   void initState() {
     super.initState();
@@ -201,104 +230,169 @@ class _MultimeterKnobState extends State<MultimeterKnob> {
   }
 
   @override
-  Widget build(BuildContext context) {
-    MultimeterStateProvider multimeterStateProvider =
-        Provider.of<MultimeterStateProvider>(context, listen: false);
+  void dispose() {
+    _knobFocusNode.dispose();
+    super.dispose();
+  }
 
-    void updateSelectedIndex(double angle) {
-      const startAngle = -pi / 2;
-      const totalAngle = 2 * pi;
+  void _changeMode(int direction) {
+    final provider = context.read<MultimeterStateProvider>();
+    final nextIndex =
+        (provider.getSelectedIndex() + direction + modeCount) % modeCount;
+    provider.setSelectedIndex(nextIndex);
+  }
 
-      final angleNormalized = (angle - startAngle + totalAngle) % totalAngle;
+  double _nearestEquivalent(double current, int index) {
+    final turns = ((current - index) / modeCount).roundToDouble();
+    return index + turns * modeCount;
+  }
 
-      final numSections = maxValue;
-      final anglePerSection = totalAngle / numSections;
+  void _selectFromGlobal(Offset globalPosition) {
+    final renderBox = context.findRenderObject() as RenderBox;
+    final localPosition = renderBox.globalToLocal(globalPosition);
+    _updateAngle(localPosition, renderBox.size);
+  }
 
-      final section = (angleNormalized / anglePerSection).round();
+  void _updateAngle(Offset position, Size size) {
+    final center = Offset(size.width / 2, size.height / 2);
+    final dx = position.dx - center.dx;
+    final dy = position.dy - center.dy;
+    final distanceFromCenter = sqrt(dx * dx + dy * dy);
 
-      final clampedSection = section.clamp(0, numSections - 1);
+    if (distanceFromCenter > (_plateDiameter / 2).r) return;
 
-      setState(() {
-        multimeterStateProvider.setSelectedIndex(clampedSection.toInt());
-      });
+    var angle = atan2(dy, dx);
+    if (angle < 0) {
+      angle += 2 * pi;
     }
 
-    void updateAngle(Offset position, Size size) {
-      if (!isDragging) return;
+    const startAngle = -pi / 2;
+    const totalAngle = 2 * pi;
+    final angleNormalized = (angle - startAngle + totalAngle) % totalAngle;
+    final anglePerSection = totalAngle / modeCount;
+    final section =
+        (angleNormalized / anglePerSection).round().clamp(0, modeCount - 1);
 
-      final center = Offset(size.width / 2, size.height / 2);
-      final dx = position.dx - center.dx;
-      final dy = position.dy - center.dy;
-      final distanceFromCenter = sqrt(dx * dx + dy * dy);
+    context.read<MultimeterStateProvider>().setSelectedIndex(section);
+  }
 
-      if (distanceFromCenter > size.width / 2) return;
+  void _setDragging(bool value) {
+    if (_isDragging == value) return;
+    setState(() => _isDragging = value);
+  }
 
-      var angle = atan2(dy, dx);
-      if (angle < 0) {
-        angle += 2 * pi;
-      }
-
-      setState(() {
-        updateSelectedIndex(angle);
-      });
-    }
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Stack(
-          alignment: Alignment.center,
-          children: [
-            CustomPaint(
-              painter: InnerDialFillPainter(),
+  Widget _buildDial() {
+    return GestureDetector(
+      onTapDown: (details) {
+        _knobFocusNode.requestFocus();
+        _selectFromGlobal(details.globalPosition);
+      },
+      onPanStart: (_) => _setDragging(true),
+      onPanUpdate: (details) => _selectFromGlobal(details.globalPosition),
+      onPanEnd: (_) => _setDragging(false),
+      onPanCancel: () => _setDragging(false),
+      child: Stack(
+        alignment: Alignment.center,
+        clipBehavior: Clip.none,
+        children: [
+          CustomPaint(
+            painter: InnerDialFillPainter(),
+            child: SizedBox(
+              width: 300.w,
+              height: 300.h,
+            ),
+          ),
+          Selector<MultimeterStateProvider, int>(
+            selector: (_, provider) => provider.getSelectedIndex(),
+            builder: (_, selectedIndex, __) {
+              _pointerTarget =
+                  _nearestEquivalent(_pointerTarget, selectedIndex);
+              return TweenAnimationBuilder<double>(
+                tween: Tween<double>(end: _pointerTarget),
+                duration: _isDragging
+                    ? Duration.zero
+                    : const Duration(milliseconds: 220),
+                curve: Curves.easeOutCubic,
+                builder: (_, value, __) => CustomPaint(
+                  painter: InnerPointerPainter(
+                    value: value,
+                    max: maxValue,
+                    color: pointerColor,
+                  ),
+                  child: SizedBox(
+                    width: 300.w,
+                    height: 300.h,
+                  ),
+                ),
+              );
+            },
+          ),
+          IgnorePointer(
+            ignoring: true,
+            child: CustomPaint(
+              painter: InnerDialPainter(),
               child: SizedBox(
-                width: 300.w,
                 height: 300.h,
+                width: 300.w,
               ),
             ),
-            GestureDetector(
-              onPanUpdate: (details) {
-                if (isDragging) {
-                  RenderBox renderBox = context.findRenderObject() as RenderBox;
-                  Offset localPosition =
-                      renderBox.globalToLocal(details.globalPosition);
-                  updateAngle(localPosition, renderBox.size);
-                }
-              },
-              child: CustomPaint(
-                painter: InnerPointerPainter(
-                  value: multimeterStateProvider.getSelectedIndex().toDouble(),
-                  max: maxValue,
-                  color: pointerColor,
-                ),
-                child: SizedBox(
-                  width: 300.w,
-                  height: 300.h,
-                ),
-              ),
-            ),
-            IgnorePointer(
-              ignoring: true,
-              child: CustomPaint(
-                painter: InnerDialPainter(),
-                child: SizedBox(
-                  height: 300.h,
-                  width: 300.w,
-                ),
-              ),
-            ),
-            IgnorePointer(
-              ignoring: true,
-              child: CustomPaint(
+          ),
+          IgnorePointer(
+            ignoring: true,
+            child: Selector<MultimeterStateProvider, int>(
+              selector: (_, provider) => provider.getSelectedIndex(),
+              builder: (_, selectedIndex, __) => CustomPaint(
                 painter: RadialLabelPainter(
                   labels: knobMarker,
                   labelColors: knobLabelColors,
                   radius: 112.r,
+                  selectedIndex: selectedIndex,
                 ),
               ),
-            )
-          ],
-        );
-      },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_isDesktopOrWeb) return _buildDial();
+
+    return Selector<MultimeterStateProvider, int>(
+      selector: (_, provider) => provider.getSelectedIndex(),
+      builder: (context, selectedIndex, child) => Semantics(
+        container: true,
+        value: knobMarker[selectedIndex],
+        increasedValue: knobMarker[(selectedIndex + 1) % knobMarker.length],
+        decreasedValue: knobMarker[
+            (selectedIndex - 1 + knobMarker.length) % knobMarker.length],
+        onIncrease: () => _changeMode(1),
+        onDecrease: () => _changeMode(-1),
+        child: child,
+      ),
+      child: FocusableActionDetector(
+        mouseCursor:
+            _isDragging ? SystemMouseCursors.grabbing : SystemMouseCursors.grab,
+        shortcuts: const <ShortcutActivator, Intent>{
+          SingleActivator(LogicalKeyboardKey.arrowUp): _AdjustModeIntent(1),
+          SingleActivator(LogicalKeyboardKey.arrowRight): _AdjustModeIntent(1),
+          SingleActivator(LogicalKeyboardKey.arrowDown): _AdjustModeIntent(-1),
+          SingleActivator(LogicalKeyboardKey.arrowLeft): _AdjustModeIntent(-1),
+        },
+        actions: <Type, Action<Intent>>{
+          _AdjustModeIntent: CallbackAction<_AdjustModeIntent>(
+            onInvoke: (intent) {
+              _changeMode(intent.direction);
+              return null;
+            },
+          ),
+        },
+        focusNode: _knobFocusNode,
+        autofocus: true,
+        child: _buildDial(),
+      ),
     );
   }
 }


### PR DESCRIPTION
Fixes #3274

## Changes

Improved the Multimeter knob experience on desktop/web.

- Added mouse wheel support to switch between modes.
- Added click support to directly select a mode.
- Kept drag-to-rotate functionality and limited it to the knob area.
- Added keyboard navigation using arrow keys.
- Added accessibility support for screen readers.
- Added smooth pointer animation when changing modes.
- Added grab/grabbing cursor feedback on the knob for desktop.
- Highlighted the currently selected mode for better visibility.

Desktop-specific features are enabled only on desktop/web platforms. Touch devices continue to use tap and drag interactions as before.

## Recordings

https://github.com/user-attachments/assets/065d1baf-6085-41fc-ab43-06ba51949811





