### PR TITLE
feat: show not connected when analyze returns false

### DIFF
--- a/lib/providers/logic_analyzer_state_provider.dart
+++ b/lib/providers/logic_analyzer_state_provider.dart
@@ -198,56 +198,59 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
         await Geolocator.getCurrentPosition(locationSettings: locationSettings);
   }
 
-  Future<void> analyze() async {
+  Future<bool> analyze() async {
+    if (!_scienceLab.isConnected()) {
+      return false;
+    }
     isProcessing = true;
     notifyListeners();
 
-    currentChannel = 0;
-    dataSets.clear();
-    analysisChannelNames.clear();
-    analysisEdgesNames.clear();
-    digitalChannels.clear();
+    try {
+      currentChannel = 0;
+      dataSets.clear();
+      analysisChannelNames.clear();
+      analysisEdgesNames.clear();
+      digitalChannels.clear();
 
-    switch (channelMode) {
-      case 1:
-        analysisChannelNames.add(channelSelectSpinner1);
-        analysisEdgesNames.add(edgeSelectSpinner1);
-        break;
-      case 2:
-        analysisChannelNames
-            .addAll([channelSelectSpinner1, channelSelectSpinner2]);
-        analysisEdgesNames.addAll([edgeSelectSpinner1, edgeSelectSpinner2]);
-        break;
-      case 3:
-        analysisChannelNames.addAll([
-          channelSelectSpinner1,
-          channelSelectSpinner2,
-          channelSelectSpinner3
-        ]);
-        analysisEdgesNames.addAll(
-            [edgeSelectSpinner1, edgeSelectSpinner2, edgeSelectSpinner3]);
-        break;
-      case 4:
-        analysisChannelNames.addAll([
-          channelSelectSpinner1,
-          channelSelectSpinner2,
-          channelSelectSpinner3,
-          channelSelectSpinner4
-        ]);
-        analysisEdgesNames.addAll([
-          edgeSelectSpinner1,
-          edgeSelectSpinner2,
-          edgeSelectSpinner3,
-          edgeSelectSpinner4
-        ]);
-        break;
-      default:
-        analysisChannelNames.add(channelSelectSpinner1);
-        analysisEdgesNames.add(edgeSelectSpinner1);
-        break;
-    }
+      switch (channelMode) {
+        case 1:
+          analysisChannelNames.add(channelSelectSpinner1);
+          analysisEdgesNames.add(edgeSelectSpinner1);
+          break;
+        case 2:
+          analysisChannelNames
+              .addAll([channelSelectSpinner1, channelSelectSpinner2]);
+          analysisEdgesNames.addAll([edgeSelectSpinner1, edgeSelectSpinner2]);
+          break;
+        case 3:
+          analysisChannelNames.addAll([
+            channelSelectSpinner1,
+            channelSelectSpinner2,
+            channelSelectSpinner3
+          ]);
+          analysisEdgesNames.addAll(
+              [edgeSelectSpinner1, edgeSelectSpinner2, edgeSelectSpinner3]);
+          break;
+        case 4:
+          analysisChannelNames.addAll([
+            channelSelectSpinner1,
+            channelSelectSpinner2,
+            channelSelectSpinner3,
+            channelSelectSpinner4
+          ]);
+          analysisEdgesNames.addAll([
+            edgeSelectSpinner1,
+            edgeSelectSpinner2,
+            edgeSelectSpinner3,
+            edgeSelectSpinner4
+          ]);
+          break;
+        default:
+          analysisChannelNames.add(channelSelectSpinner1);
+          analysisEdgesNames.add(edgeSelectSpinner1);
+          break;
+      }
 
-    if (_scienceLab.isConnected()) {
       switch (channelMode) {
         case 1:
           await captureOne(analysisChannelNames[0], analysisEdgesNames[0]);
@@ -273,9 +276,11 @@ class LogicAnalyzerStateProvider extends ChangeNotifier {
           break;
       }
       isData = true;
+      return true;
+    } finally {
+      isProcessing = false;
+      notifyListeners();
     }
-    isProcessing = false;
-    notifyListeners();
   }
 
   double getMaxY() {

--- a/lib/view/widgets/logic_analyzer_channel_selection.dart
+++ b/lib/view/widgets/logic_analyzer_channel_selection.dart
@@ -509,7 +509,16 @@ class _LogicAnalyzerChannelSelectionState
                         borderRadius: BorderRadius.circular(6),
                       ),
                     ),
-                    onPressed: provider.analyze,
+                    onPressed: () async {
+                      final success = await provider.analyze();
+                      if (!success && context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(appLocalizations.notConnected),
+                          ),
+                        );
+                      }
+                    },
                     child: Text(
                       appLocalizations.analyze.toUpperCase(),
                       style: TextStyle(


### PR DESCRIPTION
Fixes #3351

## Changes
1. Changed return type of ```analyze``` from ```void``` to ```bool``` so it returns false when PSLab is not connected. This returned false is used to display "not connected" message.
2. Ensure ```isProcessing``` is reset even when analysis fails by wrapping the analysis flow in a ```try-finally block``` to prevent indefinite processing on screen.

## Screenshots / Recordings
https://github.com/user-attachments/assets/7d3b0901-1015-4d9d-91e0-73880ac4f6d2

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.