### PR TITLE
docs: regenerate app-branch download page (fix #3428)

### DIFF
--- a/.github/workflows/push-event.yml
+++ b/.github/workflows/push-event.yml
@@ -341,6 +341,9 @@ jobs:
             mv "$file" "pslab-$branch-${file#*-}"
           done
 
+          echo "Generating download page"
+          bash ../scripts/generate-app-download-page.sh "${{ github.repository }}" .
+
           git checkout --orphan temporary
           git add --all .
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This repository holds the Android App for performing experiments with [PSLab](ht
 
 The PSLab app is available for **Android**, **iOS**, **Windows**, **macOS**, **Linux**, and **Web**.
 
-For download links and installation instructions for all platforms, see the [PSLab Application documentation](https://docs.pslab.io/application/Readme.html).
+- Store listings and install guides: [PSLab Application documentation](https://docs.pslab.io/application/Readme.html)
+- Development builds (direct downloads): [Download page](https://github.com/fossasia/pslab-app/raw/refs/heads/app/index.html)
 
 Sign up for the latest updates and test new features early by joining our [beta program](https://play.google.com/apps/testing/io.pslab).
 

--- a/scripts/generate-app-download-page.sh
+++ b/scripts/generate-app-download-page.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Generate a simple download index for the `app` branch artifacts.
+# Links use GitHub raw URLs so browsers download files instead of opening blob pages.
+set -euo pipefail
+
+repo="${1:?repository owner/name required, e.g. fossasia/pslab-app}"
+outdir="${2:-.}"
+raw_base="https://github.com/${repo}/raw/app"
+outfile="${outdir%/}/index.html"
+
+{
+  cat <<'EOF'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>PSLab App Downloads</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; max-width: 720px; margin: 48px auto; padding: 0 20px; line-height: 1.5; color: #24292f; }
+    h1 { margin-bottom: 8px; }
+    p { color: #57606a; }
+    ul { list-style: none; padding: 0; }
+    li { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 12px 0; border-top: 1px solid #d0d7de; }
+    a { color: #fff; background: #cf2b27; text-decoration: none; padding: 8px 14px; border-radius: 8px; font-weight: 600; white-space: nowrap; }
+    .name { font-weight: 600; word-break: break-all; }
+  </style>
+</head>
+<body>
+  <h1>PSLab App Downloads</h1>
+  <p>Development builds from the <code>app</code> branch. Each link starts a direct file download.</p>
+  <ul>
+EOF
+
+  shopt -s nullglob
+  for file in "$outdir"/*; do
+    [ -f "$file" ] || continue
+    base=$(basename "$file")
+    [ "$base" = "index.html" ] && continue
+    case "$base" in
+      *.apk|*.aab|*.ipa|*.exe|*.deb|*.rpm|*.dmg|*.zip) ;;
+      *) continue ;;
+    esac
+    escaped_name=$(printf '%s' "$base" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')
+    encoded_name=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=""))' "$base")
+    printf '    <li><span class="name">%s</span><a href="%s/%s" download>Download</a></li>\n' \
+      "$escaped_name" "$raw_base" "$encoded_name"
+  done
+
+  cat <<'EOF'
+  </ul>
+</body>
+</html>
+EOF
+} > "$outfile"
+
+echo "Wrote $outfile"


### PR DESCRIPTION
## Summary
- Rebuild the `app` branch download page as a follow-up to reverted #3435
- Move HTML generation into `scripts/generate-app-download-page.sh` so `push-event.yml` stays valid YAML
- Link README to the raw `index.html` so users get direct downloads

Fixes #3428

## Test plan
- [ ] `push-event.yml` passes workflow syntax validation
- [ ] After a main push, `app` branch contains `index.html`
- [ ] Download links use `raw/app/...` and start a file download (not a blob page)
- [ ] README Download section links to the page

## Summary by Sourcery

Generate the app branch download page as part of the push workflow and expose it via the README as a direct-download entry point.

Enhancements:
- Add a reusable script to generate an HTML download index from built app artifacts using GitHub raw URLs for direct file downloads.

CI:
- Extend the push-event workflow to invoke the download page generator so the app branch is populated with an index.html on main pushes.

Documentation:
- Update README download section to distinguish documentation links from development builds and link to the regenerated app branch download page.