### PR TITLE
fix: use version branch for Windows, macOS, and Web PR builds

### DIFF
--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -33,7 +33,10 @@ runs:
         VERSION_CODE: ${{ inputs.VERSION_CODE }}
       run: |
         flutter config --enable-macos-desktop
-        flutter build macos --build-name $VERSION_NAME --build-number $VERSION_CODE
+        # Keep PackageInfo / DMG name aligned with CI version inputs.
+        sed -i '' "s/^version: .*/version: ${VERSION_NAME}+${VERSION_CODE}/" pubspec.yaml || \
+          sed -i "s/^version: .*/version: ${VERSION_NAME}+${VERSION_CODE}/" pubspec.yaml
+        flutter build macos --build-name "$VERSION_NAME" --build-number "$VERSION_CODE"
     
     - name: Package into dmg
       shell: bash

--- a/.github/actions/windows/action.yml
+++ b/.github/actions/windows/action.yml
@@ -23,15 +23,17 @@ runs:
       shell: pwsh
       run: |
         flutter config --enable-windows-desktop
-        flutter build windows --build-name ${{ inputs.VERSION_NAME }} --build-number ${{ inputs.VERSION_CODE }}
+        # Bake CI version into pubspec before build so installer metadata and
+        # PackageInfo match (same approach as the Linux desktop workaround).
+        (Get-Content pubspec.yaml) -replace '^version: .*', "version: ${{ inputs.VERSION_NAME }}+${{ inputs.VERSION_CODE }}" | Set-Content pubspec.yaml
+        flutter build windows --release `
+          --build-name ${{ inputs.VERSION_NAME }} `
+          --build-number ${{ inputs.VERSION_CODE }}
     
     - name: Build iss script
       id: build-iss
       shell: pwsh
       run: |
-        # Update version in pubspec.yaml for iss script
-        (Get-Content pubspec.yaml) -replace '^version: .*', "version: ${{ inputs.VERSION_NAME }}+${{ inputs.VERSION_CODE }}" | Set-Content pubspec.yaml
-
         dart run inno_bundle:build --no-app --release --no-installer
         echo $(dart run inno_bundle:build --envs --no-hf) | Out-File -FilePath $Env:GITHUB_OUTPUT -Encoding utf8 -Append
     

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -196,6 +196,9 @@ jobs:
       - name: Web App Workflow
         if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/web
+        with:
+          VERSION_NAME: ${{ needs.common.outputs.VERSION_NAME }}
+          VERSION_CODE: ${{ needs.common.outputs.VERSION_CODE }}
 
       - name: Non-Code Change
         if: needs.changes.outputs.is_code != 'true'
@@ -212,6 +215,9 @@ jobs:
       - name: Windows Workflow
         if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/windows
+        with:
+          VERSION_NAME: ${{ needs.common.outputs.VERSION_NAME }}
+          VERSION_CODE: ${{ needs.common.outputs.VERSION_CODE }}
 
       - name: Non-Code Change
         if: needs.changes.outputs.is_code != 'true'
@@ -272,6 +278,9 @@ jobs:
       - name: macOS Workflow
         if: needs.changes.outputs.is_code == 'true'
         uses: ./.github/actions/macos
+        with:
+          VERSION_NAME: ${{ needs.common.outputs.VERSION_NAME }}
+          VERSION_CODE: ${{ needs.common.outputs.VERSION_CODE }}
 
       - name: Non-Code Change
         if: needs.changes.outputs.is_code != 'true'


### PR DESCRIPTION
## Summary
- Extend the Linux PR versioning fix so Windows, macOS, and Web PR artifacts also use the `version` branch (not hardcoded `1.0.0`)
- Patch `pubspec.yaml` before Windows/macOS builds so installer/DMG names and PackageInfo stay aligned

Related to desktop release readiness / follow-up to #3443

## Test plan
- [ ] Windows CI artifact name includes the current version (not `1.0.0`)
- [ ] macOS DMG name includes the current version
- [ ] Web zip / artifact name includes the current version
- [ ] Linux jobs still receive VERSION_NAME/VERSION_CODE as before

## Summary by Sourcery

Align PR build artifacts for Windows, macOS, and Web with the version branch metadata used in Linux, ensuring consistent versioned outputs across platforms.

Enhancements:
- Propagate VERSION_NAME and VERSION_CODE from the common job into Windows, macOS, and Web PR workflows so their artifacts reflect the current version branch.
- Update Windows build and macOS build actions to patch pubspec.yaml with CI-provided version info before building, keeping installer/DMG names and runtime PackageInfo in sync with the branch version.