### PR TITLE
fix: thermometer logs playback

### DIFF
--- a/lib/providers/thermometer_state_provider.dart
+++ b/lib/providers/thermometer_state_provider.dart
@@ -40,6 +40,7 @@ class ThermometerStateProvider extends ChangeNotifier {
   double _temperatureMax = 0;
   double _temperatureSum = 0;
   int _dataCount = 0;
+  int? _playbackStartTimestamp;
 
   bool _isSensorAvailable = false;
   bool _isInitialized = false;
@@ -321,7 +322,8 @@ class ThermometerStateProvider extends ChangeNotifier {
   }
 
   void startPlayback(List<List<dynamic>> data) {
-    if (data.length <= 1) return;
+    if (data.length <= 2) return;
+    _playbackStartTimestamp = int.tryParse(data[2][0].toString())?.toInt();
 
     _isPlayingBack = true;
     _isPlaybackPaused = false;
@@ -343,7 +345,12 @@ class ThermometerStateProvider extends ChangeNotifier {
     final currentRow = _playbackData![_playbackIndex];
     if (currentRow.length > 2) {
       _currentTemperature = double.tryParse(currentRow[2].toString()) ?? 0.0;
-      _currentTime = (_playbackIndex - 1).toDouble();
+      final timestamp = int.tryParse(currentRow[0].toString())?.toInt();
+      if (timestamp != null && _playbackStartTimestamp != null) {
+        _currentTime = (timestamp - _playbackStartTimestamp!) / 1000.0;
+      } else {
+        _currentTime = (_playbackIndex - 1).toDouble();
+      }
       _updateData();
       _playbackIndex++;
       notifyListeners();
@@ -390,6 +397,7 @@ class ThermometerStateProvider extends ChangeNotifier {
     _playbackTimer?.cancel();
     _playbackData = null;
     _playbackIndex = 0;
+    _playbackStartTimestamp = null;
 
     _resetTemperatureData();
     notifyListeners();

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -21,6 +21,7 @@ import '../l10n/app_localizations.dart';
 import '../providers/locator.dart';
 import 'accelerometer_screen.dart';
 import 'compass_screen.dart';
+import 'package:pslab/view/thermometer_screen.dart';
 
 class LoggedDataScreen extends StatefulWidget {
   final List<String> instrumentNames;
@@ -385,6 +386,14 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
             context,
             MaterialPageRoute(
               builder: (context) => SoundMeterScreen(playbackData: data),
+            ),
+          );
+          break;
+        case 'thermometer':
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (context) => ThermometerScreen(playbackData: data),
             ),
           );
           break;
@@ -754,6 +763,9 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
                                             .toLowerCase() ||
                                     instrumentName ==
                                         appLocalizations.compassTitle
+                                            .toLowerCase() ||
+                                    instrumentName ==
+                                        appLocalizations.thermometerTitle
                                             .toLowerCase())
                                   PopupMenuItem<String>(
                                     value: appLocalizations.play,

--- a/lib/view/thermometer_screen.dart
+++ b/lib/view/thermometer_screen.dart
@@ -153,7 +153,7 @@ class _ThermometerScreenState extends State<ThermometerScreen> {
         builder: (context) => LoggedDataScreen(
           instrumentNames: [appLocalizations.thermometerTitle.toLowerCase()],
           appBarName: appLocalizations.thermometerTitle,
-          instrumentIcons: [instrumentIcons[12]],
+          instrumentIcons: [instrumentIcons[11]],
         ),
       ),
     );


### PR DESCRIPTION
Fixes #3317

## Changes
- Added support to play back logged thermometer data with correct timing.
- Added thermometer support in logged data screens.
- Fixed wrong at logs data screen

## Screenshots / Recordings

[Screencast from 2026-06-12 12-56-23.webm](https://github.com/user-attachments/assets/a079bf34-6f30-45ce-86da-e6ab71749149)

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add thermometer playback support to logged data workflows and correct playback timing and icon mapping.

Bug Fixes:
- Fix thermometer playback time axis to use logged timestamps relative to playback start.
- Fix incorrect instrument icon index for the thermometer logged data screen.

Enhancements:
- Enable opening thermometer playback from logged data entries and expose play action for logged thermometer logs.