### PR TITLE
fix: set Linux app version via pubspec workaround

### DIFF
--- a/.github/actions/linux-arm64/action.yml
+++ b/.github/actions/linux-arm64/action.yml
@@ -51,16 +51,8 @@ runs:
         for vf in build/linux/*/release/bundle/data/flutter_assets/version.json \
                   build/linux/*/release/bundle/share/pslab/flutter_assets/version.json; do
           [ -f "$vf" ] || continue
-          python3 -c "
-import json
-path = '''$vf'''
-with open(path) as f:
-    data = json.load(f)
-data['version'] = '''${{ inputs.VERSION_NAME }}'''
-data['build_number'] = '''${{ inputs.VERSION_CODE }}'''
-with open(path, 'w') as f:
-    json.dump(data, f)
-"
+          python3 -c "import json,sys; p,v,b=sys.argv[1:4]; d=json.load(open(p)); d['version']=v; d['build_number']=b; json.dump(d, open(p,'w'))" \
+            "$vf" "${{ inputs.VERSION_NAME }}" "${{ inputs.VERSION_CODE }}"
         done
 
     - name: Install fpm

--- a/.github/actions/linux-arm64/action.yml
+++ b/.github/actions/linux-arm64/action.yml
@@ -41,7 +41,27 @@ runs:
       run: |
         flutter config --enable-linux-desktop
         source linux/prep.sh
-        flutter build linux --build-name ${{ inputs.VERSION_NAME }} --build-number ${{ inputs.VERSION_CODE }}
+        # Flutter ignores --build-name/--build-number on Linux (flutter/flutter#152236).
+        # Bake the CI version into pubspec.yaml so version.json / PackageInfo are correct.
+        sed -i "s/^version: .*/version: ${{ inputs.VERSION_NAME }}+${{ inputs.VERSION_CODE }}/" pubspec.yaml
+        flutter build linux --release \
+          --build-name ${{ inputs.VERSION_NAME }} \
+          --build-number ${{ inputs.VERSION_CODE }}
+        # Ensure the bundled version.json matches even if Flutter still ignores the flags.
+        for vf in build/linux/*/release/bundle/data/flutter_assets/version.json \
+                  build/linux/*/release/bundle/share/pslab/flutter_assets/version.json; do
+          [ -f "$vf" ] || continue
+          python3 -c "
+import json
+path = '''$vf'''
+with open(path) as f:
+    data = json.load(f)
+data['version'] = '''${{ inputs.VERSION_NAME }}'''
+data['build_number'] = '''${{ inputs.VERSION_CODE }}'''
+with open(path, 'w') as f:
+    json.dump(data, f)
+"
+        done
 
     - name: Install fpm
       shell: bash

--- a/.github/actions/linux/action.yml
+++ b/.github/actions/linux/action.yml
@@ -31,7 +31,27 @@ runs:
       run: |
         flutter config --enable-linux-desktop
         source linux/prep.sh
-        flutter build linux --build-name ${{ inputs.VERSION_NAME }} --build-number ${{ inputs.VERSION_CODE }}
+        # Flutter ignores --build-name/--build-number on Linux (flutter/flutter#152236).
+        # Bake the CI version into pubspec.yaml so version.json / PackageInfo are correct.
+        sed -i "s/^version: .*/version: ${{ inputs.VERSION_NAME }}+${{ inputs.VERSION_CODE }}/" pubspec.yaml
+        flutter build linux --release \
+          --build-name ${{ inputs.VERSION_NAME }} \
+          --build-number ${{ inputs.VERSION_CODE }}
+        # Ensure the bundled version.json matches even if Flutter still ignores the flags.
+        for vf in build/linux/*/release/bundle/data/flutter_assets/version.json \
+                  build/linux/*/release/bundle/share/pslab/flutter_assets/version.json; do
+          [ -f "$vf" ] || continue
+          python3 -c "
+import json
+path = '''$vf'''
+with open(path) as f:
+    data = json.load(f)
+data['version'] = '''${{ inputs.VERSION_NAME }}'''
+data['build_number'] = '''${{ inputs.VERSION_CODE }}'''
+with open(path, 'w') as f:
+    json.dump(data, f)
+"
+        done
 
     - name: Install fpm
       shell: bash

--- a/.github/actions/linux/action.yml
+++ b/.github/actions/linux/action.yml
@@ -41,16 +41,8 @@ runs:
         for vf in build/linux/*/release/bundle/data/flutter_assets/version.json \
                   build/linux/*/release/bundle/share/pslab/flutter_assets/version.json; do
           [ -f "$vf" ] || continue
-          python3 -c "
-import json
-path = '''$vf'''
-with open(path) as f:
-    data = json.load(f)
-data['version'] = '''${{ inputs.VERSION_NAME }}'''
-data['build_number'] = '''${{ inputs.VERSION_CODE }}'''
-with open(path, 'w') as f:
-    json.dump(data, f)
-"
+          python3 -c "import json,sys; p,v,b=sys.argv[1:4]; d=json.load(open(p)); d['version']=v; d['build_number']=b; json.dump(d, open(p,'w'))" \
+            "$vf" "${{ inputs.VERSION_NAME }}" "${{ inputs.VERSION_CODE }}"
         done
 
     - name: Install fpm

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -37,6 +37,9 @@ jobs:
     name: Common Build
     needs: changes
     runs-on: ubuntu-latest
+    outputs:
+      VERSION_NAME: ${{ steps.flutter-version.outputs.VERSION_NAME }}
+      VERSION_CODE: ${{ steps.flutter-version.outputs.VERSION_CODE }}
     steps:
       - uses: actions/checkout@v7
         if: needs.changes.outputs.is_code == 'true'
@@ -44,6 +47,19 @@ jobs:
       - name: Common Workflow
         if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/common
+
+      - name: Read current version
+        if: needs.changes.outputs.is_code == 'true'
+        id: flutter-version
+        run: |
+          # Use the version branch (same source as push builds) without bumping,
+          # so Linux .deb/.rpm artifacts are not named with the default 1.0.0.
+          git clone --depth=1 --branch=version \
+            https://github.com/${{ github.event.pull_request.base.repo.full_name }} version
+          read -r version_name < version/versionName.txt
+          read -r version_code < version/versionCode.txt
+          echo "VERSION_NAME=$version_name" >> $GITHUB_OUTPUT
+          echo "VERSION_CODE=$version_code" >> $GITHUB_OUTPUT
 
       - name: Save PR number
         if: needs.changes.outputs.is_code == 'true'
@@ -212,6 +228,9 @@ jobs:
       - name: Linux Workflow
         if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/linux
+        with:
+          VERSION_NAME: ${{ needs.common.outputs.VERSION_NAME }}
+          VERSION_CODE: ${{ needs.common.outputs.VERSION_CODE }}
 
       - name: Non-Code Change
         if: needs.changes.outputs.is_code != 'true'
@@ -228,6 +247,9 @@ jobs:
       - name: Linux ARM64 Workflow
         if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/linux-arm64
+        with:
+          VERSION_NAME: ${{ needs.common.outputs.VERSION_NAME }}
+          VERSION_CODE: ${{ needs.common.outputs.VERSION_CODE }}
 
       - name: Non-Code Change
         if: needs.changes.outputs.is_code != 'true'


### PR DESCRIPTION
Fixes #3443

## Summary
- Flutter ignores `--build-name` / `--build-number` on Linux ([flutter/flutter#152236](https://github.com/flutter/flutter/issues/152236)), so Linux builds keep the default `1.0.0` from `pubspec.yaml`
- Before `flutter build linux`, set `pubspec.yaml` `version:` to the CI `VERSION_NAME` + `VERSION_CODE`
- After the build, patch bundled `version.json` as a fallback
- Applied in both `linux` and `linux-arm64` composite actions

## Test plan
- [ ] Linux CI build succeeds
- [ ] About Us shows the CI version (not `1.0.0`)
- [ ] `pslab -v` shows the same version

## Screenshots / Recordings
> N/A (CI/build metadata change)

## Summary by Sourcery

Ensure Linux builds embed the CI-provided app version by working around Flutter’s ignored build-name/build-number flags.

Bug Fixes:
- Correct Linux desktop app version metadata so it no longer defaults to 1.0.0 when built in CI.

CI:
- Update linux and linux-arm64 GitHub composite actions to patch pubspec.yaml and bundled version.json with the CI version information.