### PR TITLE
fix: add error handling for launchUrl in Map screen

### DIFF
--- a/lib/view/map_screen.dart
+++ b/lib/view/map_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/providers/locator.dart';
 import 'package:pslab/theme/colors.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -59,8 +60,17 @@ class MapScreen extends StatelessWidget {
               attributions: [
                 TextSourceAttribution(
                   appLocalizations.openStreetMapContributors,
-                  onTap: () => launchUrl(
-                      Uri.parse('https://openstreetmap.org/copyright')),
+                  onTap: () async {
+                    final uri =
+                        Uri.parse('https://openstreetmap.org/copyright');
+                    if (await canLaunchUrl(uri)) {
+                      await launchUrl(uri);
+                    } else {
+                      logger.e(
+                        'Could not launch https://openstreetmap.org/copyright',
+                      );
+                    }
+                  },
                 ),
               ],
             ),


### PR DESCRIPTION
Fixes #3400

## Problem
The OpenStreetMap attribution link in `lib/view/map_screen.dart` called `launchUrl()` directly with no `canLaunchUrl` check and no error handling. If the URL fails to launch for any reason (no browser, network issue), the app throws an unhandled exception and crashes.

## Root Cause
The `onTap` handler used a fire-and-forget `launchUrl` call with no guard, unlike other links in the app which already use `canLaunchUrl` correctly.

## Fix
Added `canLaunchUrl` check and `logger.e()` for the failure case, consistent with the existing pattern already used in `about_us_screen.dart`, `faq_screen.dart` and `connect_device_screen.dart`.

## Impact
- Prevents app crash when the OpenStreetMap attribution URL cannot be launched
- Consistent with existing error handling pattern in the app
- No UI change

## Screenshots / Recordings
N/A — crash fix, no UI changes

## Checklist
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.