### PR TITLE
fix: correct soundmeter instrument name for chart config and playback

### DIFF
--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -330,7 +330,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
           'xDataColumnIndex': 0,
           'yDataColumnIndex': 2,
         };
-      case 'soundmeter':
+      case 'sound meter':
         return {
           'xAxisLabel': appLocalizations.timeAxisLabel,
           'yAxisLabel': appLocalizations.db,


### PR DESCRIPTION
## Problem
Tapping Play on a Sound Meter log in the Logged Data screen did nothing.

The root cause was a name mismatch:
- `_getChartConfig()` matched on `'soundmeter'` (no space)
- `_playFile()` matched on `'sound meter'` (with space)
- The actual value from `appLocalizations.soundMeter.toLowerCase()` is `"sound meter"` (with space)

So `_getChartConfig` never matched, and playback silently fell through.

## Fix
Changed `case 'soundmeter':` to `case 'sound meter':` in `_getChartConfig` so both methods use the same string.

## Files changed
- `lib/view/logged_data_screen.dart` — 1 line changed

## Summary by Sourcery

Bug Fixes:
- Fix sound meter log playback by correcting the instrument name used in chart configuration matching.