### PR TITLE
fix: give Oscilloscope bottom controls a fixed height

### DIFF
--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -41,10 +41,11 @@ class OscilloscopeScreen extends StatefulWidget {
 }
 
 class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
-  /// Fixed height for the bottom controls panel (channel/timebase/etc.).
-  /// Avoids stretching on tall windows and overlapping controls on short ones
-  /// (see fossasia/pslab-app#3461).
-  static const double _controlsPanelHeight = 180;
+  /// Approx. content height for the bottom controls (two rows of
+  /// checkbox + dropdown). Same for Channel / Timebase / Data Analysis / XY
+  /// Plot. Not true wrap-content yet: those tabs use Stack + Positioned, so
+  /// they need an explicit height (see fossasia/pslab-app#3461 / #3468).
+  static const double _controlsContentHeight = 120;
 
   late OscilloscopeStateProvider _provider;
   late OscilloscopeConfigProvider? _configProvider;
@@ -450,8 +451,15 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                                     ),
                                                   ),
                                                   SizedBox(
+                                                    // Cap so phones keep most of
+                                                    // the screen for the graph.
                                                     height:
-                                                        _controlsPanelHeight,
+                                                        _controlsContentHeight
+                                                            .clamp(
+                                                      0,
+                                                      constraints.maxHeight *
+                                                          0.35,
+                                                    ),
                                                     child: Selector<
                                                         OscilloscopeStateProvider,
                                                         int>(

--- a/lib/view/oscilloscope_screen.dart
+++ b/lib/view/oscilloscope_screen.dart
@@ -41,6 +41,11 @@ class OscilloscopeScreen extends StatefulWidget {
 }
 
 class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
+  /// Fixed height for the bottom controls panel (channel/timebase/etc.).
+  /// Avoids stretching on tall windows and overlapping controls on short ones
+  /// (see fossasia/pslab-app#3461).
+  static const double _controlsPanelHeight = 180;
+
   late OscilloscopeStateProvider _provider;
   late OscilloscopeConfigProvider? _configProvider;
   AppLocalizations get appLocalizations => getIt.get<AppLocalizations>();
@@ -435,11 +440,6 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                               Column(
                                                 children: [
                                                   Expanded(
-                                                    flex:
-                                                        constraints.maxHeight <
-                                                                600
-                                                            ? 68
-                                                            : 80,
                                                     child: Container(
                                                       padding:
                                                           const EdgeInsets.only(
@@ -449,12 +449,9 @@ class _OscilloscopeScreenState extends State<OscilloscopeScreen> {
                                                           const OscilloscopeGraph(),
                                                     ),
                                                   ),
-                                                  Expanded(
-                                                    flex:
-                                                        constraints.maxHeight <
-                                                                600
-                                                            ? 32
-                                                            : 20,
+                                                  SizedBox(
+                                                    height:
+                                                        _controlsPanelHeight,
                                                     child: Selector<
                                                         OscilloscopeStateProvider,
                                                         int>(


### PR DESCRIPTION
## Summary
- Give the Oscilloscope bottom (white) controls panel a **fixed height** instead of flex-sizing it with the window
- Let the black waveform area use the remaining space when the window is resized
- Fixes overlap on short windows and empty wasted space in the controls panel on tall windows

Closes #3461

## Changes
- In `oscilloscope_screen.dart`, replace the bottom `Expanded(flex: …)` panel with `SizedBox(height: 180)`
- Keep the graph in an `Expanded` so it grows/shrinks with the window

## Test plan
- [x] Open Oscilloscope (Windows/desktop)
- [x] Stretch the window taller → white panel height stays the same; graph grows
- [x] Shrink the window → controls no longer overlap/reflow badly
- [x] Switch Channel / Timebase / Data Analysis / XY tabs → panel height stays fixed
- [x] `flutter analyze lib/view/oscilloscope_screen.dart` — no issues


Uploading Recording 2026-08-03 000237.mp4…

## Summary by Sourcery

Enhancements:
- Introduce a shared constant for the Oscilloscope controls panel height to standardize layout across window sizes.