### PR TITLE
feat: add Oscilloscope stacked mode

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -312,6 +312,8 @@
     "ch1": "CH1",
     "noSignal": "No signal found.",
     "autoScale": "AUTO",
+    "stackedMode": "Stacked mode",
+    "stackedModeInfo": "Show each channel in its own vertical pane instead of overlapping on one plot.",
     "automatedMeasurements": "Automated Measurements",
     "luxMeterTitle": "Lux Meter",
     "builtIn": "Built-In",

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -68,6 +68,9 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   late bool isTriggered;
   late bool isFourierTransformSelected;
   late bool isXYPlotSelected;
+  /// When true, each enabled channel is drawn in its own vertical pane
+  /// instead of overlapping on a single plot (desktop-friendly view).
+  late bool isStackedMode;
   late bool sineFit;
   late bool squareFit;
   late String triggerChannel;
@@ -189,6 +192,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     isTriggered = false;
     isFourierTransformSelected = false;
     isXYPlotSelected = false;
+    isStackedMode = false;
     _monitor = true;
     _isRecording = false;
     isRunning = true;
@@ -1214,6 +1218,47 @@ class OscilloscopeStateProvider extends ChangeNotifier {
     } else {
       return false;
     }
+  }
+
+  void setStackedMode(bool value) {
+    isStackedMode = value;
+    notifyListeners();
+  }
+
+  /// Active channel names for stacked panes (selection and/or live data).
+  List<String> stackedChannelNames() {
+    final names = <String>[];
+    if (dataParamsChannels.isNotEmpty) {
+      for (final name in dataParamsChannels) {
+        if (!names.contains(name)) names.add(name);
+      }
+      return names;
+    }
+    if (isCH1Selected) names.add('CH1');
+    if (isCH2Selected) names.add('CH2');
+    if (isCH3Selected) names.add('CH3');
+    if (isMICSelected || isInBuiltMICSelected) names.add('MIC');
+    if (names.isEmpty) names.add('CH1');
+    return names;
+  }
+
+  List<LineChartBarData> createPlotForChannel(String channelName) {
+    final index = dataParamsChannels.indexOf(channelName);
+    final plots = <LineChartBarData>[];
+    if (index >= 0 && index < dataEntries.length) {
+      plots.add(
+        LineChartBarData(
+          spots: dataEntries[index],
+          isCurved: true,
+          color: colors[index % colors.length],
+          barWidth: 1,
+          dotData: const FlDotData(
+            show: false,
+          ),
+        ),
+      );
+    }
+    return plots;
   }
 
   List<LineChartBarData> createPlots() {

--- a/lib/providers/oscilloscope_state_provider.dart
+++ b/lib/providers/oscilloscope_state_provider.dart
@@ -68,6 +68,7 @@ class OscilloscopeStateProvider extends ChangeNotifier {
   late bool isTriggered;
   late bool isFourierTransformSelected;
   late bool isXYPlotSelected;
+
   /// When true, each enabled channel is drawn in its own vertical pane
   /// instead of overlapping on a single plot (desktop-friendly view).
   late bool isStackedMode;

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -144,6 +144,40 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
             },
           ),
         ),
+        PopupMenuItem<CheckboxListTile>(
+          child: CheckboxListTile(
+            title: Text(appLocalizations.stackedMode),
+            secondary: IconButton(
+                icon: Icon(Icons.info_outline),
+                tooltip: appLocalizations.info,
+                onPressed: () {
+                  showDialog<void>(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return AlertDialog(
+                        title: Text(appLocalizations.stackedMode),
+                        content: Text(appLocalizations.stackedModeInfo),
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: () {
+                              Navigator.of(context).pop();
+                            },
+                            child: Text(appLocalizations.ok),
+                          ),
+                        ],
+                      );
+                    },
+                  );
+                }),
+            value: _provider.isStackedMode,
+            onChanged: (bool? newValue) {
+              setState(() {
+                _provider.setStackedMode(newValue ?? false);
+              });
+              Navigator.pop(context);
+            },
+          ),
+        ),
       ],
       elevation: 8,
     ).then((value) {

--- a/lib/view/widgets/oscilloscope_graph.dart
+++ b/lib/view/widgets/oscilloscope_graph.dart
@@ -119,8 +119,7 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
           show: true,
           drawHorizontalLine: true,
           drawVerticalLine: true,
-          horizontalInterval:
-              provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+          horizontalInterval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
           verticalInterval:
               provider.oscilloscopeAxesScale.getTimebaseInterval(),
           getDrawingHorizontalLine: (value) {
@@ -226,8 +225,7 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
           show: true,
           drawHorizontalLine: true,
           drawVerticalLine: true,
-          horizontalInterval:
-              provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+          horizontalInterval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
           verticalInterval:
               provider.oscilloscopeAxesScale.getTimebaseInterval(),
           getDrawingHorizontalLine: (value) {
@@ -277,7 +275,8 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
         for (int i = 0; i < channels.length; i++)
           Expanded(
             child: Padding(
-              padding: EdgeInsets.only(bottom: i == channels.length - 1 ? 0 : 2),
+              padding:
+                  EdgeInsets.only(bottom: i == channels.length - 1 ? 0 : 2),
               child: _buildStackedChannelChart(
                 provider,
                 channelName: channels[i],

--- a/lib/view/widgets/oscilloscope_graph.dart
+++ b/lib/view/widgets/oscilloscope_graph.dart
@@ -44,144 +44,268 @@ class _OscilloscopeGraphState extends State<OscilloscopeGraph> {
     );
   }
 
+  double _maxX(OscilloscopeStateProvider provider) {
+    return provider.oscilloscopeAxesScale.xAxisScale == 875
+        ? provider.oscilloscopeAxesScale.xAxisScale
+        : provider.oscilloscopeAxesScale.xAxisScale / 1000;
+  }
+
+  Widget _buildOverlayChart(OscilloscopeStateProvider provider) {
+    return LineChart(
+      LineChartData(
+        backgroundColor: chartBackgroundColor,
+        lineTouchData: LineTouchData(
+          enabled: !provider.isPlayingBack,
+        ),
+        titlesData: FlTitlesData(
+          show: true,
+          topTitles: AxisTitles(
+            axisNameWidget: Text(
+              provider.isFourierTransformSelected
+                  ? 'Frequency (Hz)'
+                  : (provider.oscilloscopeAxesScale.xAxisScale == 875
+                      ? 'Time (\u00b5s)'
+                      : 'Time (ms)'),
+              style: TextStyle(
+                fontSize: 10,
+                color: chartTextColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            sideTitles: SideTitles(
+              maxIncluded: false,
+              interval: provider.oscilloscopeAxesScale.getTimebaseInterval(),
+              reservedSize: 20,
+              showTitles: true,
+              getTitlesWidget: topTitleWidgets,
+            ),
+          ),
+          bottomTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          leftTitles: AxisTitles(
+            axisNameWidget: Text(
+              provider.isFourierTransformSelected ? 'Magnitude (V)' : 'CH1 (V)',
+              style: TextStyle(
+                fontSize: 10,
+                color: chartTextColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            sideTitles: SideTitles(
+              interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+              reservedSize: 30,
+              showTitles: true,
+              getTitlesWidget: sideTitleWidgets,
+            ),
+          ),
+          rightTitles: AxisTitles(
+            axisNameWidget: Text(
+              provider.isFourierTransformSelected ? 'Magnitude (V)' : 'CH2 (V)',
+              style: TextStyle(
+                fontSize: 10,
+                color: chartTextColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            sideTitles: SideTitles(
+              interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+              reservedSize: 30,
+              showTitles: true,
+              getTitlesWidget: sideTitleWidgets,
+            ),
+          ),
+        ),
+        gridData: FlGridData(
+          show: true,
+          drawHorizontalLine: true,
+          drawVerticalLine: true,
+          horizontalInterval:
+              provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+          verticalInterval:
+              provider.oscilloscopeAxesScale.getTimebaseInterval(),
+          getDrawingHorizontalLine: (value) {
+            return const FlLine(
+              color: Color.fromARGB(50, 255, 255, 255),
+              strokeWidth: 1,
+            );
+          },
+          getDrawingVerticalLine: (value) {
+            return const FlLine(
+              color: Color.fromARGB(50, 255, 255, 255),
+              strokeWidth: 1,
+            );
+          },
+        ),
+        borderData: FlBorderData(
+          show: true,
+          border: Border(
+            bottom: BorderSide(
+              color: chartBorderColor,
+            ),
+            left: BorderSide(
+              color: chartBorderColor,
+            ),
+            top: BorderSide(
+              color: chartBorderColor,
+            ),
+            right: BorderSide(
+              color: chartBorderColor,
+            ),
+          ),
+        ),
+        maxY: provider.oscilloscopeAxesScale.yAxisScaleMax,
+        minY: provider.oscilloscopeAxesScale.yAxisScaleMin,
+        maxX: _maxX(provider),
+        minX: 0,
+        clipData: const FlClipData.all(),
+        lineBarsData: provider.createPlots(),
+      ),
+    );
+  }
+
+  Widget _buildStackedChannelChart(
+    OscilloscopeStateProvider provider, {
+    required String channelName,
+    required bool showTimeAxis,
+  }) {
+    return LineChart(
+      LineChartData(
+        backgroundColor: chartBackgroundColor,
+        lineTouchData: LineTouchData(
+          enabled: !provider.isPlayingBack,
+        ),
+        titlesData: FlTitlesData(
+          show: true,
+          topTitles: AxisTitles(
+            axisNameWidget: showTimeAxis
+                ? Text(
+                    provider.isFourierTransformSelected
+                        ? 'Frequency (Hz)'
+                        : (provider.oscilloscopeAxesScale.xAxisScale == 875
+                            ? 'Time (\u00b5s)'
+                            : 'Time (ms)'),
+                    style: TextStyle(
+                      fontSize: 10,
+                      color: chartTextColor,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  )
+                : const SizedBox.shrink(),
+            sideTitles: SideTitles(
+              maxIncluded: false,
+              interval: provider.oscilloscopeAxesScale.getTimebaseInterval(),
+              reservedSize: showTimeAxis ? 20 : 8,
+              showTitles: showTimeAxis,
+              getTitlesWidget: topTitleWidgets,
+            ),
+          ),
+          bottomTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+          leftTitles: AxisTitles(
+            axisNameWidget: Text(
+              provider.isFourierTransformSelected
+                  ? '$channelName (V)'
+                  : '$channelName (V)',
+              style: TextStyle(
+                fontSize: 10,
+                color: chartTextColor,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            sideTitles: SideTitles(
+              interval: provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+              reservedSize: 30,
+              showTitles: true,
+              getTitlesWidget: sideTitleWidgets,
+            ),
+          ),
+          rightTitles:
+              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        ),
+        gridData: FlGridData(
+          show: true,
+          drawHorizontalLine: true,
+          drawVerticalLine: true,
+          horizontalInterval:
+              provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
+          verticalInterval:
+              provider.oscilloscopeAxesScale.getTimebaseInterval(),
+          getDrawingHorizontalLine: (value) {
+            return const FlLine(
+              color: Color.fromARGB(50, 255, 255, 255),
+              strokeWidth: 1,
+            );
+          },
+          getDrawingVerticalLine: (value) {
+            return const FlLine(
+              color: Color.fromARGB(50, 255, 255, 255),
+              strokeWidth: 1,
+            );
+          },
+        ),
+        borderData: FlBorderData(
+          show: true,
+          border: Border(
+            bottom: BorderSide(
+              color: chartBorderColor,
+            ),
+            left: BorderSide(
+              color: chartBorderColor,
+            ),
+            top: BorderSide(
+              color: chartBorderColor,
+            ),
+            right: BorderSide(
+              color: chartBorderColor,
+            ),
+          ),
+        ),
+        maxY: provider.oscilloscopeAxesScale.yAxisScaleMax,
+        minY: provider.oscilloscopeAxesScale.yAxisScaleMin,
+        maxX: _maxX(provider),
+        minX: 0,
+        clipData: const FlClipData.all(),
+        lineBarsData: provider.createPlotForChannel(channelName),
+      ),
+    );
+  }
+
+  Widget _buildStackedCharts(OscilloscopeStateProvider provider) {
+    final channels = provider.stackedChannelNames();
+    return Column(
+      children: [
+        for (int i = 0; i < channels.length; i++)
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.only(bottom: i == channels.length - 1 ? 0 : 2),
+              child: _buildStackedChannelChart(
+                provider,
+                channelName: channels[i],
+                showTimeAxis: i == 0,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    OscilloscopeStateProvider oscilloscopeStateProvider =
-        Provider.of<OscilloscopeStateProvider>(context);
     return Consumer<OscilloscopeStateProvider>(
       builder: (context, provider, _) {
-        if (oscilloscopeStateProvider.isXYPlotSelected) {
+        if (provider.isXYPlotSelected) {
           return const SizedBox(
             child: XYPlotGraph(),
           );
-        } else {
+        }
+        if (provider.isStackedMode) {
           return SizedBox(
-            child: LineChart(
-              LineChartData(
-                backgroundColor: chartBackgroundColor,
-                lineTouchData: LineTouchData(
-                  enabled: !oscilloscopeStateProvider.isPlayingBack,
-                ),
-                titlesData: FlTitlesData(
-                  show: true,
-                  topTitles: AxisTitles(
-                    axisNameWidget: Text(
-                      provider.isFourierTransformSelected
-                          ? 'Frequency (Hz)'
-                          : (provider.oscilloscopeAxesScale.xAxisScale == 875
-                              ? 'Time (\u00b5s)'
-                              : 'Time (ms)'),
-                      style: TextStyle(
-                        fontSize: 10,
-                        color: chartTextColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    sideTitles: SideTitles(
-                      maxIncluded: false,
-                      interval: oscilloscopeStateProvider.oscilloscopeAxesScale
-                          .getTimebaseInterval(),
-                      reservedSize: 20,
-                      showTitles: true,
-                      getTitlesWidget: topTitleWidgets,
-                    ),
-                  ),
-                  bottomTitles: const AxisTitles(
-                      sideTitles: SideTitles(showTitles: false)),
-                  leftTitles: AxisTitles(
-                    axisNameWidget: Text(
-                      provider.isFourierTransformSelected
-                          ? 'Magnitude (V)'
-                          : 'CH1 (V)',
-                      style: TextStyle(
-                        fontSize: 10,
-                        color: chartTextColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    sideTitles: SideTitles(
-                      interval:
-                          provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
-                      reservedSize: 30,
-                      showTitles: true,
-                      getTitlesWidget: sideTitleWidgets,
-                    ),
-                  ),
-                  rightTitles: AxisTitles(
-                    axisNameWidget: Text(
-                      provider.isFourierTransformSelected
-                          ? 'Magnitude (V)'
-                          : 'CH2 (V)',
-                      style: TextStyle(
-                        fontSize: 10,
-                        color: chartTextColor,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    sideTitles: SideTitles(
-                      interval:
-                          provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
-                      reservedSize: 30,
-                      showTitles: true,
-                      getTitlesWidget: sideTitleWidgets,
-                    ),
-                  ),
-                ),
-                gridData: FlGridData(
-                  show: true,
-                  drawHorizontalLine: true,
-                  drawVerticalLine: true,
-                  horizontalInterval:
-                      provider.oscilloscopeAxesScale.yAxisScaleMax / 4,
-                  verticalInterval: oscilloscopeStateProvider
-                      .oscilloscopeAxesScale
-                      .getTimebaseInterval(),
-                  getDrawingHorizontalLine: (value) {
-                    return const FlLine(
-                      color: Color.fromARGB(50, 255, 255, 255),
-                      strokeWidth: 1,
-                    );
-                  },
-                  getDrawingVerticalLine: (value) {
-                    return const FlLine(
-                      color: Color.fromARGB(50, 255, 255, 255),
-                      strokeWidth: 1,
-                    );
-                  },
-                ),
-                borderData: FlBorderData(
-                  show: true,
-                  border: Border(
-                    bottom: BorderSide(
-                      color: chartBorderColor,
-                    ),
-                    left: BorderSide(
-                      color: chartBorderColor,
-                    ),
-                    top: BorderSide(
-                      color: chartBorderColor,
-                    ),
-                    right: BorderSide(
-                      color: chartBorderColor,
-                    ),
-                  ),
-                ),
-                maxY: provider.oscilloscopeAxesScale.yAxisScaleMax,
-                minY: provider.oscilloscopeAxesScale.yAxisScaleMin,
-                maxX: oscilloscopeStateProvider
-                            .oscilloscopeAxesScale.xAxisScale ==
-                        875
-                    ? oscilloscopeStateProvider.oscilloscopeAxesScale.xAxisScale
-                    : oscilloscopeStateProvider
-                            .oscilloscopeAxesScale.xAxisScale /
-                        1000,
-                minX: 0,
-                clipData: const FlClipData.all(),
-                lineBarsData: oscilloscopeStateProvider.createPlots(),
-              ),
-            ),
+            child: _buildStackedCharts(provider),
           );
         }
+        return SizedBox(
+          child: _buildOverlayChart(provider),
+        );
       },
     );
   }


### PR DESCRIPTION
## Summary
- Adds **Stacked mode** for the Oscilloscope so each enabled channel gets its own vertical pane instead of overlapping on one plot
- Toggle via Oscilloscope menu (`⋮`) → **Stacked mode** (with a short info dialog)
- Keeps the existing overlay behavior when Stacked mode is off; XY Plot mode is unchanged

Fixes #3465

## Test plan
- [x] Open Oscilloscope, enable CH1 + CH2
- [x] Confirm default view is still a single overlapping plot
- [x] Enable **Stacked mode** from the `⋮` menu → CH1 and CH2 appear in separate stacked panes
- [x] Disable Stacked mode → returns to overlay
- [x] With XY Plot enabled, chart still uses XY view as before
- [x] (Optional, with hardware) Verify waveforms appear in the correct stacked panes


<img width="1912" height="1016" alt="image" src="https://github.com/user-attachments/assets/bc06e290-dbae-4413-ad1d-0e79551a55b4" />

## Summary by Sourcery

Introduce a stacked display option for the oscilloscope so channels can be viewed in separate vertical panes alongside the existing overlay and XY plot modes.

New Features:
- Add a stacked mode toggle in the oscilloscope menu to display each active channel in its own vertical pane.
- Support per-channel waveform rendering for stacked mode using channel-aware plot generation in the oscilloscope state provider.

Enhancements:
- Refactor oscilloscope graph rendering into reusable helpers for overlay vs stacked layouts while preserving existing XY plot behavior.

Documentation:
- Add localized texts describing the stacked mode option and its info dialog in the oscilloscope UI.