### PR TITLE
fix: add error handling for launchUrlString in Software Licenses screen

### DIFF
--- a/lib/view/software_licenses_screen.dart
+++ b/lib/view/software_licenses_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pslab/l10n/app_localizations.dart';
+import 'package:pslab/others/logger_service.dart';
 import 'package:pslab/oss_licenses.dart';
 import 'package:pslab/view/widgets/main_scaffold_widget.dart';
-import 'package:url_launcher/url_launcher_string.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class SoftwareLicensesScreen extends StatelessWidget {
   const SoftwareLicensesScreen({super.key});
@@ -140,7 +141,16 @@ class MiscOssLicenseSingle extends StatelessWidget {
                         color: Colors.blue,
                         decoration: TextDecoration.underline),
                   ),
-                  onTap: () => launchUrlString(package.homepage!),
+                  onTap: () async {
+                    final uri = Uri.parse(package.homepage!);
+                    if (await canLaunchUrl(uri)) {
+                      await launchUrl(uri);
+                    } else {
+                      logger.e(
+                        'Could not launch ${package.homepage}',
+                      );
+                    }
+                  },
                 ),
               ),
             ],

--- a/lib/view/software_licenses_screen.dart
+++ b/lib/view/software_licenses_screen.dart
@@ -142,9 +142,20 @@ class MiscOssLicenseSingle extends StatelessWidget {
                         decoration: TextDecoration.underline),
                   ),
                   onTap: () async {
-                    final uri = Uri.parse(package.homepage!);
+                    final uri = Uri.tryParse(package.homepage!);
+                    if (uri == null) {
+                      logger.e(
+                        'Invalid URL: ${package.homepage}',
+                      );
+                      return;
+                    }
                     if (await canLaunchUrl(uri)) {
-                      await launchUrl(uri);
+                      final launched = await launchUrl(uri);
+                      if (!launched) {
+                        logger.e(
+                          'launchUrl returned false for ${package.homepage} after canLaunchUrl succeeded',
+                        );
+                      }
                     } else {
                       logger.e(
                         'Could not launch ${package.homepage}',


### PR DESCRIPTION
Fixes #3405

## Problem
The package homepage link in `lib/view/software_licenses_screen.dart` called `launchUrlString()` directly with no error handling. If the URL fails to launch for any reason (no browser, invalid URL, network issue), the app throws an unhandled exception and crashes.

## Root Cause
The `onTap` handler used `launchUrlString()` with no guard, unlike other links in the app which already use `canLaunchUrl` correctly. Also replaced the deprecated `url_launcher_string.dart` import with the standard `url_launcher.dart`.

## Fix
Replaced `launchUrlString` with `canLaunchUrl` check and `launchUrl` with `logger.e()` for the failure case, consistent with the existing pattern already used in `about_us_screen.dart`, `faq_screen.dart`, `connect_device_screen.dart` and `map_screen.dart`.

## Impact
- Prevents app crash when a package homepage URL cannot be launched
- Replaces deprecated `launchUrlString` with standard `launchUrl`
- Consistent with existing error handling pattern in the app
- No UI change

## Screenshots / Recordings
N/A — crash fix, no UI changes

## Checklist
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Handle failures when opening package homepage links from the Software Licenses screen to prevent crashes and align with existing URL handling patterns.

Bug Fixes:
- Prevent app crashes on the Software Licenses screen when a package homepage URL cannot be launched.

Enhancements:
- Replace deprecated url_launcher_string usage with the standard url_launcher API and integrate logging for URL launch failures.