### PR TITLE
fix: allow oscilloscope recording when only built-in mic is selected

### DIFF
--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -1028,7 +1028,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   }
 
   Future<bool> startRecording() async {
-    if (!_scienceLab.isConnected()) {
+    if (!_scienceLab.isConnected() && !isInBuiltMICSelected) {
       return false;
     }
     if (_configProvider.config.includeLocationData) {


### PR DESCRIPTION
Fixes #3342 

## Changes
Allow recording when only Built-in mic is selected
``` dart
    if (!_scienceLab.isConnected() && !isInBuiltMICSelected) {
      return false;
    }
```

## Screenshots / Recordings

https://github.com/user-attachments/assets/76591c6b-4301-44be-94eb-4024bc23b2db

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Relax the oscilloscope recording precondition so recording can proceed with the built-in microphone even when the ScienceLab device is not connected.