### PR TITLE
chore: include iOS IPA files in app branch

### DIFF
--- a/.github/actions/ios/action.yml
+++ b/.github/actions/ios/action.yml
@@ -27,19 +27,34 @@ runs:
         pod install --repo-update
 
     - name: Build iOS IPA (No code signing for PRs)
-      if: ${{ github.event_name == 'pull_request' }}
+      # if: ${{ github.event_name == 'pull_request' }} # TODO: Uncomment once iOS certs are renewed.
       shell: bash
       env:
         VERSION_NAME: ${{ inputs.VERSION_NAME }}
         VERSION_CODE: ${{ inputs.VERSION_CODE }}
       run: |
-        flutter build ipa --no-codesign --build-name $VERSION_NAME --build-number $VERSION_CODE
+        flutter build ios --release --no-codesign --build-name "$VERSION_NAME" --build-number "$VERSION_CODE"
 
-    - name: Build iOS IPA (With Code Signing)
-      if: ${{ github.event_name != 'pull_request' }}
-      shell: bash
-      env:
-        VERSION_NAME: ${{ inputs.VERSION_NAME }}
-        VERSION_CODE: ${{ inputs.VERSION_CODE }}
-      run: |
-        flutter build ipa --build-name $VERSION_NAME --build-number $VERSION_CODE
+        cd build/ios/iphoneos
+        mkdir Payload
+        cp -r Runner.app Payload/
+        zip -qr pslab-unsigned.ipa Payload/
+        mv pslab-unsigned.ipa ../../../
+
+    # - name: Build Signed iOS IPA (For Production) # TODO: Uncomment once iOS certs are renewed.
+    #  if: ${{ github.event_name != 'pull_request' }}
+    #  shell: bash
+    #  env:
+    #    VERSION_NAME: ${{ inputs.VERSION_NAME }}
+    #   VERSION_CODE: ${{ inputs.VERSION_CODE }}
+    # run: |
+        # flutter build ipa --build-name "$VERSION_NAME" --build-number "$VERSION_CODE"
+
+    - name: Store IPA file
+      uses: actions/upload-artifact@v7
+      with:
+        name: iOS IPA Generated
+        path: |
+          pslab-unsigned.ipa
+          build/ios/ipa/*.ipa
+        if-no-files-found: ignore

--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -129,26 +129,28 @@ jobs:
 
       - uses: actions/checkout@v7
 
-      - name: Prepare Build Keys
-        if: ${{ github.repository == 'fossasia/pslab-app' }}
-        env:
-          ENCRYPTED_IOS_IV: ${{ secrets.ENCRYPTED_IOS_IV }}
-          ENCRYPTED_IOS_KEY: ${{ secrets.ENCRYPTED_IOS_KEY }}
-        run: |
-          bash scripts/prep-ios-key.sh
+      # # TODO: Uncomment once iOS certs are renewed.
+      # - name: Prepare Build Keys
+      #   if: ${{ github.repository == 'fossasia/pslab-app' }}
+      #   env:
+      #     ENCRYPTED_IOS_IV: ${{ secrets.ENCRYPTED_IOS_IV }}
+      #     ENCRYPTED_IOS_KEY: ${{ secrets.ENCRYPTED_IOS_KEY }}
+      #   run: |
+      #     bash scripts/prep-ios-key.sh
 
-      - name: Setup Certs
-        if: ${{ github.repository == 'fossasia/pslab-app' }}
-        env:
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
-        run: |
-          cd ./iOS
-          git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
-          fastlane setupCertificates
-          if [[ $? -ne 0 ]]; then
-              exit 1
-          fi
+      # # TODO: Uncomment once iOS certs are renewed.
+      # - name: Setup Certs
+      #   if: ${{ github.repository == 'fossasia/pslab-app' }}
+      #   env:
+      #     MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+      #     MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+      #   run: |
+      #     cd ./iOS
+      #     git clone --branch=fastlane-ios --depth=1 https://${{ github.repository_owner }}:${{ github.token }}@github.com/${{ github.repository }} fastlane
+      #     fastlane setupCertificates
+      #     if [[ $? -ne 0 ]]; then
+      #         exit 1
+      #     fi
 
       - name: iOS Workflow
         uses: ./.github/actions/ios
@@ -156,14 +158,25 @@ jobs:
           VERSION_NAME: ${{needs.common.outputs.VERSION_NAME}}
           VERSION_CODE: ${{needs.common.outputs.VERSION_CODE}}
 
-      - name: Push app to testflight
-        if: ${{ github.repository == 'fossasia/pslab-app' }}
-        run: |
-          cd ./iOS
-          fastlane uploadToBeta
-          if [[ $? -ne 0 ]]; then
-              exit 1
-          fi
+      # # TODO: Uncomment once iOS certs are renewed.
+      # - name: Push app to testflight
+      #   if: ${{ github.repository == 'fossasia/pslab-app' }}
+      #   run: |
+      #     cd ./iOS
+      #     fastlane uploadToBeta
+      #     if [[ $? -ne 0 ]]; then
+      #         exit 1
+      #     fi
+
+      - name: Upload iOS IPA
+        uses: actions/upload-artifact@v7
+        with:
+          name: iOS IPA Generated
+          # TODO: Remove pslab-unsigned.ipa from this list once iOS certs are renewed.
+          path: |
+            pslab-unsigned.ipa 
+            build/ios/ipa/*.ipa
+          if-no-files-found: ignore
 
   web:
     name: Web App Flutter Build
@@ -271,7 +284,7 @@ jobs:
 
   publish-app-branch:
     name: Publish artifacts to app branch
-    needs: [android, windows, linux, linux-arm64, macos, web]
+    needs: [android, ios, windows, linux, linux-arm64, macos, web]
     if: ${{ github.repository == 'fossasia/pslab-app' }}
     runs-on: ubuntu-latest
 
@@ -302,7 +315,7 @@ jobs:
 
           echo "Removing old artifacts"
 
-          find . -maxdepth 1 -type f \( -name '*.apk' -o -name '*.aab' -o -name '*.exe' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.zip' \) -delete
+          find . -maxdepth 1 -type f \( -name '*.apk' -o -name '*.aab' -o -name '*.ipa' -o -name '*.exe' -o -name '*.deb' -o -name '*.rpm' -o -name '*.dmg' -o -name '*.zip' \) -delete
 
           echo "Removing debug artifacts"
           
@@ -313,6 +326,7 @@ jobs:
           find ../artifacts -type f \( \
             -name '*.apk' -o \
             -name '*.aab' -o \
+            -name '*.ipa' -o \
             -name '*.exe' -o \
             -name '*.deb' -o \
             -name '*.rpm' -o \


### PR DESCRIPTION
Fixes #3333

### Changes

- Temporarily commented out iOS code-signing steps until iOS certificates are renewed/fixed.
- Enabled CI to build and upload unsigned `.ipa` artifacts for PRs and pushes.
- Updated `publish-app-branch` to sync iOS artifacts.
- Verified the generated `.ipa` on a physical iOS device via BrowserStack.
- Link: https://github.com/fossasia/pslab-app/actions/runs/27943623096/artifacts/7788680953


## Screenshots / Recordings
<img width="1913" height="960" alt="Screenshot 2026-06-22 133845" src="https://github.com/user-attachments/assets/41114117-8455-448c-ac08-7c70e13ccb79" />
<img width="1917" height="837" alt="Screenshot 2026-06-22 133919" src="https://github.com/user-attachments/assets/1423ef52-ef8b-4823-98a2-b92f10fdbc4f" />


**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.