### PR TITLE
fix: calculate elapsed time from CSV timestamps in luxmeter

### DIFF
--- a/lib/providers/luxmeter_state_provider.dart
+++ b/lib/providers/luxmeter_state_provider.dart
@@ -43,7 +43,7 @@ class LuxMeterStateProvider extends ChangeNotifier {
   double _luxMax = 0;
   double _luxSum = 0;
   int _dataCount = 0;
-
+  int? _playbackStartTimestamp;
   bool _sensorAvailable = false;
   bool _isRecording = false;
   List<List<dynamic>> _recordedData = [];
@@ -291,8 +291,8 @@ class LuxMeterStateProvider extends ChangeNotifier {
   }
 
   void startPlayback(List<List<dynamic>> data) {
-    if (data.length <= 1) return;
-
+    if (data.length <= 2) return;
+    _playbackStartTimestamp = int.tryParse(data[2][0].toString())?.toInt();
     _isPlayingBack = true;
     _isPlaybackPaused = false;
     _playbackData = data;
@@ -322,7 +322,10 @@ class LuxMeterStateProvider extends ChangeNotifier {
     final currentRow = _playbackData![_playbackIndex];
     if (currentRow.length > 2) {
       _currentLux = double.tryParse(currentRow[2].toString()) ?? 0.0;
-      _currentTime = (_playbackIndex - 1).toDouble();
+      final timestamp = int.tryParse(currentRow[0].toString())?.toInt();
+      if (timestamp != null && _playbackStartTimestamp != null) {
+        _currentTime = (timestamp - _playbackStartTimestamp!) / 1000.0;
+      }
       _updateData();
       _playbackIndex++;
       notifyListeners();


### PR DESCRIPTION
Fixes #3300

## Changes
- Fixed playback timeline calculation in Lux Meter recorded log playback.
- Replaced index-based time calculation, which assumed a fixed 1-second interval between samples.

## Screenshots / Recordings

Before (Time scaling issue):

https://github.com/user-attachments/assets/6a8a35d3-d236-4896-8cc5-e448f87d30e1

After (Fixed time scaling issue):

https://github.com/user-attachments/assets/37009503-820e-4d0a-9a46-e89769471d4c

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.