### PR TITLE
fix: add error handling for launchUrl in About Us feedback link

### DIFF
--- a/lib/view/about_us_screen.dart
+++ b/lib/view/about_us_screen.dart
@@ -36,7 +36,7 @@ Widget buildContactList(List<Map<String, dynamic>> items) {
           if (await canLaunchUrl(uri)) {
             await launchUrl(uri);
           } else {
-            debugPrint('Could not launch ${item['url']}');
+            logger.e('Could not launch URL: ${item['url']}');
           }
         },
       );
@@ -140,8 +140,7 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                     await launchUrl(uri);
                   } else {
                     logger.e(
-                      'Could not launch feedback form URL',
-                      'url=${appLocalizations.feedbackForm}',
+                      'Could not launch feedback form URL: ${appLocalizations.feedbackForm}',
                     );
                   }
                 },

--- a/lib/view/about_us_screen.dart
+++ b/lib/view/about_us_screen.dart
@@ -135,7 +135,14 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                   style: const TextStyle(fontSize: 15),
                 ),
                 onTap: () async {
-                  await launchUrl(Uri.parse(appLocalizations.feedbackForm));
+                  final uri = Uri.parse(appLocalizations.feedbackForm);
+                  if (await canLaunchUrl(uri)) {
+                    await launchUrl(uri);
+                  } else {
+                    debugPrint(
+                      'Could not launch ${appLocalizations.feedbackForm}',
+                    );
+                  }
                 },
               ),
               const Divider(thickness: 0.5),
@@ -162,7 +169,8 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                       );
                     } else if (snapshot.hasError) {
                       logger.e(
-                          "Error getting version information: ${snapshot.error.toString()}");
+                        "Error getting version information: ${snapshot.error.toString()}",
+                      );
                       return Text(
                         appLocalizations.error,
                         style: const TextStyle(fontSize: 15),

--- a/lib/view/about_us_screen.dart
+++ b/lib/view/about_us_screen.dart
@@ -139,8 +139,9 @@ class _AboutUsScreenState extends State<AboutUsScreen> {
                   if (await canLaunchUrl(uri)) {
                     await launchUrl(uri);
                   } else {
-                    debugPrint(
-                      'Could not launch ${appLocalizations.feedbackForm}',
+                    logger.e(
+                      'Could not launch feedback form URL',
+                      'url=${appLocalizations.feedbackForm}',
                     );
                   }
                 },


### PR DESCRIPTION
Fixes #3374

## Problem
The feedback/bug-report link in the About Us screen called `launchUrl()` directly with no `canLaunchUrl` check and no `try/catch`. If the URL fails to launch for any reason (no browser, network issue, invalid URL), the app throws an unhandled exception and crashes.

## Root Cause
Line 138 of `lib/view/about_us_screen.dart` called launchUrl directly without checking if the URL could actually be launched. Other links in the same file already use a `canLaunchUrl` guard correctly, but this one was missed.

## Fix
Added a `canLaunchUrl` check before calling `launchUrl`, consistent with the existing pattern used by other links in the same file. If the URL cannot be launched, it now logs a debug message instead of crashing.

## Impact
- Prevents app crash when feedback URL cannot be launched
- Consistent with how all other links in about_us_screen.dart are handled
- No UI change

## Screenshots / Recordings
N/A — crash fix, no UI changes

## Checklist
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Add defensive URL launch handling for the About Us feedback link to prevent crashes when the feedback form cannot be opened.

Bug Fixes:
- Prevent app crashes on the About Us feedback link by checking URL launch capability before invoking launchUrl.

Enhancements:
- Improve error logging formatting when version information fails to load.