### PR TITLE
fix: cancel stream subscriptions in BoardStateProvider on dispose

### DIFF
--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -48,33 +48,33 @@ class BoardStateProvider extends ChangeNotifier {
 
     if (configProvider.config.autoStart) {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        _usbSubscription ??= UsbSerial.usbEventStream?.listen(
-          (UsbEvent usbEvent) async {
-            if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
-              if (_isProcessing) return;
-              _isProcessing = true;
-              if (!scienceLabCommon.isConnected() &&
-                  await attemptToConnectPSLab()) {
-                pslabIsConnected = await scienceLabCommon.openDevice();
-                await setPSLabVersionIDs();
-                await fetchFirmwareVersion();
-                _isProcessing = false;
-              }
-            } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
-                !scienceLabCommon.isWiFiConnected()) {
-              scienceLabCommon.setConnected(false);
-              pslabIsConnected = false;
-              pslabVersionID = 'Not Connected';
-              notifyListeners();
+        _usbSubscription ??= UsbSerial.usbEventStream?.listen((
+          UsbEvent usbEvent,
+        ) async {
+          if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
+            if (_isProcessing) return;
+            _isProcessing = true;
+            if (!scienceLabCommon.isConnected() &&
+                await attemptToConnectPSLab()) {
+              pslabIsConnected = await scienceLabCommon.openDevice();
+              await setPSLabVersionIDs();
+              await fetchFirmwareVersion();
+              _isProcessing = false;
             }
-          },
-        );
+          } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
+              !scienceLabCommon.isWiFiConnected()) {
+            scienceLabCommon.setConnected(false);
+            pslabIsConnected = false;
+            pslabVersionID = 'Not Connected';
+            notifyListeners();
+          }
+        });
       }
     }
 
-    _connectivitySubscription ??= Connectivity()
-        .onConnectivityChanged
-        .listen((List<ConnectivityResult> results) {
+    _connectivitySubscription ??= Connectivity().onConnectivityChanged.listen((
+      List<ConnectivityResult> results,
+    ) {
       if (results.contains(ConnectivityResult.none)) {
         scienceLabCommon.setWiFiConnected(false);
         pslabIsConnected = false;
@@ -104,8 +104,10 @@ class BoardStateProvider extends ChangeNotifier {
 
   Future<void> fetchFirmwareVersion() async {
     if (getIt.get<ScienceLab>().isConnected()) {
-      pslabFirmwareVersion =
-          await getIt.get<ScienceLab>().mPacketHandler.getFirmwareVersion();
+      pslabFirmwareVersion = await getIt
+          .get<ScienceLab>()
+          .mPacketHandler
+          .getFirmwareVersion();
     }
     if (pslabFirmwareVersion < 3 && pslabFirmwareVersion != 0) {
       legacyFirmwareNotifier.value = "LegacyFirmwareDetected";

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -48,6 +48,7 @@ class BoardStateProvider extends ChangeNotifier {
 
     if (configProvider.config.autoStart) {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
+        await _usbSubscription?.cancel();
         _usbSubscription = UsbSerial.usbEventStream?.listen(
           (UsbEvent usbEvent) async {
             if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
@@ -72,6 +73,7 @@ class BoardStateProvider extends ChangeNotifier {
       }
     }
 
+    await _connectivitySubscription?.cancel();
     _connectivitySubscription = Connectivity()
         .onConnectivityChanged
         .listen((List<ConnectivityResult> results) {

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -23,6 +25,8 @@ class BoardStateProvider extends ChangeNotifier {
   int pslabVersion = 0;
   int pslabFirmwareVersion = 0;
   bool _isProcessing = false;
+  StreamSubscription<UsbEvent>? _usbSubscription;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
 
   final ValueNotifier<String?> legacyFirmwareNotifier = ValueNotifier(null);
 
@@ -44,7 +48,7 @@ class BoardStateProvider extends ChangeNotifier {
 
     if (configProvider.config.autoStart) {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        UsbSerial.usbEventStream?.listen(
+        _usbSubscription = UsbSerial.usbEventStream?.listen(
           (UsbEvent usbEvent) async {
             if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
               if (_isProcessing) return;
@@ -68,7 +72,7 @@ class BoardStateProvider extends ChangeNotifier {
       }
     }
 
-    Connectivity()
+    _connectivitySubscription = Connectivity()
         .onConnectivityChanged
         .listen((List<ConnectivityResult> results) {
       if (results.contains(ConnectivityResult.none)) {
@@ -119,5 +123,13 @@ class BoardStateProvider extends ChangeNotifier {
       }
     }
     return false;
+  }
+
+  @override
+  void dispose() {
+    _usbSubscription?.cancel();
+    _connectivitySubscription?.cancel();
+    legacyFirmwareNotifier.dispose();
+    super.dispose();
   }
 }

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -48,33 +48,33 @@ class BoardStateProvider extends ChangeNotifier {
 
     if (configProvider.config.autoStart) {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        _usbSubscription ??= UsbSerial.usbEventStream?.listen((
-          UsbEvent usbEvent,
-        ) async {
-          if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
-            if (_isProcessing) return;
-            _isProcessing = true;
-            if (!scienceLabCommon.isConnected() &&
-                await attemptToConnectPSLab()) {
-              pslabIsConnected = await scienceLabCommon.openDevice();
-              await setPSLabVersionIDs();
-              await fetchFirmwareVersion();
-              _isProcessing = false;
+        _usbSubscription ??= UsbSerial.usbEventStream?.listen(
+          (UsbEvent usbEvent) async {
+            if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
+              if (_isProcessing) return;
+              _isProcessing = true;
+              if (!scienceLabCommon.isConnected() &&
+                  await attemptToConnectPSLab()) {
+                pslabIsConnected = await scienceLabCommon.openDevice();
+                await setPSLabVersionIDs();
+                await fetchFirmwareVersion();
+                _isProcessing = false;
+              }
+            } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
+                !scienceLabCommon.isWiFiConnected()) {
+              scienceLabCommon.setConnected(false);
+              pslabIsConnected = false;
+              pslabVersionID = 'Not Connected';
+              notifyListeners();
             }
-          } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
-              !scienceLabCommon.isWiFiConnected()) {
-            scienceLabCommon.setConnected(false);
-            pslabIsConnected = false;
-            pslabVersionID = 'Not Connected';
-            notifyListeners();
-          }
-        });
+          },
+        );
       }
     }
 
-    _connectivitySubscription ??= Connectivity().onConnectivityChanged.listen((
-      List<ConnectivityResult> results,
-    ) {
+    _connectivitySubscription ??= Connectivity()
+        .onConnectivityChanged
+        .listen((List<ConnectivityResult> results) {
       if (results.contains(ConnectivityResult.none)) {
         scienceLabCommon.setWiFiConnected(false);
         pslabIsConnected = false;
@@ -104,10 +104,8 @@ class BoardStateProvider extends ChangeNotifier {
 
   Future<void> fetchFirmwareVersion() async {
     if (getIt.get<ScienceLab>().isConnected()) {
-      pslabFirmwareVersion = await getIt
-          .get<ScienceLab>()
-          .mPacketHandler
-          .getFirmwareVersion();
+      pslabFirmwareVersion =
+          await getIt.get<ScienceLab>().mPacketHandler.getFirmwareVersion();
     }
     if (pslabFirmwareVersion < 3 && pslabFirmwareVersion != 0) {
       legacyFirmwareNotifier.value = "LegacyFirmwareDetected";

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -48,8 +48,7 @@ class BoardStateProvider extends ChangeNotifier {
 
     if (configProvider.config.autoStart) {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        await _usbSubscription?.cancel();
-        _usbSubscription = UsbSerial.usbEventStream?.listen(
+        _usbSubscription ??= UsbSerial.usbEventStream?.listen(
           (UsbEvent usbEvent) async {
             if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
               if (_isProcessing) return;
@@ -73,8 +72,7 @@ class BoardStateProvider extends ChangeNotifier {
       }
     }
 
-    await _connectivitySubscription?.cancel();
-    _connectivitySubscription = Connectivity()
+    _connectivitySubscription ??= Connectivity()
         .onConnectivityChanged
         .listen((List<ConnectivityResult> results) {
       if (results.contains(ConnectivityResult.none)) {


### PR DESCRIPTION
## Summary
Two stream subscriptions in `BoardStateProvider` were never cancelled, causing a memory leak on every re-initialization of the provider.

## Root Cause
`BoardStateProvider.initialize()` subscribes to two streams:

| Stream | Purpose |
|--------|---------|
| `UsbSerial.usbEventStream` | Detects USB attach/detach events |
| `Connectivity().onConnectivityChanged` | Detects WiFi disconnect |

Both `.listen()` calls return a `StreamSubscription` object that must be stored and cancelled when the provider is destroyed. Previously, the return values were discarded entirely:

```dart
// Before — return value thrown away, can never be cancelled
UsbSerial.usbEventStream?.listen((UsbEvent usbEvent) async {
  ...
});

Connectivity().onConnectivityChanged.listen((results) {
  ...
});
```

This means every time `initialize()` is called (e.g. on hot-restart or re-init), a new subscription is added on top of the old one. Over time, multiple subscriptions fire for the same event, wasting memory and CPU.

## Fix
Stored both subscriptions in named fields and cancelled them in
`dispose()`:

```dart
// After — subscriptions stored and cancelled on dispose
StreamSubscription<UsbEvent>? _usbSubscription;
StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;

// In initialize():
_usbSubscription = UsbSerial.usbEventStream?.listen(...);
_connectivitySubscription = Connectivity().onConnectivityChanged.listen(...);

// New dispose() method:
@override
void dispose() {
  _usbSubscription?.cancel();
  _connectivitySubscription?.cancel();
  legacyFirmwareNotifier.dispose();
  super.dispose();
}
```

Also added `legacyFirmwareNotifier.dispose()` in the same `dispose()` method since `ValueNotifier` should also be disposed when the provider is destroyed.

## Impact
- Prevents accumulation of duplicate stream listeners on re-init
- Frees memory when `BoardStateProvider` is no longer needed
- Follows Flutter best practice for `ChangeNotifier` lifecycle

## Files Changed
- `lib/providers/board_state_provider.dart`

## Summary by Sourcery

Ensure BoardStateProvider cleans up its resources on disposal to prevent leaks and duplicate event handling.

Bug Fixes:
- Prevent memory and CPU leaks by cancelling USB and connectivity stream subscriptions when BoardStateProvider is disposed.

Enhancements:
- Dispose legacyFirmwareNotifier alongside BoardStateProvider to align with ChangeNotifier lifecycle best practices.