### PR TITLE
fix: apply pressure limit to gauge

### DIFF
--- a/lib/providers/barometer_state_provider.dart
+++ b/lib/providers/barometer_state_provider.dart
@@ -170,7 +170,12 @@ class BarometerStateProvider extends ChangeNotifier {
 
     _barometerSubscription = barometerEventStream().listen(
       (BarometerEvent event) {
-        _currentPressure = event.pressure / 1013.25;
+        double pressure = event.pressure / 1013.25;
+        final limit = _currentLimit;
+        if (limit != null && pressure > limit) {
+          pressure = limit;
+        }
+        _currentPressure = pressure;
         _currentAltitude = _pressureToAltitude(_currentPressure);
         _currentTemperature = 0.0;
 


### PR DESCRIPTION
Fixes #3359

## Changes
Fixes an issue where the barometer gauge displayed the raw sensor pressure value instead of respecting the configured pressure limit.
Applied the configured pressure limit before updating _currentPressure.

## Screenshots / Recordings
High limit is working properly:
 
https://github.com/user-attachments/assets/bec1ed76-2d3a-4037-95d8-6fd9ad1b0ea7



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Ensure the barometer gauge respects the configured pressure limit instead of displaying raw sensor pressure values.