### PR TITLE
fix: Robotic Arm logs navigation

### DIFF
--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -22,6 +22,7 @@ import '../providers/locator.dart';
 import 'accelerometer_screen.dart';
 import 'compass_screen.dart';
 import 'package:pslab/view/thermometer_screen.dart';
+import 'package:pslab/view/robotic_arm_screen.dart';
 
 class LoggedDataScreen extends StatefulWidget {
   final List<String> instrumentNames;
@@ -362,7 +363,15 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
     final data = await _dataService.readDataFromFile(file);
     if (mounted) {
       if (instrumentName.toLowerCase() == 'robotic arm') {
-        Navigator.pop(context, data);
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => RoboticArmScreen(
+              importedData: data,
+            ),
+          ),
+        );
+        return;
       } else {
         final config = _getChartConfig(instrumentName);
         Navigator.push(

--- a/lib/view/robotic_arm_screen.dart
+++ b/lib/view/robotic_arm_screen.dart
@@ -15,7 +15,12 @@ import 'package:pslab/view/widgets/guide_widget.dart';
 import 'widgets/servo_card.dart';
 
 class RoboticArmScreen extends StatefulWidget {
-  const RoboticArmScreen({super.key});
+  final List<List<dynamic>>? importedData;
+
+  const RoboticArmScreen({
+    super.key,
+    this.importedData,
+  });
 
   @override
   State<RoboticArmScreen> createState() => _RoboticArmScreenState();
@@ -39,6 +44,11 @@ class _RoboticArmScreenState extends State<RoboticArmScreen> {
     ];
     provider = RoboticArmStateProvider();
     provider.initialize();
+    if (widget.importedData != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) async {
+        await provider.importTimelineData(widget.importedData!);
+      });
+    }
 
     provider.onPlaybackEnd = () {
       showDialog(


### PR DESCRIPTION
Fixes #3366

## Changes
Fixed Robotic Arm log import to always navigate to the Robotic Arm screen after selecting a log.

## Screenshots / Recordings

https://github.com/user-attachments/assets/2bebb54d-b86e-478c-9af1-40b1bd806849



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.