### PR TITLE
chore: Bump com.android.application from 9.2.1 to 9.3.1 in /android

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -28,8 +28,8 @@ runs:
     - name: Set up Java
       uses: actions/setup-java@v5
       with:
-        java-version: 17
-        distribution: 'adopt'
+        java-version: 21
+        distribution: 'temurin'
         cache: 'gradle'
 
     - name: Set up Flutter

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,12 +79,6 @@ android {
     buildFeatures {
         compose true
     }
-    lint {
-        checkDependencies false
-        checkReleaseBuilds true
-        abortOnError false
-        disable 'EasterEgg', 'StopShip'
-    }
 }
 
 dependencies {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -79,6 +79,12 @@ android {
     buildFeatures {
         compose true
     }
+    lint {
+        checkDependencies false
+        checkReleaseBuilds true
+        abortOnError false
+        disable 'EasterEgg', 'StopShip'
+    }
 }
 
 dependencies {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "9.2.1" apply false
+    id "com.android.application" version "9.3.1" apply false
     id "org.jetbrains.kotlin.android" version "2.4.10" apply false
     id "org.jetbrains.kotlin.plugin.compose" version "2.4.10" apply false
 }


### PR DESCRIPTION
Fixes #3436

## Changes

* **Dependencies:** Bumped `com.android.application` from `9.2.1` to `9.3.1` in `android/settings.gradle`.
* **CI** Updated the Android workflow to use Java 21 (`temurin`) to resolve linting crashes during the release build.

## Screenshots / Recordings
N/A

**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.