### PR TITLE
feat(logic-analyzer): add desktop mouse/keyboard support and recording playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 *.log
 *.pyc
 *.swp
+
+# FVM (local Flutter version manager)
+.fvm/
+.fvmrc
 .atom/
 .buildlog/
 .history

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -67,6 +67,8 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
   bool isPlaybackPaused = false;
   Timer? _playbackTimer;
   static const Duration _playbackTick = Duration(milliseconds: 50);
+  // Total time the playhead takes to sweep across the whole recording.
+  static const Duration _playbackSweep = Duration(seconds: 5);
 
   void startPlaybackAnimation() {
     if (recordingDurationUs <= 0) return;
@@ -78,8 +80,8 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
 
   void _runPlaybackTimer() {
     _playbackTimer?.cancel();
-    final double stepUs =
-        recordingDurationUs * (_playbackTick.inMilliseconds / 5000.0);
+    final double stepUs = recordingDurationUs *
+        (_playbackTick.inMilliseconds / _playbackSweep.inMilliseconds);
     _playbackTimer = Timer.periodic(_playbackTick, (timer) {
       if (isPlaybackPaused) return;
       playbackPositionUs += stepUs;
@@ -870,8 +872,8 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
     setConfigData();
     isData = true;
     isPlayingBack = true;
+    // startPlaybackAnimation() already calls notifyListeners().
     startPlaybackAnimation();
-    notifyListeners();
   }
 
   void setConfigData() {

--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:fl_chart/fl_chart.dart';
@@ -55,6 +56,66 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
   late ScienceLab _scienceLab;
   late bool isProcessing;
   late bool isData;
+
+  bool isPlayingBack = false;
+
+  double recordingDurationUs = 0;
+
+  DateTime? recordedAt;
+
+  double playbackPositionUs = 0;
+  bool isPlaybackPaused = false;
+  Timer? _playbackTimer;
+  static const Duration _playbackTick = Duration(milliseconds: 50);
+
+  void startPlaybackAnimation() {
+    if (recordingDurationUs <= 0) return;
+    playbackPositionUs = 0;
+    isPlaybackPaused = false;
+    _runPlaybackTimer();
+    notifyListeners();
+  }
+
+  void _runPlaybackTimer() {
+    _playbackTimer?.cancel();
+    final double stepUs =
+        recordingDurationUs * (_playbackTick.inMilliseconds / 5000.0);
+    _playbackTimer = Timer.periodic(_playbackTick, (timer) {
+      if (isPlaybackPaused) return;
+      playbackPositionUs += stepUs;
+      if (playbackPositionUs >= recordingDurationUs) {
+        playbackPositionUs = recordingDurationUs;
+        isPlaybackPaused = true;
+        timer.cancel();
+      }
+      notifyListeners();
+    });
+  }
+
+  void togglePlaybackPause() {
+    if (!isPlayingBack) return;
+    if (playbackPositionUs >= recordingDurationUs) {
+      playbackPositionUs = 0;
+      isPlaybackPaused = false;
+      _runPlaybackTimer();
+    } else {
+      isPlaybackPaused = !isPlaybackPaused;
+    }
+    notifyListeners();
+  }
+
+  void seekPlayback(double positionUs) {
+    if (!isPlayingBack) return;
+    playbackPositionUs = positionUs.clamp(0.0, recordingDurationUs);
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _playbackTimer?.cancel();
+    super.dispose();
+  }
+
   List<List<dynamic>> _recordedData = [];
 
   Position? currentPosition;
@@ -783,17 +844,33 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
   }
 
   void loadPlaybackData(List<List<dynamic>> playbackData) {
-    dataSets =
-        parseFlSpotList(playbackData[playbackData.length - 1][2].toString());
-    maxY = double.parse(playbackData[playbackData.length - 1][3].toString());
-    minY = double.parse(playbackData[playbackData.length - 1][4].toString());
-    analysisChannelNames =
-        parseList(playbackData[playbackData.length - 1][5].toString());
-    analysisEdgesNames =
-        parseList(playbackData[playbackData.length - 1][6].toString());
+    final row = playbackData[playbackData.length - 1];
+    dataSets = parseFlSpotList(row[2].toString());
+    maxY = double.parse(row[3].toString());
+    minY = double.parse(row[4].toString());
+    analysisChannelNames = parseList(row[5].toString());
+    analysisEdgesNames = parseList(row[6].toString());
     channelMode = analysisChannelNames.length;
+
+    recordedAt = DateTime.tryParse(row[1].toString());
+    if (recordedAt == null) {
+      final epoch = int.tryParse(row[0].toString());
+      if (epoch != null) {
+        recordedAt = DateTime.fromMillisecondsSinceEpoch(epoch);
+      }
+    }
+    double maxX = 0;
+    for (final set in dataSets) {
+      for (final spot in set) {
+        if (spot.x > maxX) maxX = spot.x;
+      }
+    }
+    recordingDurationUs = maxX;
+
     setConfigData();
     isData = true;
+    isPlayingBack = true;
+    startPlaybackAnimation();
     notifyListeners();
   }
 

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -626,7 +626,8 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                 )
               : Focus(
                   focusNode: _keyboardFocusNode,
-                  autofocus: true,
+                  canRequestFocus: !_isSearching,
+                  autofocus: !_isSearching,
                   onKeyEvent: (node, event) => _handleKey(event),
                   child: RefreshIndicator(
                     onRefresh: _loadFiles,

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:home_widget/home_widget.dart';
 import 'package:intl/intl.dart';
 import 'package:pslab/others/csv_service.dart';
@@ -52,6 +53,10 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
   final TextEditingController _searchController = TextEditingController();
   bool _isLoading = true;
 
+  final FocusNode _keyboardFocusNode = FocusNode(debugLabel: 'LoggedDataKeys');
+  int _selectedIndex = -1;
+  final Map<String, GlobalKey> _itemKeys = {};
+
   @override
   void initState() {
     super.initState();
@@ -90,9 +95,60 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
     if (mounted) {
       setState(() {
         _isLoading = false;
+        if (_selectedIndex >= _filteredFiles.length) {
+          _selectedIndex = _filteredFiles.length - 1;
+        }
       });
       _filterLogs(_searchController.text);
     }
+  }
+
+  GlobalKey _keyFor(String path) =>
+      _itemKeys.putIfAbsent(path, () => GlobalKey());
+
+  void _ensureSelectedVisible() {
+    if (_selectedIndex < 0 || _selectedIndex >= _filteredFiles.length) return;
+    final ctx =
+        _itemKeys[_filteredFiles[_selectedIndex].file.path]?.currentContext;
+    if (ctx != null) {
+      Scrollable.ensureVisible(
+        ctx,
+        duration: const Duration(milliseconds: 200),
+        alignment: 0.5,
+      );
+    }
+  }
+
+  KeyEventResult _handleKey(KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (_filteredFiles.isEmpty) return KeyEventResult.ignored;
+
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      setState(() => _selectedIndex =
+          (_selectedIndex + 1).clamp(0, _filteredFiles.length - 1));
+      _ensureSelectedVisible();
+      return KeyEventResult.handled;
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      setState(
+          () => _selectedIndex = _selectedIndex <= 0 ? 0 : _selectedIndex - 1);
+      _ensureSelectedVisible();
+      return KeyEventResult.handled;
+    } else if (event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter) {
+      if (_selectedIndex >= 0 && _selectedIndex < _filteredFiles.length) {
+        final selected = _filteredFiles[_selectedIndex];
+        _openFile(File(selected.file.path), selected.instrumentName);
+      }
+      return KeyEventResult.handled;
+    } else if (event.logicalKey == LogicalKeyboardKey.delete) {
+      if (_selectedIndex >= 0 && _selectedIndex < _filteredFiles.length) {
+        _deleteFile(_filteredFiles[_selectedIndex].file.path);
+      }
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
   }
 
   Future<void> _deleteFile(String filePath, {bool askConfirm = true}) async {
@@ -291,7 +347,9 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
     // so the generic chart viewer can't render them ("No valid data to
     // display"). Tapping the file should behave like Play and open the
     // oscilloscope playback screen, which also shows the recording details.
-    if (instrumentName.toLowerCase() == 'oscilloscope') {
+    if (instrumentName.toLowerCase() == 'oscilloscope' ||
+        instrumentName.toLowerCase() ==
+            appLocalizations.logicAnalyzer.toLowerCase()) {
       return _playFile(file, instrumentName);
     }
     final data = await _csvService.readCsvFromFile(file);
@@ -394,7 +452,10 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
           Navigator.push(
             context,
             MaterialPageRoute(
-              builder: (context) => LogicAnalyzerScreen(playbackData: data),
+              builder: (context) => LogicAnalyzerScreen(
+                playbackData: data,
+                fileName: file.uri.pathSegments.last,
+              ),
             ),
           );
           break;
@@ -563,208 +624,222 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                     style: TextStyle(color: Theme.of(context).primaryColor),
                   ),
                 )
-              : RefreshIndicator(
-                  onRefresh: _loadFiles,
-                  child: ListView.builder(
-                    itemCount: _filteredFiles.length,
-                    itemBuilder: (context, index) {
-                      final file = File(_filteredFiles[index].file.path);
-                      final stat = file.statSync();
-                      final fileName = file.uri.pathSegments.last;
-                      final instrumentName =
-                          _filteredFiles[index].instrumentName;
-                      final formattedDate =
-                          DateFormat.yMMMd().add_jm().format(stat.modified);
+              : Focus(
+                  focusNode: _keyboardFocusNode,
+                  autofocus: true,
+                  onKeyEvent: (node, event) => _handleKey(event),
+                  child: RefreshIndicator(
+                    onRefresh: _loadFiles,
+                    child: ListView.builder(
+                      itemCount: _filteredFiles.length,
+                      itemBuilder: (context, index) {
+                        final file = File(_filteredFiles[index].file.path);
+                        final stat = file.statSync();
+                        final fileName = file.uri.pathSegments.last;
+                        final instrumentName =
+                            _filteredFiles[index].instrumentName;
+                        final formattedDate =
+                            DateFormat.yMMMd().add_jm().format(stat.modified);
+                        final bool selected = index == _selectedIndex;
 
-                      return Card(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.zero,
-                        ),
-                        color: Theme.of(context).colorScheme.surface,
-                        margin:
-                            const EdgeInsets.only(left: 8, right: 8, top: 8),
-                        child: ListTile(
-                          onTap: () => _openFile(file, instrumentName),
-                          leading: Image.asset(
-                            widget.instrumentIcons[
-                                widget.instrumentNames.indexOf(instrumentName)],
-                            color: primaryRed,
+                        return Card(
+                          key: _keyFor(file.path),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.zero,
                           ),
-                          title: Text(fileName,
-                              style:
-                                  const TextStyle(fontWeight: FontWeight.bold)),
-                          subtitle: Text(
-                              '${(stat.size / 1024).toStringAsFixed(2)} KB\n$formattedDate'),
-                          isThreeLine: true,
-                          trailing: PopupMenuButton<String>(
-                            icon: const Icon(Icons.more_vert,
-                                color: Colors.black),
-                            onSelected: (value) async {
-                              if (value == appLocalizations.play) {
-                                _playFile(file, instrumentName);
-                              } else if (value == appLocalizations.location) {
-                                final data =
-                                    await _csvService.readCsvFromFile(file);
-                                if (!context.mounted) return;
-                                double latitude = 0;
-                                double longitude = 0;
-                                if (data[data.length - 1]
-                                        [data[data.length - 1].length - 2]
-                                    is double) {
-                                  latitude = data[data.length - 1]
+                          color: selected
+                              ? primaryRed.withValues(alpha: 0.08)
+                              : Theme.of(context).colorScheme.surface,
+                          margin:
+                              const EdgeInsets.only(left: 8, right: 8, top: 8),
+                          child: ListTile(
+                            onTap: () {
+                              setState(() => _selectedIndex = index);
+                              _openFile(file, instrumentName);
+                            },
+                            leading: Image.asset(
+                              widget.instrumentIcons[widget.instrumentNames
+                                  .indexOf(instrumentName)],
+                              color: primaryRed,
+                            ),
+                            title: Text(fileName,
+                                style: const TextStyle(
+                                    fontWeight: FontWeight.bold)),
+                            subtitle: Text(
+                                '${(stat.size / 1024).toStringAsFixed(2)} KB\n$formattedDate'),
+                            isThreeLine: true,
+                            trailing: PopupMenuButton<String>(
+                              icon: const Icon(Icons.more_vert,
+                                  color: Colors.black),
+                              onSelected: (value) async {
+                                if (value == appLocalizations.play) {
+                                  _playFile(file, instrumentName);
+                                } else if (value == appLocalizations.location) {
+                                  final data =
+                                      await _csvService.readCsvFromFile(file);
+                                  if (!context.mounted) return;
+                                  double latitude = 0;
+                                  double longitude = 0;
+                                  if (data[data.length - 1]
                                           [data[data.length - 1].length - 2]
-                                      .toDouble();
-                                  longitude = data[data.length - 1]
-                                          [data[data.length - 1].length - 1]
-                                      .toDouble();
-                                }
-                                if (latitude == 0 && longitude == 0) {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    SnackBar(
-                                      content: Text(
-                                        appLocalizations
-                                            .noLocationDataAvailable,
-                                        style: TextStyle(
-                                            color: snackBarContentColor),
+                                      is double) {
+                                    latitude = data[data.length - 1]
+                                            [data[data.length - 1].length - 2]
+                                        .toDouble();
+                                    longitude = data[data.length - 1]
+                                            [data[data.length - 1].length - 1]
+                                        .toDouble();
+                                  }
+                                  if (latitude == 0 && longitude == 0) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text(
+                                          appLocalizations
+                                              .noLocationDataAvailable,
+                                          style: TextStyle(
+                                              color: snackBarContentColor),
+                                        ),
+                                        backgroundColor:
+                                            snackBarBackgroundColor,
                                       ),
-                                      backgroundColor: snackBarBackgroundColor,
+                                    );
+                                    return;
+                                  }
+                                  await Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => MapScreen(
+                                        latitude: latitude,
+                                        longitude: longitude,
+                                      ),
                                     ),
                                   );
-                                  return;
+                                } else if (value == appLocalizations.share) {
+                                  _csvService.shareFile(file.path);
+                                } else if (value == appLocalizations.rename) {
+                                  _renameFile(file);
+                                } else if (value == appLocalizations.delete) {
+                                  _deleteFile(file.path);
                                 }
-                                await Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (context) => MapScreen(
-                                      latitude: latitude,
-                                      longitude: longitude,
+                              },
+                              itemBuilder: (BuildContext context) => [
+                                if (instrumentName == appLocalizations.soundMeter.toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.barometer
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.powerSource
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.gyroscope
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.luxMeter
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.waveGenerator
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.oscilloscope
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.multimeter
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.logicAnalyzer
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.accelerometer
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.compassTitle
+                                            .toLowerCase())
+                                  PopupMenuItem<String>(
+                                    value: appLocalizations.play,
+                                    child: ListTile(
+                                      dense: true,
+                                      leading: Icon(
+                                        Icons.play_arrow,
+                                        color: primaryRed,
+                                      ),
+                                      title: Text(
+                                        appLocalizations.play,
+                                        style: TextStyle(
+                                          color: Colors.black,
+                                        ),
+                                      ),
                                     ),
                                   ),
-                                );
-                              } else if (value == appLocalizations.share) {
-                                _csvService.shareFile(file.path);
-                              } else if (value == appLocalizations.rename) {
-                                _renameFile(file);
-                              } else if (value == appLocalizations.delete) {
-                                _deleteFile(file.path);
-                              }
-                            },
-                            itemBuilder: (BuildContext context) => [
-                              if (instrumentName == appLocalizations.soundMeter.toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.barometer
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.powerSource
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.gyroscope
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.luxMeter.toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.waveGenerator
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.oscilloscope
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.multimeter
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.logicAnalyzer
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.accelerometer
-                                          .toLowerCase() ||
-                                  instrumentName ==
-                                      appLocalizations.compassTitle
-                                          .toLowerCase())
                                 PopupMenuItem<String>(
-                                  value: appLocalizations.play,
+                                  value: appLocalizations.location,
                                   child: ListTile(
                                     dense: true,
                                     leading: Icon(
-                                      Icons.play_arrow,
+                                      Icons.map,
                                       color: primaryRed,
                                     ),
                                     title: Text(
-                                      appLocalizations.play,
+                                      appLocalizations.location,
                                       style: TextStyle(
                                         color: Colors.black,
                                       ),
                                     ),
                                   ),
                                 ),
-                              PopupMenuItem<String>(
-                                value: appLocalizations.location,
-                                child: ListTile(
-                                  dense: true,
-                                  leading: Icon(
-                                    Icons.map,
-                                    color: primaryRed,
-                                  ),
-                                  title: Text(
-                                    appLocalizations.location,
-                                    style: TextStyle(
-                                      color: Colors.black,
+                                PopupMenuItem<String>(
+                                  value: appLocalizations.share,
+                                  child: ListTile(
+                                    dense: true,
+                                    leading: Icon(
+                                      Icons.share,
+                                      color: primaryRed,
+                                    ),
+                                    title: Text(
+                                      appLocalizations.share,
+                                      style: TextStyle(
+                                        color: Colors.black,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              PopupMenuItem<String>(
-                                value: appLocalizations.share,
-                                child: ListTile(
-                                  dense: true,
-                                  leading: Icon(
-                                    Icons.share,
-                                    color: primaryRed,
-                                  ),
-                                  title: Text(
-                                    appLocalizations.share,
-                                    style: TextStyle(
-                                      color: Colors.black,
+                                PopupMenuItem<String>(
+                                  value: appLocalizations.rename,
+                                  child: ListTile(
+                                    dense: true,
+                                    leading: Icon(
+                                      Icons.drive_file_rename_outline,
+                                      color: primaryRed,
+                                    ),
+                                    title: Text(
+                                      appLocalizations.rename,
+                                      style: TextStyle(
+                                        color: Colors.black,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              PopupMenuItem<String>(
-                                value: appLocalizations.rename,
-                                child: ListTile(
-                                  dense: true,
-                                  leading: Icon(
-                                    Icons.drive_file_rename_outline,
-                                    color: primaryRed,
-                                  ),
-                                  title: Text(
-                                    appLocalizations.rename,
-                                    style: TextStyle(
-                                      color: Colors.black,
+                                PopupMenuItem<String>(
+                                  value: appLocalizations.delete,
+                                  child: ListTile(
+                                    dense: true,
+                                    leading: Icon(
+                                      Icons.delete,
+                                      color: primaryRed,
+                                    ),
+                                    title: Text(
+                                      appLocalizations.delete,
+                                      style: TextStyle(
+                                        color: Colors.black,
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              PopupMenuItem<String>(
-                                value: appLocalizations.delete,
-                                child: ListTile(
-                                  dense: true,
-                                  leading: Icon(
-                                    Icons.delete,
-                                    color: primaryRed,
-                                  ),
-                                  title: Text(
-                                    appLocalizations.delete,
-                                    style: TextStyle(
-                                      color: Colors.black,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
-                        ),
-                      );
-                    },
+                        );
+                      },
+                    ),
                   ),
                 ),
     );
@@ -772,6 +847,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
 
   @override
   void dispose() {
+    _keyboardFocusNode.dispose();
     _searchController.dispose();
     super.dispose();
   }

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/communication/science_lab.dart';
 import 'package:pslab/constants.dart';
@@ -18,8 +19,9 @@ import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 
 class LogicAnalyzerScreen extends StatefulWidget {
-  const LogicAnalyzerScreen({super.key, this.playbackData});
+  const LogicAnalyzerScreen({super.key, this.playbackData, this.fileName});
   final List<List<dynamic>>? playbackData;
+  final String? fileName;
   final logicAnalyzerCircuit = 'assets/images/logic_analyzer_circuit.png';
 
   @override
@@ -170,6 +172,17 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
     final String? fileName = await showSaveFileNameDialog(context);
 
     if (fileName != null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              appLocalizations.saving,
+              style: TextStyle(color: snackBarContentColor),
+            ),
+            backgroundColor: snackBarBackgroundColor,
+          ),
+        );
+      }
       _csvService.writeMetaData(
           appLocalizations.logicAnalyzer.toLowerCase(), data);
       final file = await _csvService.saveCsvFile(
@@ -266,6 +279,158 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
     });
   }
 
+  String _formatDuration(double micros) {
+    if (micros >= 1e6) return '${(micros / 1e6).toStringAsFixed(3)} s';
+    if (micros >= 1e3) return '${(micros / 1e3).toStringAsFixed(3)} ms';
+    return '${micros.toStringAsFixed(2)} µs';
+  }
+
+  Widget _buildPlaybackBar(LogicAnalyzerStateProvider provider) {
+    final double total =
+        provider.recordingDurationUs <= 0 ? 1.0 : provider.recordingDurationUs;
+    final double position = provider.playbackPositionUs.clamp(0.0, total);
+    final bool atEnd = position >= total;
+    return Container(
+      color: Colors.black,
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      child: Row(
+        children: [
+          IconButton(
+            tooltip: provider.isPlaybackPaused
+                ? appLocalizations.play
+                : appLocalizations.pause,
+            icon: Icon(
+              provider.isPlaybackPaused || atEnd
+                  ? Icons.play_arrow
+                  : Icons.pause,
+              color: Colors.white,
+            ),
+            onPressed: provider.togglePlaybackPause,
+          ),
+          Text(
+            _formatDuration(position),
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+          Expanded(
+            child: SliderTheme(
+              data: SliderTheme.of(context).copyWith(
+                trackHeight: 2,
+                thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+                overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
+              ),
+              child: Slider(
+                value: position,
+                min: 0,
+                max: total,
+                activeColor: primaryRed,
+                inactiveColor: Colors.white24,
+                onChanged: provider.seekPlayback,
+              ),
+            ),
+          ),
+          Text(
+            _formatDuration(total),
+            style: const TextStyle(color: Colors.white, fontSize: 11),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _showRecordingDetails() {
+    final entries = <MapEntry<String, String>>[];
+    if (_provider.recordedAt != null) {
+      entries.add(MapEntry(
+        'Date Recorded',
+        DateFormat('yyyy-MM-dd HH:mm:ss').format(_provider.recordedAt!),
+      ));
+    }
+    if (widget.fileName != null) {
+      entries.add(MapEntry('File', widget.fileName!));
+    }
+    entries.add(MapEntry('Channels', '${_provider.channelMode}'));
+    if (_provider.analysisChannelNames.isNotEmpty) {
+      entries.add(
+          MapEntry('Channel Names', _provider.analysisChannelNames.join(', ')));
+    }
+    if (_provider.analysisEdgesNames.isNotEmpty) {
+      entries.add(MapEntry('Edges', _provider.analysisEdgesNames.join(', ')));
+    }
+    entries.add(
+        MapEntry('Duration', _formatDuration(_provider.recordingDurationUs)));
+    final points =
+        _provider.dataSets.fold<int>(0, (sum, set) => sum + set.length);
+    entries.add(MapEntry('Data Points', '$points'));
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: scaffoldBackgroundColor,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) {
+        final onSurface = Theme.of(context).colorScheme.onSurface;
+        return SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.article_outlined, color: primaryRed, size: 24),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        'Recording Details',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: onSurface,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                const Divider(height: 1),
+                const SizedBox(height: 4),
+                for (final e in entries)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        SizedBox(
+                          width: 140,
+                          child: Text(
+                            e.key,
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w600,
+                              color: onSurface,
+                            ),
+                          ),
+                        ),
+                        Expanded(
+                          child: Text(
+                            e.value,
+                            style: TextStyle(fontSize: 14, color: onSurface),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
@@ -279,67 +444,80 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
           return Stack(
             children: [
               CommonScaffold(
-                title: appLocalizations.logicAnalyzerTitle,
-                onOptionsPressed: _showOptionsMenu,
+                title: widget.playbackData != null
+                    ? (widget.fileName ?? appLocalizations.logicAnalyzerTitle)
+                    : appLocalizations.logicAnalyzerTitle,
+                onOptionsPressed:
+                    widget.playbackData != null ? null : _showOptionsMenu,
                 onGuidePressed: _showInstrumentGuide,
+                isPlayingBack: widget.playbackData != null,
+                onPlaybackStop: widget.playbackData != null
+                    ? () => Navigator.maybePop(context)
+                    : null,
                 body: SafeArea(
                   left: false,
                   right: false,
                   minimum: const EdgeInsets.only(right: 0, bottom: 0),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: chartBackgroundColor,
-                    ),
-                    padding: const EdgeInsets.only(bottom: 5, top: 5),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          flex: 73,
-                          child: LogicAnalyzerGraph(),
+                  child: Column(
+                    children: [
+                      Expanded(
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: chartBackgroundColor,
+                          ),
+                          padding: const EdgeInsets.only(bottom: 5, top: 5),
+                          child: Row(
+                            children: [
+                              Expanded(
+                                flex: 73,
+                                child: LogicAnalyzerGraph(),
+                              ),
+                              Expanded(
+                                flex: 27,
+                                child: LogicAnalyzerChannelSelection(),
+                              ),
+                            ],
+                          ),
                         ),
-                        Expanded(
-                          flex: 27,
-                          child: LogicAnalyzerChannelSelection(),
-                        ),
-                      ],
-                    ),
+                      ),
+                      if (provider.isPlayingBack) _buildPlaybackBar(provider),
+                    ],
                   ),
                 ),
-                actions: [
-                  IconButton(
-                    icon: Icon(Icons.save, color: Colors.white),
-                    onPressed: () async {
-                      if (!getIt.get<ScienceLab>().isConnected()) {
-                        if (context.mounted) {
-                          ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(
-                              content: Text(
-                                appLocalizations.notConnected,
-                                style: TextStyle(color: snackBarContentColor),
-                              ),
-                              backgroundColor: snackBarBackgroundColor,
-                            ),
-                          );
-                        }
-                        return;
-                      }
-                      if (mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              appLocalizations.saving,
-                              style: TextStyle(color: snackBarContentColor),
-                            ),
-                            backgroundColor: snackBarBackgroundColor,
-                          ),
-                        );
-                      }
-                      await _provider.logData();
-                      final data = _provider.recordedData;
-                      await _showSaveFileDialog(data);
-                    },
-                  ),
-                ],
+                actions: widget.playbackData != null
+                    ? [
+                        IconButton(
+                          tooltip: 'Recording details',
+                          icon: const Icon(Icons.article_outlined,
+                              color: Colors.white),
+                          onPressed: _showRecordingDetails,
+                        ),
+                      ]
+                    : [
+                        IconButton(
+                          icon: Icon(Icons.save, color: Colors.white),
+                          onPressed: () async {
+                            if (!getIt.get<ScienceLab>().isConnected()) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(
+                                      appLocalizations.notConnected,
+                                      style: TextStyle(
+                                          color: snackBarContentColor),
+                                    ),
+                                    backgroundColor: snackBarBackgroundColor,
+                                  ),
+                                );
+                              }
+                              return;
+                            }
+                            await _provider.logData();
+                            final data = _provider.recordedData;
+                            await _showSaveFileDialog(data);
+                          },
+                        ),
+                      ],
               ),
               if (_showGuide)
                 InstrumentOverviewDrawer(

--- a/lib/view/logic_analyzer_screen.dart
+++ b/lib/view/logic_analyzer_screen.dart
@@ -397,32 +397,42 @@ class _LogicAnalyzerScreenState extends State<LogicAnalyzerScreen> {
                 const SizedBox(height: 12),
                 const Divider(height: 1),
                 const SizedBox(height: 4),
-                for (final e in entries)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    child: Row(
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        SizedBox(
-                          width: 140,
-                          child: Text(
-                            e.key,
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w600,
-                              color: onSurface,
+                        for (final e in entries)
+                          Padding(
+                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                SizedBox(
+                                  width: 140,
+                                  child: Text(
+                                    e.key,
+                                    style: TextStyle(
+                                      fontSize: 14,
+                                      fontWeight: FontWeight.w600,
+                                      color: onSurface,
+                                    ),
+                                  ),
+                                ),
+                                Expanded(
+                                  child: Text(
+                                    e.value,
+                                    style: TextStyle(
+                                        fontSize: 14, color: onSurface),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
-                        ),
-                        Expanded(
-                          child: Text(
-                            e.value,
-                            style: TextStyle(fontSize: 14, color: onSurface),
-                          ),
-                        ),
                       ],
                     ),
                   ),
+                ),
               ],
             ),
           ),

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -517,9 +517,7 @@ class _LogicAnalyzerChannelSelectionState
                         fontSize: 14,
                       ),
                     ),
-                    onPressed: () => {
-                      provider.analyze(),
-                    },
+                    onPressed: provider.analyze,
                   )
               ],
             ),

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -509,6 +509,7 @@ class _LogicAnalyzerChannelSelectionState
                         borderRadius: BorderRadius.circular(6),
                       ),
                     ),
+                    onPressed: provider.analyze,
                     child: Text(
                       appLocalizations.analyze.toUpperCase(),
                       style: TextStyle(
@@ -517,7 +518,6 @@ class _LogicAnalyzerChannelSelectionState
                         fontSize: 14,
                       ),
                     ),
-                    onPressed: provider.analyze,
                   )
               ],
             ),

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -1,10 +1,30 @@
 import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:pslab/l10n/app_localizations.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/providers/logic_analyzer_state_provider.dart';
 import 'package:pslab/theme/colors.dart';
+
+enum _LAControlType { channelCount, channel, edge }
+
+class _HoveredControl {
+  const _HoveredControl(this.type, this.index);
+
+  final _LAControlType type;
+
+  final int index;
+
+  @override
+  bool operator ==(Object other) =>
+      other is _HoveredControl && other.type == type && other.index == index;
+
+  @override
+  int get hashCode => Object.hash(type, index);
+}
 
 class LogicAnalyzerChannelSelection extends StatefulWidget {
   const LogicAnalyzerChannelSelection({super.key});
@@ -18,6 +38,27 @@ class _LogicAnalyzerChannelSelectionState
   AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
   late List<String> channelNames;
   late List<String> analysisOptions;
+
+  final CarouselSliderController _carouselController =
+      CarouselSliderController();
+  final FocusNode _keyboardFocusNode = FocusNode(debugLabel: 'LAKeyboard');
+  _HoveredControl? _hoveredControl;
+
+  final Map<_HoveredControl, GlobalKey> _controlKeys = {};
+  GlobalKey _keyFor(_HoveredControl control) =>
+      _controlKeys.putIfAbsent(control, () => GlobalKey());
+
+  static const Duration _scrollThrottle = Duration(milliseconds: 60);
+  DateTime _lastScrollStep = DateTime.fromMillisecondsSinceEpoch(0);
+
+  static const int _minChannels = 1;
+  static const int _maxChannels = 4;
+
+  bool get _usesPointer =>
+      kIsWeb ||
+      defaultTargetPlatform == TargetPlatform.windows ||
+      defaultTargetPlatform == TargetPlatform.linux ||
+      defaultTargetPlatform == TargetPlatform.macOS;
 
   @override
   void initState() {
@@ -35,434 +76,453 @@ class _LogicAnalyzerChannelSelectionState
       appLocalizations.analysisOptionEveryFourthRisingEdge.toUpperCase(),
       appLocalizations.analysisOptionDisabled.toUpperCase(),
     ];
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _keyboardFocusNode.requestFocus();
+    });
+  }
+
+  @override
+  void dispose() {
+    _keyboardFocusNode.dispose();
+    super.dispose();
+  }
+
+  String _channelValue(LogicAnalyzerStateProvider provider, int index) {
+    switch (index) {
+      case 0:
+        return provider.channelSelectSpinner1;
+      case 1:
+        return provider.channelSelectSpinner2;
+      case 2:
+        return provider.channelSelectSpinner3;
+      default:
+        return provider.channelSelectSpinner4;
+    }
+  }
+
+  void _setChannelValue(
+      LogicAnalyzerStateProvider provider, int index, String value) {
+    switch (index) {
+      case 0:
+        provider.channelSelectSpinner1 = value;
+        break;
+      case 1:
+        provider.channelSelectSpinner2 = value;
+        break;
+      case 2:
+        provider.channelSelectSpinner3 = value;
+        break;
+      default:
+        provider.channelSelectSpinner4 = value;
+        break;
+    }
+  }
+
+  String _edgeValue(LogicAnalyzerStateProvider provider, int index) {
+    switch (index) {
+      case 0:
+        return provider.edgeSelectSpinner1;
+      case 1:
+        return provider.edgeSelectSpinner2;
+      case 2:
+        return provider.edgeSelectSpinner3;
+      default:
+        return provider.edgeSelectSpinner4;
+    }
+  }
+
+  void _setEdgeValue(
+      LogicAnalyzerStateProvider provider, int index, String value) {
+    switch (index) {
+      case 0:
+        provider.edgeSelectSpinner1 = value;
+        break;
+      case 1:
+        provider.edgeSelectSpinner2 = value;
+        break;
+      case 2:
+        provider.edgeSelectSpinner3 = value;
+        break;
+      default:
+        provider.edgeSelectSpinner4 = value;
+        break;
+    }
+  }
+
+  void _applyStep(
+    LogicAnalyzerStateProvider provider,
+    _HoveredControl control,
+    int step,
+  ) {
+    if (provider.isPlayingBack) return;
+    switch (control.type) {
+      case _LAControlType.channelCount:
+        final int target =
+            (provider.channelMode + step).clamp(_minChannels, _maxChannels);
+        if (target != provider.channelMode) {
+          _carouselController.animateToPage(target - 1);
+        }
+        break;
+      case _LAControlType.channel:
+        if (control.index >= provider.channelMode) return;
+        final int current =
+            channelNames.indexOf(_channelValue(provider, control.index));
+        final int next = (current + step).clamp(0, channelNames.length - 1);
+        if (next != current) {
+          setState(() {
+            _setChannelValue(provider, control.index, channelNames[next]);
+          });
+        }
+        break;
+      case _LAControlType.edge:
+        if (control.index >= provider.channelMode) return;
+        final int current =
+            analysisOptions.indexOf(_edgeValue(provider, control.index));
+        final int next = (current + step).clamp(0, analysisOptions.length - 1);
+        if (next != current) {
+          setState(() {
+            _setEdgeValue(provider, control.index, analysisOptions[next]);
+          });
+        }
+        break;
+    }
+  }
+
+  void _handlePointerScroll(
+    PointerSignalEvent event,
+    LogicAnalyzerStateProvider provider,
+    _HoveredControl control,
+  ) {
+    if (event is! PointerScrollEvent || event.scrollDelta.dy == 0) return;
+    if (provider.isPlayingBack) return;
+
+    GestureBinding.instance.pointerSignalResolver.register(event, (_) {
+      final DateTime now = DateTime.now();
+      if (now.difference(_lastScrollStep) < _scrollThrottle) return;
+      _lastScrollStep = now;
+      _applyStep(provider, control, event.scrollDelta.dy < 0 ? 1 : -1);
+    });
+  }
+
+  KeyEventResult _handleKey(
+      LogicAnalyzerStateProvider provider, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (provider.isPlayingBack) return KeyEventResult.ignored;
+
+    if (event.logicalKey == LogicalKeyboardKey.enter ||
+        event.logicalKey == LogicalKeyboardKey.numpadEnter) {
+      provider.analyze();
+      return KeyEventResult.handled;
+    }
+
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      _moveActive(provider.channelMode, 1);
+      return KeyEventResult.handled;
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      _moveActive(provider.channelMode, -1);
+      return KeyEventResult.handled;
+    }
+
+    final _HoveredControl? control = _hoveredControl;
+    if (control == null) return KeyEventResult.ignored;
+
+    if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+      _applyStep(provider, control, 1);
+      return KeyEventResult.handled;
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+      _applyStep(provider, control, -1);
+      return KeyEventResult.handled;
+    }
+    return KeyEventResult.ignored;
+  }
+
+  List<_HoveredControl> _orderedControls(int channelMode) {
+    final controls = <_HoveredControl>[
+      const _HoveredControl(_LAControlType.channelCount, 0),
+    ];
+    for (int i = 0; i < channelMode; i++) {
+      controls.add(_HoveredControl(_LAControlType.channel, i));
+      controls.add(_HoveredControl(_LAControlType.edge, i));
+    }
+    return controls;
+  }
+
+  void _moveActive(int channelMode, int delta) {
+    final controls = _orderedControls(channelMode);
+    int index;
+    final int current =
+        _hoveredControl == null ? -1 : controls.indexOf(_hoveredControl!);
+    if (current == -1) {
+      index = delta > 0 ? 0 : controls.length - 1;
+    } else {
+      index = (current + delta).clamp(0, controls.length - 1);
+    }
+    final next = controls[index];
+    setState(() => _hoveredControl = next);
+
+    if (next.type != _LAControlType.channelCount) {
+      final ctx = _controlKeys[next]?.currentContext;
+      if (ctx != null) {
+        Scrollable.ensureVisible(
+          ctx,
+          duration: const Duration(milliseconds: 200),
+          alignment: 0.5,
+        );
+      }
+    }
+  }
+
+  bool _isHovered(_HoveredControl control) => _hoveredControl == control;
+
+  void _setHovered(_HoveredControl? control) {
+    if (_hoveredControl == control) return;
+    setState(() => _hoveredControl = control);
+    if (control != null && !_keyboardFocusNode.hasFocus) {
+      _keyboardFocusNode.requestFocus();
+    }
+  }
+
+  Widget _interactiveControl({
+    required LogicAnalyzerStateProvider provider,
+    required _HoveredControl control,
+    required Widget child,
+  }) {
+    return Listener(
+      key: _keyFor(control),
+      onPointerSignal: (event) =>
+          _handlePointerScroll(event, provider, control),
+      child: MouseRegion(
+        onEnter: (_) => _setHovered(control),
+        onExit: (_) {
+          if (_isHovered(control)) _setHovered(null);
+        },
+        child: child,
+      ),
+    );
+  }
+
+  Widget _hoverHighlight({required bool hovered, required Widget child}) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 120),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(
+          color: hovered ? logicAnalyzerTextColor : Colors.transparent,
+          width: 1.4,
+        ),
+      ),
+      child: child,
+    );
+  }
+
+  Widget _buildDropdown({
+    required String value,
+    required ValueChanged<String>? onChanged,
+    required List<String> items,
+  }) {
+    return DropdownButton<String>(
+      dropdownColor: primaryRed,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      value: value,
+      isExpanded: true,
+      underline: Container(),
+      iconEnabledColor: logicAnalyzerTextColor,
+      disabledHint: Text(
+        value,
+        style: TextStyle(color: logicAnalyzerTextColor, fontSize: 14),
+      ),
+      style: TextStyle(
+        color: logicAnalyzerTextColor,
+        fontSize: 14,
+      ),
+      items: items.map((String item) {
+        return DropdownMenuItem<String>(
+          value: item,
+          child: Text(item),
+        );
+      }).toList(),
+      onChanged: onChanged == null
+          ? null
+          : (newValue) => setState(() => onChanged(newValue!)),
+    );
+  }
+
+  Widget _buildChannelBlock(LogicAnalyzerStateProvider provider, int index) {
+    final channelControl = _HoveredControl(_LAControlType.channel, index);
+    final edgeControl = _HoveredControl(_LAControlType.edge, index);
+    return Container(
+      margin: EdgeInsets.only(top: index == 0 ? 0 : 10),
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      decoration: BoxDecoration(
+        color: primaryRed,
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          _interactiveControl(
+            provider: provider,
+            control: channelControl,
+            child: _hoverHighlight(
+              hovered: _isHovered(channelControl),
+              child: _buildDropdown(
+                value: _channelValue(provider, index),
+                items: channelNames,
+                onChanged: provider.isPlayingBack
+                    ? null
+                    : (value) => _setChannelValue(provider, index, value),
+              ),
+            ),
+          ),
+          Divider(
+            height: 1,
+            color: logicAnalyzerTextColor,
+          ),
+          _interactiveControl(
+            provider: provider,
+            control: edgeControl,
+            child: _hoverHighlight(
+              hovered: _isHovered(edgeControl),
+              child: _buildDropdown(
+                value: _edgeValue(provider, index),
+                items: analysisOptions,
+                onChanged: provider.isPlayingBack
+                    ? null
+                    : (value) => _setEdgeValue(provider, index, value),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChannelCount(LogicAnalyzerStateProvider provider) {
+    const control = _HoveredControl(_LAControlType.channelCount, 0);
+    return _interactiveControl(
+      provider: provider,
+      control: control,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        margin: const EdgeInsets.only(top: 10),
+        width: double.infinity,
+        decoration: BoxDecoration(
+          color: logicAnalyzerTextColor,
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(
+            color: _isHovered(control) ? primaryRed : Colors.transparent,
+            width: 1.6,
+          ),
+        ),
+        child: CarouselSlider(
+          carouselController: _carouselController,
+          items: [
+            appLocalizations.noOfChannelsOne,
+            appLocalizations.noOfChannelsTwo,
+            appLocalizations.noOfChannelsThree,
+            appLocalizations.noOfChannelsFour,
+          ]
+              .map(
+                (label) => Center(
+                  child: Text(
+                    label,
+                    style: TextStyle(
+                      fontSize: 25,
+                      color: logicAnalyzerChannelsTextColor,
+                    ),
+                  ),
+                ),
+              )
+              .toList(),
+          options: CarouselOptions(
+            height: 40,
+            enableInfiniteScroll: false,
+            initialPage: provider.channelMode - 1,
+            viewportFraction: 0.4,
+            enlargeCenterPage: true,
+            enlargeFactor: 0.4,
+            scrollPhysics: (_usesPointer || provider.isPlayingBack)
+                ? const NeverScrollableScrollPhysics()
+                : null,
+            onPageChanged: (index, reason) {
+              if (provider.isPlayingBack) return;
+              setState(() {
+                provider.channelMode = index + 1;
+              });
+            },
+          ),
+        ),
+      ),
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<LogicAnalyzerStateProvider>(
       builder: (context, provider, _) {
-        return Container(
-          margin: const EdgeInsets.only(
-            left: 15,
-          ),
-          child: Column(
-            children: [
-              Text(
-                appLocalizations.channelSelection,
-                style: TextStyle(
-                  fontSize: 14,
-                  color: chartTextColor,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              Container(
-                margin: EdgeInsets.only(top: 10),
-                width: double.infinity,
-                decoration: BoxDecoration(
-                  color: logicAnalyzerTextColor,
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: CarouselSlider(
-                  items: [
-                    Text(
-                      appLocalizations.noOfChannelsOne,
-                      style: TextStyle(
-                        fontSize: 25,
-                        color: logicAnalyzerChannelsTextColor,
-                      ),
-                    ),
-                    Text(
-                      appLocalizations.noOfChannelsTwo,
-                      style: TextStyle(
-                        fontSize: 25,
-                        color: logicAnalyzerChannelsTextColor,
-                      ),
-                    ),
-                    Text(
-                      appLocalizations.noOfChannelsThree,
-                      style: TextStyle(
-                        fontSize: 25,
-                        color: logicAnalyzerChannelsTextColor,
-                      ),
-                    ),
-                    Text(
-                      appLocalizations.noOfChannelsFour,
-                      style: TextStyle(
-                        fontSize: 25,
-                        color: logicAnalyzerChannelsTextColor,
-                      ),
-                    ),
-                  ],
-                  options: CarouselOptions(
-                    height: 40,
-                    enableInfiniteScroll: false,
-                    initialPage: provider.channelMode - 1,
-                    viewportFraction: 0.4,
-                    enlargeCenterPage: true,
-                    enlargeFactor: 0.4,
-                    onPageChanged: (index, reason) {
-                      setState(() {
-                        provider.channelMode = index + 1;
-                      });
-                    },
-                  ),
-                ),
-              ),
-              Expanded(
-                child: Container(
-                  margin: const EdgeInsets.only(top: 10, right: 5),
-                  child: ScrollConfiguration(
-                    behavior: ScrollBehavior(),
-                    child: ListView(
-                      children: [
-                        Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 10),
-                          decoration: BoxDecoration(
-                            color: primaryRed,
-                            borderRadius: BorderRadius.circular(6),
-                          ),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            children: [
-                              DropdownButton(
-                                dropdownColor: primaryRed,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 10,
-                                ),
-                                value: provider.channelSelectSpinner1,
-                                isExpanded: true,
-                                underline: Container(),
-                                iconEnabledColor: logicAnalyzerTextColor,
-                                style: TextStyle(
-                                  color: logicAnalyzerTextColor,
-                                  fontSize: 14,
-                                ),
-                                items: channelNames.map(
-                                  (String value) {
-                                    return DropdownMenuItem<String>(
-                                      value: value,
-                                      child: Text(value),
-                                    );
-                                  },
-                                ).toList(),
-                                onChanged: (value) => {
-                                  setState(
-                                    () {
-                                      provider.channelSelectSpinner1 = value!;
-                                    },
-                                  ),
-                                },
-                              ),
-                              Divider(
-                                height: 1,
-                                color: logicAnalyzerTextColor,
-                              ),
-                              DropdownButton(
-                                dropdownColor: primaryRed,
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 10,
-                                ),
-                                value: provider.edgeSelectSpinner1,
-                                isExpanded: true,
-                                underline: Container(),
-                                iconEnabledColor: logicAnalyzerTextColor,
-                                style: TextStyle(
-                                  color: logicAnalyzerTextColor,
-                                  fontSize: 14,
-                                ),
-                                items: analysisOptions.map(
-                                  (String value) {
-                                    return DropdownMenuItem<String>(
-                                      value: value,
-                                      child: Text(value),
-                                    );
-                                  },
-                                ).toList(),
-                                onChanged: (value) => {
-                                  setState(
-                                    () {
-                                      provider.edgeSelectSpinner1 = value!;
-                                    },
-                                  ),
-                                },
-                              ),
-                            ],
-                          ),
-                        ),
-                        provider.channelMode > 1
-                            ? Container(
-                                margin: const EdgeInsets.only(top: 10),
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 10),
-                                decoration: BoxDecoration(
-                                  color: primaryRed,
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    DropdownButton(
-                                      dropdownColor: primaryRed,
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                      value: provider.channelSelectSpinner2,
-                                      isExpanded: true,
-                                      underline: Container(),
-                                      iconEnabledColor: logicAnalyzerTextColor,
-                                      style: TextStyle(
-                                        color: logicAnalyzerTextColor,
-                                        fontSize: 14,
-                                      ),
-                                      items: channelNames.map(
-                                        (String value) {
-                                          return DropdownMenuItem<String>(
-                                            value: value,
-                                            child: Text(value),
-                                          );
-                                        },
-                                      ).toList(),
-                                      onChanged: (value) => {
-                                        setState(
-                                          () {
-                                            provider.channelSelectSpinner2 =
-                                                value!;
-                                          },
-                                        ),
-                                      },
-                                    ),
-                                    Divider(
-                                      height: 1,
-                                      color: logicAnalyzerTextColor,
-                                    ),
-                                    DropdownButton(
-                                      dropdownColor: primaryRed,
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                      value: provider.edgeSelectSpinner2,
-                                      isExpanded: true,
-                                      underline: Container(),
-                                      iconEnabledColor: logicAnalyzerTextColor,
-                                      style: TextStyle(
-                                        color: logicAnalyzerTextColor,
-                                        fontSize: 14,
-                                      ),
-                                      items: analysisOptions.map(
-                                        (String value) {
-                                          return DropdownMenuItem<String>(
-                                            value: value,
-                                            child: Text(value),
-                                          );
-                                        },
-                                      ).toList(),
-                                      onChanged: (value) => {
-                                        setState(
-                                          () {
-                                            provider.edgeSelectSpinner2 =
-                                                value!;
-                                          },
-                                        ),
-                                      },
-                                    ),
-                                  ],
-                                ),
-                              )
-                            : Container(),
-                        provider.channelMode > 2
-                            ? Container(
-                                margin: const EdgeInsets.only(top: 10),
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 10),
-                                decoration: BoxDecoration(
-                                  color: primaryRed,
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    DropdownButton(
-                                      dropdownColor: primaryRed,
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                      value: provider.channelSelectSpinner3,
-                                      isExpanded: true,
-                                      underline: Container(),
-                                      iconEnabledColor: logicAnalyzerTextColor,
-                                      style: TextStyle(
-                                        color: logicAnalyzerTextColor,
-                                        fontSize: 14,
-                                      ),
-                                      items: channelNames.map(
-                                        (String value) {
-                                          return DropdownMenuItem<String>(
-                                            value: value,
-                                            child: Text(value),
-                                          );
-                                        },
-                                      ).toList(),
-                                      onChanged: (value) => {
-                                        setState(
-                                          () {
-                                            provider.channelSelectSpinner3 =
-                                                value!;
-                                          },
-                                        ),
-                                      },
-                                    ),
-                                    Divider(
-                                      height: 1,
-                                      color: logicAnalyzerTextColor,
-                                    ),
-                                    DropdownButton(
-                                      dropdownColor: primaryRed,
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                      value: provider.edgeSelectSpinner3,
-                                      isExpanded: true,
-                                      underline: Container(),
-                                      iconEnabledColor: logicAnalyzerTextColor,
-                                      style: TextStyle(
-                                        color: logicAnalyzerTextColor,
-                                        fontSize: 14,
-                                      ),
-                                      items: analysisOptions.map(
-                                        (String value) {
-                                          return DropdownMenuItem<String>(
-                                            value: value,
-                                            child: Text(value),
-                                          );
-                                        },
-                                      ).toList(),
-                                      onChanged: (value) => {
-                                        setState(
-                                          () {
-                                            provider.edgeSelectSpinner3 =
-                                                value!;
-                                          },
-                                        ),
-                                      },
-                                    ),
-                                  ],
-                                ),
-                              )
-                            : Container(),
-                        provider.channelMode > 3
-                            ? Container(
-                                margin: const EdgeInsets.only(top: 10),
-                                padding:
-                                    const EdgeInsets.symmetric(horizontal: 10),
-                                decoration: BoxDecoration(
-                                  color: primaryRed,
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.center,
-                                  children: [
-                                    DropdownButton(
-                                      dropdownColor: primaryRed,
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                      value: provider.channelSelectSpinner4,
-                                      isExpanded: true,
-                                      underline: Container(),
-                                      iconEnabledColor: logicAnalyzerTextColor,
-                                      style: TextStyle(
-                                        color: logicAnalyzerTextColor,
-                                        fontSize: 14,
-                                      ),
-                                      items: channelNames.map(
-                                        (String value) {
-                                          return DropdownMenuItem<String>(
-                                            value: value,
-                                            child: Text(value),
-                                          );
-                                        },
-                                      ).toList(),
-                                      onChanged: (value) => {
-                                        setState(
-                                          () {
-                                            provider.channelSelectSpinner4 =
-                                                value!;
-                                          },
-                                        ),
-                                      },
-                                    ),
-                                    Divider(
-                                      height: 1,
-                                      color: logicAnalyzerTextColor,
-                                    ),
-                                    DropdownButton(
-                                      dropdownColor: primaryRed,
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 10,
-                                      ),
-                                      value: provider.edgeSelectSpinner4,
-                                      isExpanded: true,
-                                      underline: Container(),
-                                      iconEnabledColor: logicAnalyzerTextColor,
-                                      style: TextStyle(
-                                        color: logicAnalyzerTextColor,
-                                        fontSize: 14,
-                                      ),
-                                      items: analysisOptions.map(
-                                        (String value) {
-                                          return DropdownMenuItem<String>(
-                                            value: value,
-                                            child: Text(value),
-                                          );
-                                        },
-                                      ).toList(),
-                                      onChanged: (value) => {
-                                        setState(
-                                          () {
-                                            provider.edgeSelectSpinner4 =
-                                                value!;
-                                          },
-                                        ),
-                                      },
-                                    ),
-                                  ],
-                                ),
-                              )
-                            : Container(),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-              TextButton(
-                style: TextButton.styleFrom(
-                  fixedSize: const Size(double.maxFinite, 40),
-                  backgroundColor: logicAnalyzerTextColor,
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 10,
-                    vertical: 5,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(6),
-                  ),
-                ),
-                child: Text(
-                  appLocalizations.analyze.toUpperCase(),
+        return Focus(
+          focusNode: _keyboardFocusNode,
+          autofocus: true,
+          onKeyEvent: (node, event) => _handleKey(provider, event),
+          child: Container(
+            margin: const EdgeInsets.only(
+              left: 15,
+            ),
+            child: Column(
+              children: [
+                Text(
+                  appLocalizations.channelSelection,
                   style: TextStyle(
-                    color: primaryRed,
-                    fontWeight: FontWeight.bold,
                     fontSize: 14,
+                    color: chartTextColor,
+                    fontWeight: FontWeight.bold,
                   ),
                 ),
-                onPressed: () => {
-                  provider.analyze(),
-                },
-              )
-            ],
+                _buildChannelCount(provider),
+                Expanded(
+                  child: Container(
+                    margin: const EdgeInsets.only(top: 10, right: 5),
+                    child: ScrollConfiguration(
+                      behavior: ScrollBehavior(),
+                      child: ListView(
+                        children: [
+                          for (int i = 0; i < provider.channelMode; i++)
+                            _buildChannelBlock(provider, i),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                if (!provider.isPlayingBack)
+                  TextButton(
+                    style: TextButton.styleFrom(
+                      fixedSize: const Size(double.maxFinite, 40),
+                      backgroundColor: logicAnalyzerTextColor,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 5,
+                      ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                    ),
+                    child: Text(
+                      appLocalizations.analyze.toUpperCase(),
+                      style: TextStyle(
+                        color: primaryRed,
+                        fontWeight: FontWeight.bold,
+                        fontSize: 14,
+                      ),
+                    ),
+                    onPressed: () => {
+                      provider.analyze(),
+                    },
+                  )
+              ],
+            ),
           ),
         );
       },

--- a/lib/view/widgets/logic_analyzer_graph.dart
+++ b/lib/view/widgets/logic_analyzer_graph.dart
@@ -123,6 +123,17 @@ class _LogicAnalyzerGraphState extends State<LogicAnalyzerGraph> {
                         ),
                         clipData: const FlClipData.all(),
                         lineBarsData: provider.createPlots(),
+                        extraLinesData: provider.isPlayingBack
+                            ? ExtraLinesData(
+                                verticalLines: [
+                                  VerticalLine(
+                                    x: provider.playbackPositionUs,
+                                    color: primaryRed,
+                                    strokeWidth: 1.5,
+                                  ),
+                                ],
+                              )
+                            : const ExtraLinesData(),
                         maxY: provider.getMaxY(),
                         minY: provider.getMinY(),
                       ),


### PR DESCRIPTION
Fixes #3307

### Changes
  
Makes the Logic Analyzer usable with mouse and keyboard on desktop, and improves how saved recordings are opened and managed.

  **Logic Analyzer**
  - Mouse wheel and arrow keys control the channel-count selector and the channel/edge dropdowns
  - Enter triggers Analyze

  **Recording playback**
  - Tapping a saved log now opens it in playback (instead of an empty chart)
  - Shows the recording's file name as the title
  - Playback is read-only (controls can't be edited)
  - Adds a Recording Details panel with capture info and duration

  **Logged Data screen**
  - Search to filter saved logs
  - Keyboard navigation (arrows to move, Enter to open, Delete to delete)
  - Rename option for saved logs

  **Fixes**
  - Instrument guide drawer now scrolls
  - "Saving…" message now shows only after confirming the filename

> Recording

https://github.com/user-attachments/assets/2d30ea6e-b607-43cd-955b-16fbad853ebb

