### PR TITLE
fix: highlight FAQ item when FAQ screen is active

### DIFF
--- a/lib/view/faq_screen.dart
+++ b/lib/view/faq_screen.dart
@@ -57,7 +57,7 @@ class FAQScreen extends StatelessWidget {
     ];
     return MainScaffold(
       title: appLocalizations.faqTitle,
-      index: 6,
+      index: 9,
       body: ListView.separated(
         padding: const EdgeInsets.symmetric(vertical: 8),
         itemCount: faqs.length,


### PR DESCRIPTION
Fixes  #3277

## Changes
Updated the sidebar logic to highlight the FAQ menu item when the FAQ page is active.

## Screenshots / Recordings
Before:

https://github.com/user-attachments/assets/e8769d21-df7a-40b0-bca4-76cfd82bf8e0


After:

https://github.com/user-attachments/assets/6b86ae42-3ccf-4376-af6c-772e36beb291



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Correct the navigation index used by the FAQ screen so the corresponding sidebar item is selected.