### PR TITLE
fix: update record_android to 2.1.1 to prevent broadcast race condition

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -992,10 +992,10 @@ packages:
     dependency: transitive
     description:
       name: record_android
-      sha256: "88b35177f0fb3582836f0b9ffcf388e178d85b9b94b4259e6a722391a93f321e"
+      sha256: "6722be803d8b2a0945112d69cfbda1391970c5cff2cb53c16afd307a6b7ef0c4"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   record_ios:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes #3345

## Changes

* **The bug** Version `2.1.0` had a regression where Android's Bluetooth SCO broadcast receiver could fire multiple times during audio initialization.
*  This caused the native plugin to reply to the Flutter `MethodChannel` twice, triggering a fatal `IllegalStateException: Reply already submitted` that crashed the app.
*  Version `2.1.1` implements a native boolean lock (`startNotified`) ensuring the Flutter result is safely consumed exactly once.
*  **Upgraded dependency:** Bumped `record_android` from `2.1.0` to `2.1.1` to pull in the official upstream patch for [Issue #607](https://github.com/llfbandit/record/issues/607).
* **Resolved** The app can now safely start recording audio without crashing when the system's Bluetooth connection state fluctuates.

## Screenshots / Recordings

https://github.com/user-attachments/assets/a8c5a7a9-f31f-41c8-9454-e50307db5984


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Update Android audio recording dependency to pull in upstream fix for a Bluetooth SCO initialization race causing crashes.

Bug Fixes:
- Prevent app crashes caused by duplicate Flutter MethodChannel replies when Android Bluetooth SCO broadcasts fire multiple times during audio initialization.

Build:
- Bump record_android dependency from 2.1.0 to 2.1.1 to include the upstream fix for the Bluetooth SCO broadcast race condition.