### PR TITLE
fix(ci): pin Xcode 26.3.0 for macOS build job

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -250,6 +250,11 @@ jobs:
     needs: common
     runs-on: macos-latest
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1.7.0
+        with:
+          xcode-version: '26.3.0'
+
       - uses: actions/checkout@v6
 
       - name: macOS Workflow


### PR DESCRIPTION
Fixes #3284

## Changes

- Added a `Set up Xcode` step to the macOS build job in `.github/workflows/push-event.yml`.
- Pinned the macOS workflow to Xcode `26.3.0`, matching the existing iOS workflow and the macOS job in `pull-request.yml`.
- Ensures the Push CI workflow builds against a compatible macOS SDK for `connectivity_plus 7.1.1`.

## Screenshots / Recordings

> N/A (CI workflow change)

**Checklist**:
- [x] **No hard coding**: Existing workflow version alignment only.
- [x] **No end of file edits**: No resource file modifications.
- [x] **Code reformatting**: Not applicable for workflow change.
- [x] **Code analysis**: GitHub Actions workflow validation and CI run.

## Summary by Sourcery

CI:
- Configure the macOS push build job to use Xcode 26.3.0 via the setup-xcode action.