### PR TITLE
fix: Validate imported logs and fix import flow

### DIFF
--- a/lib/others/data_service.dart
+++ b/lib/others/data_service.dart
@@ -201,8 +201,11 @@ class DataService {
     }
   }
 
-  Future<List<List<dynamic>>?> pickAndReadFile() async {
+  Future<(List<List<dynamic>>, String, String)?> pickAndReadFile(
+      List<String> allowedInstruments) async {
     try {
+      logger.i(
+          'Opening file picker. Allowed instruments count: ${allowedInstruments.length}');
       final result = await FilePicker.pickFiles(
         type: FileType.custom,
         allowedExtensions: ['csv', 'txt', 'json'],
@@ -210,12 +213,193 @@ class DataService {
 
       if (result != null && result.files.single.path != null) {
         final file = File(result.files.single.path!);
-        return await readDataFromFile(file);
+        final fileName = result.files.single.name;
+        logger.i('File selected: ${file.path}');
+
+        final data = await readDataFromFile(file);
+
+        if (data.length < 2) {
+          logger.w('Validation Failed: Imported file has insufficient rows.');
+          return (<List<dynamic>>[], '', fileName);
+        }
+
+        String detectedInstrument = '';
+        if (data[0].isNotEmpty) {
+          detectedInstrument = data[0][0].toString().toLowerCase().trim();
+        }
+
+        final matchedInstrument = allowedInstruments.cast<String?>().firstWhere(
+              (inst) => inst!.toLowerCase() == detectedInstrument,
+              orElse: () => null,
+            );
+
+        if (matchedInstrument == null) {
+          logger.w(
+              'Validation Failed: "$detectedInstrument" is not allowed here.');
+          return (<List<dynamic>>[], detectedInstrument, fileName);
+        }
+
+        if (!_isValidFormat(data, detectedInstrument)) {
+          logger.w('File format validation failed for $detectedInstrument.');
+          return (<List<dynamic>>[], matchedInstrument, fileName);
+        }
+
+        return (data, matchedInstrument, fileName);
       }
     } catch (e) {
       logger.e('${appLocalizations.csvPickingError}: $e');
     }
     return null;
+  }
+
+  bool _isValidFormat(List<List<dynamic>> data, String detectedInstrument) {
+    int headerIndex = 1;
+
+    if (data.length <= headerIndex) {
+      logger.w('Validation Failed: No data found after headers.');
+      return false;
+    }
+    final headers = data[headerIndex]
+        .map((e) => e.toString().toLowerCase().trim())
+        .toList();
+    logger.i('Extracted file headers: $headers');
+
+    bool hasRequiredColumns =
+        _verifyInstrumentHeaders(detectedInstrument, headers);
+    if (!hasRequiredColumns) return false;
+
+    int expectedColumnCount = data[headerIndex].length;
+    logger.i('Expecting all data rows to have $expectedColumnCount columns.');
+
+    for (int i = headerIndex + 1; i < data.length; i++) {
+      if (data[i].isEmpty) continue;
+
+      if (data[i].length != expectedColumnCount) {
+        logger.w(
+            'Validation Failed at Row $i: Column mismatch. Expected $expectedColumnCount, got ${data[i].length}.');
+        logger.w('Problematic Row Data: ${data[i]}');
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  bool _verifyInstrumentHeaders(String instrument, List<String> fileHeaders) {
+    final Map<String, List<String>> requiredColumns = {
+      appLocalizations.accelerometer.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readingsx',
+        'readingsy',
+        'readingsz'
+      ],
+      appLocalizations.barometer.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'pressure',
+        'altitude'
+      ],
+      appLocalizations.compass.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'bx',
+        'by',
+        'bz',
+        'degree'
+      ],
+      appLocalizations.gasSensor.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readings',
+        'active gas'
+      ],
+      appLocalizations.gyroscope.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readingsx',
+        'readingsy',
+        'readingsz'
+      ],
+      appLocalizations.logicAnalyzer.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readings',
+        'maxy',
+        'miny',
+        'channels',
+        'edges'
+      ],
+      appLocalizations.luxMeter.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readings'
+      ],
+      appLocalizations.multimeter.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'mode',
+        'reading',
+        'unit'
+      ],
+      appLocalizations.oledDisplayTitle.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'framebufferhex'
+      ],
+      appLocalizations.oscilloscope.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readings',
+        'channels',
+        'xaxisscale',
+        'yaxisscale'
+      ],
+      appLocalizations.powerSource.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'pv1',
+        'pv2',
+        'pv3',
+        'pcs'
+      ],
+      appLocalizations.roboticArmTitle.toLowerCase(): [
+        'timestamp',
+        'servo1',
+        'servo2',
+        'servo3',
+        'servo4',
+        'datetime'
+      ],
+      appLocalizations.soundMeter.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readings'
+      ],
+      appLocalizations.thermometer.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'readings'
+      ],
+      appLocalizations.waveGenerator.toLowerCase(): [
+        'timestamp',
+        'datetime',
+        'waveform data'
+      ],
+    };
+
+    final required = requiredColumns[instrument.toLowerCase()];
+
+    if (required == null) return true;
+    for (String col in required) {
+      if (!fileHeaders.any((header) => header == col)) {
+        logger
+            .w('Missing required column "$col" for instrument "$instrument".');
+        return false;
+      }
+    }
+
+    return true;
   }
 
   Future<List<List<dynamic>>> readDataFromFile(File file) async {

--- a/lib/others/data_service.dart
+++ b/lib/others/data_service.dart
@@ -66,9 +66,10 @@ class DataService {
       final file = File('${directory.path}/$finalFileName');
 
       String fileContent;
-      if (format == 'JSON') {
+      String upperFormat = format.toUpperCase();
+      if (upperFormat == 'JSON') {
         fileContent = jsonEncode(data);
-      } else if (format == 'TXT') {
+      } else if (upperFormat == 'TXT') {
         final codec = csv.Csv(fieldDelimiter: '\t');
         fileContent = codec.encode(data);
       } else {
@@ -228,10 +229,24 @@ class DataService {
           detectedInstrument = data[0][0].toString().toLowerCase().trim();
         }
 
-        final matchedInstrument = allowedInstruments.cast<String?>().firstWhere(
-              (inst) => inst!.toLowerCase() == detectedInstrument,
-              orElse: () => null,
-            );
+        String? matchedInstrument =
+            allowedInstruments.cast<String?>().firstWhere(
+                  (inst) => inst!.toLowerCase() == detectedInstrument,
+                  orElse: () => null,
+                );
+
+        if (matchedInstrument == null && data.length > 1) {
+          final fileHeaders =
+              data[1].map((e) => e.toString().toLowerCase().trim()).toList();
+          for (String allowedInst in allowedInstruments) {
+            if (_verifyInstrumentHeaders(allowedInst, fileHeaders)) {
+              matchedInstrument = allowedInst;
+              logger.i(
+                  'Matched instrument "$matchedInstrument" via header fallback.');
+              break;
+            }
+          }
+        }
 
         if (matchedInstrument == null) {
           logger.w(
@@ -239,8 +254,8 @@ class DataService {
           return (<List<dynamic>>[], detectedInstrument, fileName);
         }
 
-        if (!_isValidFormat(data, detectedInstrument)) {
-          logger.w('File format validation failed for $detectedInstrument.');
+        if (!_isValidFormat(data, matchedInstrument)) {
+          logger.w('File format validation failed for $matchedInstrument.');
           return (<List<dynamic>>[], matchedInstrument, fileName);
         }
 
@@ -408,8 +423,34 @@ class DataService {
 
       if (extension == 'json') {
         final content = await file.readAsString();
-        final decoded = jsonDecode(content) as List<dynamic>;
-        return decoded.map((e) => (e as List<dynamic>).toList()).toList();
+
+        try {
+          final decoded = jsonDecode(content) as List<dynamic>;
+
+          return decoded.map((row) {
+            return (row as List<dynamic>).map((cell) {
+              if (cell is String) {
+                return num.tryParse(cell) ?? cell;
+              }
+              return cell;
+            }).toList();
+          }).toList();
+        } catch (e) {
+          logger.w(
+              'JSON parse failed. Falling back to CSV parser for corrupted file. Error: $e');
+
+          final codec = csv.Csv(dynamicTyping: true);
+          final lines = const LineSplitter().convert(content);
+          final List<List<dynamic>> rows = [];
+
+          for (final line in lines) {
+            final parsedRow = codec.decode(line);
+            if (parsedRow.isNotEmpty) {
+              rows.add(parsedRow.first);
+            }
+          }
+          return rows;
+        }
       } else {
         final lines = file
             .openRead()
@@ -424,7 +465,6 @@ class DataService {
 
         await for (final line in lines) {
           final parsedRow = codec.decode(line);
-
           if (parsedRow.isNotEmpty) {
             rows.add(parsedRow.first);
           }

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -448,23 +448,52 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
     }
   }
 
-  Future<void> _pickAndImportFile(String instrumentName) async {
-    final data = await _dataService.pickAndReadFile();
-    if (data != null && mounted) {
-      if (instrumentName.toLowerCase() == 'robotic arm') {
-        Navigator.pop(context, data);
-      } else {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => LoggedDataChartScreen(
-              fileName: 'Imported Log',
-              instrumentName: instrumentName,
-              data: data,
-            ),
+  Future<void> _pickAndImportFile() async {
+    final result = await _dataService.pickAndReadFile(widget.instrumentNames);
+
+    if (result != null && mounted) {
+      final data = result.$1;
+      final instrumentName = result.$2;
+      final originalFileName = result.$3;
+
+      if (data.isEmpty) {
+        String errorMsg = instrumentName.isEmpty
+            ? 'Invalid file format. Could not detect a valid PSLab log.'
+            : 'Invalid log format or unsupported instrument: $instrumentName';
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content:
+                Text(errorMsg, style: TextStyle(color: snackBarContentColor)),
+            backgroundColor: snackBarBackgroundColor,
           ),
         );
+        return;
       }
+
+      String format = 'csv';
+      if (originalFileName.toLowerCase().endsWith('.txt')) format = 'txt';
+      if (originalFileName.toLowerCase().endsWith('.json')) format = 'json';
+
+      String newName = originalFileName;
+      int extIndex = newName.lastIndexOf('.');
+      if (extIndex != -1) {
+        newName = newName.substring(0, extIndex);
+      }
+
+      await _dataService.saveDataFile(instrumentName, newName, data, format);
+
+      await _loadFiles();
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Successfully imported into $instrumentName',
+            style: TextStyle(color: snackBarContentColor),
+          ),
+          backgroundColor: snackBarBackgroundColor,
+        ),
+      );
     }
   }
 
@@ -478,11 +507,10 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
         0,
       ),
       items: [
-        if (widget.instrumentNames.length == 1)
-          PopupMenuItem(
-            value: 'import_log',
-            child: Text(appLocalizations.importLog),
-          ),
+        PopupMenuItem(
+          value: 'import_log',
+          child: Text(appLocalizations.importLog),
+        ),
         PopupMenuItem(
           value: 'delete_all',
           child: Text(appLocalizations.deleteAllData),
@@ -492,7 +520,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
       if (value != null) {
         switch (value) {
           case 'import_log':
-            _pickAndImportFile(widget.instrumentNames.first);
+            _pickAndImportFile();
             break;
           case 'delete_all':
             _deleteAllFiles();

--- a/lib/view/logged_data_screen.dart
+++ b/lib/view/logged_data_screen.dart
@@ -484,7 +484,7 @@ class _LoggedDataScreenState extends State<LoggedDataScreen> {
       await _dataService.saveDataFile(instrumentName, newName, data, format);
 
       await _loadFiles();
-
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(


### PR DESCRIPTION
Fixes #3452

## Changes

- Fixed the log import feature, which was previously not working.
- Added proper validation checks, including validation of column names before importing logs.
- Logs can now be imported from their respective instrument screens or from the Logged Data screen available in the navigation drawer.


## Screenshots / Recordings

https://github.com/user-attachments/assets/cacf0f59-24ab-4c34-89b1-a0ec2521a282



**Checklist**: <!-- Please tick following check boxes with `[x]` if the respective task is completed -->
- [x] **No hard coding**: I have used values from `constants.dart` or localization files instead of hard-coded values.
- [x] **No end of file edits**: No modifications done at end of resource files.
- [x] **Code reformatting**: I have formatted the code using `dart format` or the IDE formatter.
- [x] **Code analysis**: My code passes checks run in `flutter analyze` and tests run in `flutter test`.

## Summary by Sourcery

Validate imported log files against allowed instruments and header formats, and update the logged data screen to save successfully validated imports with user feedback.

Bug Fixes:
- Fix log import flow so files are properly validated, saved, and listed instead of just opened in a chart view.

Enhancements:
- Add instrument and column-level validation for imported log files, including row-length checks and contextual logging.
- Allow log import from the logged data screen for multiple instruments with appropriate success and error snackbars.