### PR TITLE
chore: upgrade AGP to 9.2.1 and Gradle to 9.6.0 with plugin compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,28 @@ rootProject.buildDir = "../build"
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }
+
+subprojects {
+    afterEvaluate { project ->
+        if (project.hasProperty('android')) {
+            project.android {
+                def currentSdk = project.android.compileSdkVersion
+                if (currentSdk != null) {
+                    def sdkString = currentSdk.toString().replaceAll("[^0-9]", "")
+                    if (!sdkString.isEmpty()) {
+                        def sdkVersion = sdkString.toInteger()
+                        if (sdkVersion < 34) {
+                            compileSdkVersion 34
+                        }
+                    }
+                } else {
+                    compileSdkVersion 34
+                }
+            }
+        }
+    }
+}
+
 subprojects {
     project.evaluationDependsOn(":app")
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 # This builtInKotlin flag was added automatically by Flutter migrator
 android.builtInKotlin=false
 # This newDsl flag was added automatically by Flutter migrator

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.2" apply false
+    id "com.android.application" version "9.2.1" apply false
     id "org.jetbrains.kotlin.android" version "2.4.0" apply false
     id "org.jetbrains.kotlin.plugin.compose" version "2.4.0" apply false
 }


### PR DESCRIPTION
Fixes #3224,#3339

* Upgraded Android Gradle Plugin to 9.2.1 and Gradle Wrapper to 9.6.0 to align with modern Android tooling standards.
* Added a defensive Gradle script in `build.gradle` that forces a minimum safety floor of API 34 for legacy plugins like `mp_audio_stream`.
* Updated `gradle.properties` with required build configuration and Flutter migration flags to ensure local and CI builds match.

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Upgrade Android build tooling and enforce a minimum compile SDK level across subprojects for compatibility with newer Gradle and Flutter tooling.

Build:
- Bump Android Gradle Plugin to 9.2.1 and Gradle wrapper to 9.6.0.
- Add a global Gradle configuration that enforces a minimum compileSdkVersion of 34 for all Android subprojects.
- Update Android Gradle properties with Flutter migrator flags for Kotlin and the new DSL behavior.