### PR TITLE
fix: preview app download page via htmlpreview (#3457)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository holds the Android App for performing experiments with [PSLab](ht
 The PSLab app is available for **Android**, **iOS**, **Windows**, **macOS**, **Linux**, and **Web**.
 
 - Store listings and install guides: [PSLab Application documentation](https://docs.pslab.io/application/Readme.html)
-- Development builds (direct downloads): [Download page](https://github.com/fossasia/pslab-app/raw/refs/heads/app/index.html)
+- Development builds (direct downloads): [Download page](https://htmlpreview.github.io/?https://raw.githubusercontent.com/fossasia/pslab-app/refs/heads/app/index.html)
 
 Sign up for the latest updates and test new features early by joining our [beta program](https://play.google.com/apps/testing/io.pslab).
 


### PR DESCRIPTION
## Summary
- README download link pointed at raw `app/index.html`, so GitHub showed source instead of a page
- Point it at htmlpreview as suggested by @marcnause in #3457
Fixes #3457.

## Summary by Sourcery

Documentation:
- Adjust README development builds download link to use htmlpreview for a rendered app preview page.