### PR TITLE
fix: replace hardcoded 'Not Connected' string with localized value

### DIFF
--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -29,6 +29,7 @@ class BoardStateProvider extends ChangeNotifier {
   BoardStateProvider() {
     scienceLabCommon = getIt.get<ScienceLabCommon>();
     configProvider = SettingsConfigProvider();
+    pslabVersionID = appLocalizations.notConnected;
   }
 
   Future<void> initialize() async {

--- a/lib/providers/board_state_provider.dart
+++ b/lib/providers/board_state_provider.dart
@@ -17,7 +17,7 @@ class BoardStateProvider extends ChangeNotifier {
   bool pslabIsConnected = false;
   bool hasPermission = false;
   late ScienceLabCommon scienceLabCommon;
-  String pslabVersionID = 'Not Connected';
+  String pslabVersionID = '';
   String pslabVersionIDV6 = 'PSLab V6';
   String pslabVersionIDV5 = 'PSLab V5';
   int pslabVersion = 0;
@@ -44,37 +44,35 @@ class BoardStateProvider extends ChangeNotifier {
 
     if (configProvider.config.autoStart) {
       if (!kIsWeb && defaultTargetPlatform == TargetPlatform.android) {
-        UsbSerial.usbEventStream?.listen(
-          (UsbEvent usbEvent) async {
-            if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
-              if (_isProcessing) return;
-              _isProcessing = true;
-              if (!scienceLabCommon.isConnected() &&
-                  await attemptToConnectPSLab()) {
-                pslabIsConnected = await scienceLabCommon.openDevice();
-                await setPSLabVersionIDs();
-                await fetchFirmwareVersion();
-                _isProcessing = false;
-              }
-            } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
-                !scienceLabCommon.isWiFiConnected()) {
-              scienceLabCommon.setConnected(false);
-              pslabIsConnected = false;
-              pslabVersionID = 'Not Connected';
-              notifyListeners();
+        UsbSerial.usbEventStream?.listen((UsbEvent usbEvent) async {
+          if (usbEvent.event == UsbEvent.ACTION_USB_ATTACHED) {
+            if (_isProcessing) return;
+            _isProcessing = true;
+            if (!scienceLabCommon.isConnected() &&
+                await attemptToConnectPSLab()) {
+              pslabIsConnected = await scienceLabCommon.openDevice();
+              await setPSLabVersionIDs();
+              await fetchFirmwareVersion();
+              _isProcessing = false;
             }
-          },
-        );
+          } else if (usbEvent.event == UsbEvent.ACTION_USB_DETACHED &&
+              !scienceLabCommon.isWiFiConnected()) {
+            scienceLabCommon.setConnected(false);
+            pslabIsConnected = false;
+            pslabVersionID = appLocalizations.notConnected;
+            notifyListeners();
+          }
+        });
       }
     }
 
-    Connectivity()
-        .onConnectivityChanged
-        .listen((List<ConnectivityResult> results) {
+    Connectivity().onConnectivityChanged.listen((
+      List<ConnectivityResult> results,
+    ) {
       if (results.contains(ConnectivityResult.none)) {
         scienceLabCommon.setWiFiConnected(false);
         pslabIsConnected = false;
-        pslabVersionID = 'Not Connected';
+        pslabVersionID = appLocalizations.notConnected;
         notifyListeners();
       }
     });
@@ -100,8 +98,10 @@ class BoardStateProvider extends ChangeNotifier {
 
   Future<void> fetchFirmwareVersion() async {
     if (getIt.get<ScienceLab>().isConnected()) {
-      pslabFirmwareVersion =
-          await getIt.get<ScienceLab>().mPacketHandler.getFirmwareVersion();
+      pslabFirmwareVersion = await getIt
+          .get<ScienceLab>()
+          .mPacketHandler
+          .getFirmwareVersion();
     }
     if (pslabFirmwareVersion < 3 && pslabFirmwareVersion != 0) {
       legacyFirmwareNotifier.value = "LegacyFirmwareDetected";


### PR DESCRIPTION
Fixes #3392

## Problem
`pslabVersionID` in `BoardStateProvider` was hardcoded to the English string `'Not Connected'` in three places:

- Field declaration (line 20)
- USB detach event handler
- WiFi disconnect handler

This means all non-English users always see "Not Connected" in English regardless of their chosen app language, breaking the app's internationalization (i18n) support.

## Root Cause
The string was hardcoded directly instead of using the existing localization key. The `notConnected` key already exists in `lib/l10n/app_en.arb` and all other supported language ARB files, so no new translations were needed.

## Fix
Replaced all three instances of `'Not Connected'` with `appLocalizations.notConnected`. Also changed the field declaration default from `'Not Connected'` to `''` since `appLocalizations` is a getter and cannot be used at field declaration time.

## Impact
- Non-English users now see the correct translated string for the disconnected state
- No functional change for English users
- No new translation keys needed — `notConnected` already exists in all language files

## Screenshots / Recordings
N/A — localization fix, no visual change for English users

## Checklist
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Localize the board disconnection status text and tidy related provider logic.

Bug Fixes:
- Use the localized `notConnected` string for the PSLab disconnection status so it respects the app language settings.

Enhancements:
- Initialize the PSLab version ID field with an empty string and slightly refactor event listener formatting for USB and connectivity handlers.