### PR TITLE
fix: replace unhandled throw with logger.e in FAQ screen launchUrl

### DIFF
--- a/lib/view/faq_screen.dart
+++ b/lib/view/faq_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/theme/colors.dart';
 import 'package:pslab/view/widgets/main_scaffold_widget.dart';
@@ -147,7 +148,7 @@ class FAQScreen extends StatelessWidget {
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
     } else {
-      throw '${appLocalizations.launchError} $url';
+      logger.e('${appLocalizations.launchError} $url');
     }
   }
 }


### PR DESCRIPTION
Fixes #3384

## Problem
`_launchURL()` in `lib/view/faq_screen.dart` throws a raw string exception when `canLaunchUrl` returns false. The only call site is a fire-and-forget `onTap` handler with no `try/catch`, so the exception is never caught and crashes the app.

## Root Cause
```dart
Future<void> _launchURL(String url) async {
  final Uri uri = Uri.parse(url);
  if (await canLaunchUrl(uri)) {
    await launchUrl(uri);
  } else {
    throw '${appLocalizations.launchError} $url';
  }
}
```

The call site:
```dart
onTap: () => _launchURL(faq.linkUrl!),
```

## Fix
Replaced the `throw` with `logger.e()`, matching the pattern already used in `about_us_screen.dart` for the same kind of failure:

```dart
Future<void> _launchURL(String url) async {
  final Uri uri = Uri.parse(url);
  if (await canLaunchUrl(uri)) {
    await launchUrl(uri);
  } else {
    logger.e('${appLocalizations.launchError} $url');
  }
}
```

## Impact
- Prevents app crash when a FAQ link cannot be launched
- Consistent with existing logger usage elsewhere in the app
- No UI change

## Screenshots / Recordings
N/A — crash fix, no UI changes

## Checklist
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Bug Fixes:
- Prevent app crashes when failing to launch FAQ links by logging errors instead of throwing uncaught exceptions.