### PR TITLE
chore: resolve Windows CI failures

### DIFF
--- a/android/app/src/main/java/io/pslab/MainActivity.java
+++ b/android/app/src/main/java/io/pslab/MainActivity.java
@@ -1,6 +1,8 @@
 package io.pslab;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
@@ -9,6 +11,8 @@ import android.os.Bundle;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
@@ -19,10 +23,15 @@ import io.flutter.plugin.common.MethodChannel;
 public class MainActivity extends FlutterActivity implements SensorEventListener {
     private static final String TEMPERATURE_CHANNEL = "io.pslab/temperature";
     private static final String TEMPERATURE_STREAM = "io.pslab/temperature_stream";
+    private static final String PERMISSION_CHANNEL = "io.pslab/permissions";
     private static final String TAG = "MainActivity";
+    private static final int PERMISSION_REQ_CODE = 1001;
+
     private SensorManager sensorManager;
     private Sensor temperatureSensor;
     private EventChannel.EventSink temperatureEventSink;
+    private MethodChannel.Result pendingPermissionResult;
+
     private boolean isListening = false;
     private float currentTemperature = 0.0f;
 
@@ -52,6 +61,9 @@ public class MainActivity extends FlutterActivity implements SensorEventListener
                 stopTemperatureUpdates();
             }
         });
+
+        MethodChannel permissionChannel = new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), PERMISSION_CHANNEL);
+        permissionChannel.setMethodCallHandler(this::handlePermissionMethodCall);
     }
 
     private void handleMethodCall(MethodCall call, MethodChannel.Result result) {
@@ -76,6 +88,68 @@ public class MainActivity extends FlutterActivity implements SensorEventListener
             default:
                 result.notImplemented();
                 break;
+        }
+    }
+
+    private void handlePermissionMethodCall(MethodCall call, @NonNull MethodChannel.Result result) {
+        String permissionArg = call.argument("permission");
+        String manifestPermission = getManifestPermission(permissionArg);
+
+        if (manifestPermission == null) {
+            result.error("INVALID", "Unknown permission requested", null);
+            return;
+        }
+
+        if ("checkStatus".equals(call.method)) {
+            result.success(getPermissionStatusString(manifestPermission));
+        } else if ("request".equals(call.method)) {
+            if ("granted".equals(getPermissionStatusString(manifestPermission))) {
+                result.success("granted");
+            } else {
+                pendingPermissionResult = result;
+                ActivityCompat.requestPermissions(this, new String[]{manifestPermission}, PERMISSION_REQ_CODE);
+            }
+        } else {
+            result.notImplemented();
+        }
+    }
+
+    private String getManifestPermission(String dartName) {
+        if ("microphone".equals(dartName)) {
+            return Manifest.permission.RECORD_AUDIO;
+        } else if ("location".equals(dartName)) {
+            return Manifest.permission.ACCESS_FINE_LOCATION;
+        }
+        return null;
+    }
+
+    private String getPermissionStatusString(String permission) {
+        if (ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED) {
+            return "granted";
+        }
+        boolean shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(this, permission);
+        if (!shouldShowRationale) {
+            return "permanentlyDenied";
+        }
+        return "denied";
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        if (requestCode == PERMISSION_REQ_CODE && pendingPermissionResult != null) {
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                pendingPermissionResult.success("granted");
+            } else {
+                if (permissions.length > 0) {
+                    boolean shouldShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(this, permissions[0]);
+                    pendingPermissionResult.success(shouldShowRationale ? "denied" : "permanentlyDenied");
+                } else {
+                    pendingPermissionResult.success("denied");
+                }
+            }
+            pendingPermissionResult = null;
         }
     }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -22,7 +22,7 @@ import CoreLocation
             binaryMessenger: controller.binaryMessenger
         )
 
-        permissionChannel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
+        permissionChannel.setMethodCallHandler { [weak self] call, result in
             guard let args = call.arguments as? [String: Any],
                   let permission = args["permission"] as? String else {
                 result(FlutterError(code: "INVALID_ARGS", message: "Missing permission argument", details: nil))
@@ -41,7 +41,6 @@ import CoreLocation
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
-
 
     private func handleCheckStatus(permission: String, result: @escaping FlutterResult) {
         if permission == "microphone" {

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -13,13 +13,16 @@ import CoreLocation
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
-        let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
+        guard let controller: FlutterViewController = window?.rootViewController as? FlutterViewController else {
+            return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+        }
+
         let permissionChannel = FlutterMethodChannel(
             name: "io.pslab/permissions",
             binaryMessenger: controller.binaryMessenger
         )
 
-        permissionChannel.setMethodCallHandler({ [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+        permissionChannel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
             guard let args = call.arguments as? [String: Any],
                   let permission = args["permission"] as? String else {
                 result(FlutterError(code: "INVALID_ARGS", message: "Missing permission argument", details: nil))
@@ -33,78 +36,90 @@ import CoreLocation
             } else {
                 result(FlutterMethodNotImplemented)
             }
-        })
+        }
 
         GeneratedPluginRegistrant.register(with: self)
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 
+
     private func handleCheckStatus(permission: String, result: @escaping FlutterResult) {
         if permission == "microphone" {
-            switch AVCaptureDevice.authorizationStatus(for: .audio) {
-            case .authorized:
-                result("granted")
-            case .denied, .restricted:
-                result("permanentlyDenied")
-            case .notDetermined:
-                result("denied")
-            @unknown default:
-                result("denied")
-            }
+            checkMicrophoneStatus(result: result)
         } else if permission == "location" {
-            let status: CLAuthorizationStatus
-            if #available(iOS 14.0, *) {
-                status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
-            } else {
-                status = CLLocationManager.authorizationStatus()
-            }
-
-            switch status {
-            case .authorizedAlways, .authorizedWhenInUse:
-                result("granted")
-            case .denied, .restricted:
-                result("permanentlyDenied")
-            case .notDetermined:
-                result("denied")
-            @unknown default:
-                result("denied")
-            }
+            checkLocationStatus(result: result)
         } else {
-            result(FlutterError(code: "UNKNOWN_PERMISSION", message: "Unknown permission type", details: nil))
+            result(FlutterError(code: "UNKNOWN", message: "Unknown permission", details: nil))
+        }
+    }
+
+    private func checkMicrophoneStatus(result: @escaping FlutterResult) {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized: result("granted")
+        case .denied, .restricted: result("permanentlyDenied")
+        case .notDetermined: result("denied")
+        @unknown default: result("denied")
+        }
+    }
+
+    private func checkLocationStatus(result: @escaping FlutterResult) {
+        let status: CLAuthorizationStatus
+        if #available(iOS 14.0, *) {
+            status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+        } else {
+            status = CLLocationManager.authorizationStatus()
+        }
+
+        switch status {
+        case .authorizedAlways, .authorizedWhenInUse: result("granted")
+        case .denied, .restricted: result("permanentlyDenied")
+        case .notDetermined: result("denied")
+        @unknown default: result("denied")
         }
     }
 
     private func handleRequest(permission: String, result: @escaping FlutterResult) {
         if permission == "microphone" {
-            AVCaptureDevice.requestAccess(for: .audio) { granted in
-                DispatchQueue.main.async {
-                    result(granted ? "granted" : "permanentlyDenied")
-                }
-            }
+            requestMicrophone(result: result)
         } else if permission == "location" {
-            let status: CLAuthorizationStatus
-            if #available(iOS 14.0, *) {
-                status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
-            } else {
-                status = CLLocationManager.authorizationStatus()
-            }
-
-            if status == .authorizedWhenInUse || status == .authorizedAlways {
-                result("granted")
-                return
-            } else if status == .denied || status == .restricted {
-                result("permanentlyDenied")
-                return
-            }
-
-            self.pendingPermissionResult = result
-            if self.locationManager == nil {
-                self.locationManager = CLLocationManager()
-                self.locationManager?.delegate = self
-            }
-            self.locationManager?.requestWhenInUseAuthorization()
+            requestLocation(result: result)
+        } else {
+            result(FlutterError(code: "UNKNOWN", message: "Unknown permission", details: nil))
         }
     }
+
+    private func requestMicrophone(result: @escaping FlutterResult) {
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            DispatchQueue.main.async {
+                result(granted ? "granted" : "permanentlyDenied")
+            }
+        }
+    }
+
+    private func requestLocation(result: @escaping FlutterResult) {
+        let status: CLAuthorizationStatus
+        if #available(iOS 14.0, *) {
+            status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+        } else {
+            status = CLLocationManager.authorizationStatus()
+        }
+
+        if status == .authorizedWhenInUse || status == .authorizedAlways {
+            result("granted")
+            return
+        } else if status == .denied || status == .restricted {
+            result("permanentlyDenied")
+            return
+        }
+
+        self.pendingPermissionResult = result
+        if self.locationManager == nil {
+            self.locationManager = CLLocationManager()
+            self.locationManager?.delegate = self
+        }
+        self.locationManager?.requestWhenInUseAuthorization()
+    }
+
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         guard let result = pendingPermissionResult else { return }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,13 +1,117 @@
-import Flutter
 import UIKit
+import Flutter
+import AVFoundation
+import CoreLocation
 
 @main
-@objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+@objc class AppDelegate: FlutterAppDelegate, CLLocationManagerDelegate {
+
+    private var pendingPermissionResult: FlutterResult?
+    private var locationManager: CLLocationManager?
+
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+    ) -> Bool {
+        let controller : FlutterViewController = window?.rootViewController as! FlutterViewController
+        let permissionChannel = FlutterMethodChannel(
+            name: "io.pslab/permissions",
+            binaryMessenger: controller.binaryMessenger
+        )
+
+        permissionChannel.setMethodCallHandler({ [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+            guard let args = call.arguments as? [String: Any],
+                  let permission = args["permission"] as? String else {
+                result(FlutterError(code: "INVALID_ARGS", message: "Missing permission argument", details: nil))
+                return
+            }
+
+            if call.method == "checkStatus" {
+                self?.handleCheckStatus(permission: permission, result: result)
+            } else if call.method == "request" {
+                self?.handleRequest(permission: permission, result: result)
+            } else {
+                result(FlutterMethodNotImplemented)
+            }
+        })
+
+        GeneratedPluginRegistrant.register(with: self)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+
+    private func handleCheckStatus(permission: String, result: @escaping FlutterResult) {
+        if permission == "microphone" {
+            switch AVCaptureDevice.authorizationStatus(for: .audio) {
+            case .authorized:
+                result("granted")
+            case .denied, .restricted:
+                result("permanentlyDenied")
+            case .notDetermined:
+                result("denied")
+            @unknown default:
+                result("denied")
+            }
+        } else if permission == "location" {
+            let status: CLAuthorizationStatus
+            if #available(iOS 14.0, *) {
+                status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+            } else {
+                status = CLLocationManager.authorizationStatus()
+            }
+
+            switch status {
+            case .authorizedAlways, .authorizedWhenInUse:
+                result("granted")
+            case .denied, .restricted:
+                result("permanentlyDenied")
+            case .notDetermined:
+                result("denied")
+            @unknown default:
+                result("denied")
+            }
+        } else {
+            result(FlutterError(code: "UNKNOWN_PERMISSION", message: "Unknown permission type", details: nil))
+        }
+    }
+
+    private func handleRequest(permission: String, result: @escaping FlutterResult) {
+        if permission == "microphone" {
+            AVCaptureDevice.requestAccess(for: .audio) { granted in
+                DispatchQueue.main.async {
+                    result(granted ? "granted" : "permanentlyDenied")
+                }
+            }
+        } else if permission == "location" {
+            let status: CLAuthorizationStatus
+            if #available(iOS 14.0, *) {
+                status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+            } else {
+                status = CLLocationManager.authorizationStatus()
+            }
+
+            if status == .authorizedWhenInUse || status == .authorizedAlways {
+                result("granted")
+                return
+            } else if status == .denied || status == .restricted {
+                result("permanentlyDenied")
+                return
+            }
+
+            self.pendingPermissionResult = result
+            if self.locationManager == nil {
+                self.locationManager = CLLocationManager()
+                self.locationManager?.delegate = self
+            }
+            self.locationManager?.requestWhenInUseAuthorization()
+        }
+    }
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        guard let result = pendingPermissionResult else { return }
+
+        if status != .notDetermined {
+            let isGranted = (status == .authorizedWhenInUse || status == .authorizedAlways)
+            result(isGranted ? "granted" : "permanentlyDenied")
+            pendingPermissionResult = nil
+        }
+    }
 }

--- a/lib/others/permissions.dart
+++ b/lib/others/permissions.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 import 'dart:io';
 import 'package:pslab/others/logger_service.dart';
 
@@ -11,6 +12,10 @@ class PSLabPermissions {
 
   static Future<AppPermissionStatus> checkStatus(
       AppPermission permission) async {
+    if (kIsWeb) {
+      return AppPermissionStatus.granted;
+    }
+
     if (Platform.isWindows || Platform.isLinux) {
       return AppPermissionStatus.granted;
     }
@@ -20,13 +25,17 @@ class PSLabPermissions {
         'permission': permission.name,
       });
       return _parseStatus(result);
-    } on PlatformException catch (e) {
-      _logError('checkStatus', e);
+    } on PlatformException catch (exception) {
+      _logError('checkStatus', exception);
       return AppPermissionStatus.denied;
     }
   }
 
   static Future<AppPermissionStatus> request(AppPermission permission) async {
+    if (kIsWeb) {
+      return AppPermissionStatus.granted;
+    }
+
     if (Platform.isWindows || Platform.isLinux) {
       return AppPermissionStatus.granted;
     }
@@ -36,8 +45,8 @@ class PSLabPermissions {
         'permission': permission.name,
       });
       return _parseStatus(result);
-    } on PlatformException catch (e) {
-      _logError('request', e);
+    } on PlatformException catch (exception) {
+      _logError('request', exception);
       return AppPermissionStatus.denied;
     }
   }

--- a/lib/others/permissions.dart
+++ b/lib/others/permissions.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/services.dart';
+import 'dart:io';
+import 'package:pslab/others/logger_service.dart';
+
+enum AppPermission { microphone, location }
+
+enum AppPermissionStatus { granted, denied, permanentlyDenied }
+
+class PSLabPermissions {
+  static const MethodChannel _channel = MethodChannel('io.pslab/permissions');
+
+  static Future<AppPermissionStatus> checkStatus(
+      AppPermission permission) async {
+    if (Platform.isWindows || Platform.isLinux) {
+      return AppPermissionStatus.granted;
+    }
+
+    try {
+      final String? result = await _channel.invokeMethod('checkStatus', {
+        'permission': permission.name,
+      });
+      return _parseStatus(result);
+    } on PlatformException catch (e) {
+      _logError('checkStatus', e);
+      return AppPermissionStatus.denied;
+    }
+  }
+
+  static Future<AppPermissionStatus> request(AppPermission permission) async {
+    if (Platform.isWindows || Platform.isLinux) {
+      return AppPermissionStatus.granted;
+    }
+
+    try {
+      final String? result = await _channel.invokeMethod('request', {
+        'permission': permission.name,
+      });
+      return _parseStatus(result);
+    } on PlatformException catch (e) {
+      _logError('request', e);
+      return AppPermissionStatus.denied;
+    }
+  }
+
+  static AppPermissionStatus _parseStatus(String? status) {
+    switch (status) {
+      case 'granted':
+        return AppPermissionStatus.granted;
+      case 'permanentlyDenied':
+        return AppPermissionStatus.permanentlyDenied;
+      case 'denied':
+      default:
+        return AppPermissionStatus.denied;
+    }
+  }
+
+  static void _logError(String method, PlatformException exception) {
+    logger.e(
+        'PSLabPermissions Error during $method: ${exception.message} (Code: ${exception.code})');
+  }
+}

--- a/lib/providers/soundmeter_state_provider.dart
+++ b/lib/providers/soundmeter_state_provider.dart
@@ -8,8 +8,9 @@ import 'package:pslab/others/logger_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/others/audio_jack.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:pslab/providers/soundmeter_config_provider.dart';
+
+import '../others/permissions.dart';
 
 class SoundMeterStateProvider extends ChangeNotifier {
   AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
@@ -90,14 +91,16 @@ class SoundMeterStateProvider extends ChangeNotifier {
     onSensorError = onError;
 
     try {
-      PermissionStatus microphonePermission =
-          await Permission.microphone.status;
+      AppPermissionStatus microphonePermission =
+          await PSLabPermissions.checkStatus(AppPermission.microphone);
 
-      if (microphonePermission != PermissionStatus.granted) {
-        microphonePermission = await Permission.microphone.request();
+      if (microphonePermission != AppPermissionStatus.granted) {
+        microphonePermission =
+            await PSLabPermissions.request(AppPermission.microphone);
       }
-      if (microphonePermission != PermissionStatus.granted) {
-        if (microphonePermission == PermissionStatus.permanentlyDenied) {
+
+      if (microphonePermission != AppPermissionStatus.granted) {
+        if (microphonePermission == AppPermissionStatus.permanentlyDenied) {
           _handleSensorError("Microphone permission is permanently denied.");
           return;
         } else {

--- a/lib/view/widgets/channel_parameters_widget.dart
+++ b/lib/view/widgets/channel_parameters_widget.dart
@@ -1,13 +1,10 @@
-import 'dart:io';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/oscilloscope_state_provider.dart';
-
+import 'package:pslab/others/logger_service.dart';
+import '../../others/permissions.dart';
 import '../../theme/colors.dart';
 
 class ChannelParametersWidget extends StatefulWidget {
@@ -252,11 +249,16 @@ class _ChannelParametersState extends State<ChannelParametersWidget> {
                       groupValue:
                           oscilloscopeStateProvider.isInBuiltMICSelected,
                       onChanged: (bool? value) async {
-                        if (!kIsWeb &&
-                            !Platform.isMacOS &&
-                            !Platform.isLinux &&
-                            !Platform.isWindows) {
-                          await Permission.microphone.request();
+                        if (value == true) {
+                          final AppPermissionStatus status =
+                              await PSLabPermissions.request(
+                                  AppPermission.microphone);
+
+                          if (status != AppPermissionStatus.granted) {
+                            logger.e(
+                                "Microphone permission was denied or permanently blocked.");
+                            return;
+                          }
                         }
                         setState(
                           () {

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -2,17 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.cs.allow-jit</key>
-	<true/>
-	<key>com.apple.security.device.usb</key>
-	<true/>
-	<key>com.apple.security.network.server</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.device.usb</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>
 </plist>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -2,34 +2,34 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
-	<key>CFBundleIconFile</key>
-	<string></string>
-	<key>CFBundleIdentifier</key>
-	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>$(FLUTTER_BUILD_NAME)</string>
-	<key>CFBundleVersion</key>
-	<string>$(FLUTTER_BUILD_NUMBER)</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>$(PRODUCT_COPYRIGHT)</string>
-	<key>NSMainNibFile</key>
-	<string>MainMenu</string>
-	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
-	<key>NSLocationUsageDescription</key>
-	<string>This app needs access to location.</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIconFile</key>
+    <string></string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$(FLUTTER_BUILD_NAME)</string>
+    <key>CFBundleVersion</key>
+    <string>$(FLUTTER_BUILD_NUMBER)</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>$(PRODUCT_COPYRIGHT)</string>
+    <key>NSMainNibFile</key>
+    <string>MainMenu</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSLocationUsageDescription</key>
+    <string>This app needs access to location.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app needs access to microphone for oscilloscope.</string>
 </dict>

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,15 +1,118 @@
 import Cocoa
 import FlutterMacOS
+import AVFoundation
+import CoreLocation
 
-class MainFlutterWindow: NSWindow {
-  override func awakeFromNib() {
-    let flutterViewController = FlutterViewController()
-    let windowFrame = self.frame
-    self.contentViewController = flutterViewController
-    self.setFrame(windowFrame, display: true)
+class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
+    private var pendingPermissionResult: FlutterResult?
+    private var locationManager: CLLocationManager?
 
-    RegisterGeneratedPlugins(registry: flutterViewController)
+    override func awakeFromNib() {
+        let flutterViewController = FlutterViewController()
+        let windowFrame = self.frame
+        self.contentViewController = flutterViewController
+        self.setFrame(windowFrame, display: true)
 
-    super.awakeFromNib()
-  }
+        let permissionChannel = FlutterMethodChannel(
+            name: "io.pslab/permissions",
+            binaryMessenger: flutterViewController.engine.binaryMessenger
+        )
+
+        permissionChannel.setMethodCallHandler({ [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+            guard let args = call.arguments as? [String: Any],
+                  let permission = args["permission"] as? String else {
+                result(FlutterError(code: "INVALID_ARGS", message: "Missing permission argument", details: nil))
+                return
+            }
+
+            if call.method == "checkStatus" {
+                self?.handleCheckStatus(permission: permission, result: result)
+            } else if call.method == "request" {
+                self?.handleRequest(permission: permission, result: result)
+            } else {
+                result(FlutterMethodNotImplemented)
+            }
+        })
+
+        RegisterGeneratedPlugins(registry: flutterViewController)
+
+        super.awakeFromNib()
+    }
+
+    private func handleCheckStatus(permission: String, result: @escaping FlutterResult) {
+        if permission == "microphone" {
+            switch AVCaptureDevice.authorizationStatus(for: .audio) {
+            case .authorized:
+                result("granted")
+            case .denied, .restricted:
+                result("permanentlyDenied")
+            case .notDetermined:
+                result("denied")
+            @unknown default:
+                result("denied")
+            }
+        } else if permission == "location" {
+            let status: CLAuthorizationStatus
+            if #available(macOS 11.0, *) {
+                status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+            } else {
+                status = CLLocationManager.authorizationStatus()
+            }
+
+            switch status {
+            case .authorizedAlways, .authorizedWhenInUse:
+                result("granted")
+            case .denied, .restricted:
+                result("permanentlyDenied")
+            case .notDetermined:
+                result("denied")
+            @unknown default:
+                result("denied")
+            }
+        } else {
+            result(FlutterError(code: "UNKNOWN_PERMISSION", message: "Unknown permission type", details: nil))
+        }
+    }
+
+    private func handleRequest(permission: String, result: @escaping FlutterResult) {
+        if permission == "microphone" {
+            AVCaptureDevice.requestAccess(for: .audio) { granted in
+                DispatchQueue.main.async {
+                    result(granted ? "granted" : "permanentlyDenied")
+                }
+            }
+        } else if permission == "location" {
+            let status: CLAuthorizationStatus
+            if #available(macOS 11.0, *) {
+                status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+            } else {
+                status = CLLocationManager.authorizationStatus()
+            }
+
+            if status == .authorizedWhenInUse || status == .authorizedAlways {
+                result("granted")
+                return
+            } else if status == .denied || status == .restricted {
+                result("permanentlyDenied")
+                return
+            }
+
+            self.pendingPermissionResult = result
+            if self.locationManager == nil {
+                self.locationManager = CLLocationManager()
+                self.locationManager?.delegate = self
+            }
+            self.locationManager?.requestAlwaysAuthorization()
+        }
+    }
+
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        guard let result = pendingPermissionResult else { return }
+
+        if status != .notDetermined {
+            let isGranted = (status == .authorizedWhenInUse || status == .authorizedAlways)
+            result(isGranted ? "granted" : "permanentlyDenied")
+            pendingPermissionResult = nil
+        }
+    }
 }

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -18,7 +18,7 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
             binaryMessenger: flutterViewController.engine.binaryMessenger
         )
 
-        permissionChannel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
+        permissionChannel.setMethodCallHandler { [weak self] call, result in
             guard let args = call.arguments as? [String: Any],
                   let permission = args["permission"] as? String else {
                 result(FlutterError(code: "INVALID_ARGS", message: "Missing permission argument", details: nil))
@@ -99,7 +99,6 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
         } else {
             status = CLLocationManager.authorizationStatus()
         }
-
 
         if status == .authorized || status == .authorizedAlways {
             result("granted")

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -18,7 +18,7 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
             binaryMessenger: flutterViewController.engine.binaryMessenger
         )
 
-        permissionChannel.setMethodCallHandler({ [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
+        permissionChannel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
             guard let args = call.arguments as? [String: Any],
                   let permission = args["permission"] as? String else {
                 result(FlutterError(code: "INVALID_ARGS", message: "Missing permission argument", details: nil))
@@ -32,7 +32,7 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
             } else {
                 result(FlutterMethodNotImplemented)
             }
-        })
+        }
 
         RegisterGeneratedPlugins(registry: flutterViewController)
 
@@ -41,76 +41,87 @@ class MainFlutterWindow: NSWindow, CLLocationManagerDelegate {
 
     private func handleCheckStatus(permission: String, result: @escaping FlutterResult) {
         if permission == "microphone" {
-            switch AVCaptureDevice.authorizationStatus(for: .audio) {
-            case .authorized:
-                result("granted")
-            case .denied, .restricted:
-                result("permanentlyDenied")
-            case .notDetermined:
-                result("denied")
-            @unknown default:
-                result("denied")
-            }
+            checkMicrophoneStatus(result: result)
         } else if permission == "location" {
-            let status: CLAuthorizationStatus
-            if #available(macOS 11.0, *) {
-                status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
-            } else {
-                status = CLLocationManager.authorizationStatus()
-            }
-
-            switch status {
-            case .authorizedAlways, .authorizedWhenInUse:
-                result("granted")
-            case .denied, .restricted:
-                result("permanentlyDenied")
-            case .notDetermined:
-                result("denied")
-            @unknown default:
-                result("denied")
-            }
+            checkLocationStatus(result: result)
         } else {
-            result(FlutterError(code: "UNKNOWN_PERMISSION", message: "Unknown permission type", details: nil))
+            result(FlutterError(code: "UNKNOWN", message: "Unknown permission", details: nil))
+        }
+    }
+
+    private func checkMicrophoneStatus(result: @escaping FlutterResult) {
+        switch AVCaptureDevice.authorizationStatus(for: .audio) {
+        case .authorized: result("granted")
+        case .denied, .restricted: result("permanentlyDenied")
+        case .notDetermined: result("denied")
+        @unknown default: result("denied")
+        }
+    }
+
+    private func checkLocationStatus(result: @escaping FlutterResult) {
+        let status: CLAuthorizationStatus
+        if #available(macOS 11.0, *) {
+            status = locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+        } else {
+            status = CLLocationManager.authorizationStatus()
+        }
+
+        switch status {
+        case .authorizedAlways, .authorized: result("granted")
+        case .denied, .restricted: result("permanentlyDenied")
+        case .notDetermined: result("denied")
+        @unknown default: result("denied")
         }
     }
 
     private func handleRequest(permission: String, result: @escaping FlutterResult) {
         if permission == "microphone" {
-            AVCaptureDevice.requestAccess(for: .audio) { granted in
-                DispatchQueue.main.async {
-                    result(granted ? "granted" : "permanentlyDenied")
-                }
-            }
+            requestMicrophone(result: result)
         } else if permission == "location" {
-            let status: CLAuthorizationStatus
-            if #available(macOS 11.0, *) {
-                status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
-            } else {
-                status = CLLocationManager.authorizationStatus()
-            }
-
-            if status == .authorizedWhenInUse || status == .authorizedAlways {
-                result("granted")
-                return
-            } else if status == .denied || status == .restricted {
-                result("permanentlyDenied")
-                return
-            }
-
-            self.pendingPermissionResult = result
-            if self.locationManager == nil {
-                self.locationManager = CLLocationManager()
-                self.locationManager?.delegate = self
-            }
-            self.locationManager?.requestAlwaysAuthorization()
+            requestLocation(result: result)
+        } else {
+            result(FlutterError(code: "UNKNOWN", message: "Unknown permission", details: nil))
         }
+    }
+
+    private func requestMicrophone(result: @escaping FlutterResult) {
+        AVCaptureDevice.requestAccess(for: .audio) { granted in
+            DispatchQueue.main.async {
+                result(granted ? "granted" : "permanentlyDenied")
+            }
+        }
+    }
+
+    private func requestLocation(result: @escaping FlutterResult) {
+        let status: CLAuthorizationStatus
+        if #available(macOS 11.0, *) {
+            status = self.locationManager?.authorizationStatus ?? CLLocationManager.authorizationStatus()
+        } else {
+            status = CLLocationManager.authorizationStatus()
+        }
+
+
+        if status == .authorized || status == .authorizedAlways {
+            result("granted")
+            return
+        } else if status == .denied || status == .restricted {
+            result("permanentlyDenied")
+            return
+        }
+
+        self.pendingPermissionResult = result
+        if self.locationManager == nil {
+            self.locationManager = CLLocationManager()
+            self.locationManager?.delegate = self
+        }
+        self.locationManager?.requestAlwaysAuthorization()
     }
 
     func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
         guard let result = pendingPermissionResult else { return }
 
         if status != .notDetermined {
-            let isGranted = (status == .authorizedWhenInUse || status == .authorizedAlways)
+            let isGranted = (status == .authorized || status == .authorizedAlways)
             result(isGranted ? "granted" : "permanentlyDenied")
             pendingPermissionResult = nil
         }

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -2,13 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.device.usb</key>
-	<true/>
-	<key>com.apple.security.personal-information.location</key>
-	<true/>
-	<key>com.apple.security.device.audio-input</key>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.device.usb</key>
+    <true/>
+    <key>com.apple.security.personal-information.location</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   get_it: ^9.2.1
   record: ^6.2.1
   data: ^0.15.1
-  permission_handler: ^12.0.1
   logger: ^2.7.0
   url_launcher: ^6.3.2
   font_awesome_flutter: ^11.0.0


### PR DESCRIPTION
Fixes #3246

## Changes

Removed the `permission_handler` dependency because it is no longer maintained and was causing CI failures on Windows.
- Implemented custom permission handling for:
  - Android
  - iOS
  - macOS
  - Web

- Windows and Linux do not require runtime permissions for our use cases. The `permission_handler` dependency enforced unnecessary permission handling on these platforms, so it has been removed.



## Screenshots / Recordings

https://github.com/user-attachments/assets/69f09d86-2870-4161-9190-0eedc08d1f97

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.